### PR TITLE
v1.1.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Pressing C-c in input box (interactive mode) will now also print the command like OS terminal
+- Set the default value of `set writeimports` as `false`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.1.0-beta.4 - (unreleased)
+## 1.1.0-beta.4 - 2025.07.09
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## (unreleased)
+
+### Added
+
+### Changed
+
+### Fixed
+- Fix error of body has been read when running the tool for first time
+
 ## 1.1.0-beta.3 - 2025.07.08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fix error of body has been read when running the tool for first time
+- Print an error when the user passes a URL list (file) to the run command
 
 ## 1.1.0-beta.3 - 2025.07.08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Pressing C-c in input box (interactive mode) will now also print the command like OS terminal
 - Set the default value of `set writeimports` as `false`
+- Do not store dupe and non-existent entries in `state.functionNavHistory` (interactive mode)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix error of body has been read when running the tool for first time
 - Print an error when the user passes a URL list (file) to the run command
+- Add error recovery in Nuxt ast parse
 
 ## 1.1.0-beta.3 - 2025.07.08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added `set funcdesc <functionId> <description>` command to interactive mode
+
 ### Changed
 
 - Pressing C-c in input box (interactive mode) will now also print the command like OS terminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## (unreleased)
+## 1.1.0-beta.4 - (unreleased)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Pressing C-c in input box (interactive mode) will now also print the command like OS terminal
+
 ### Fixed
 
 - Fix error of body has been read when running the tool for first time

--- a/docs/interactive-mode.md
+++ b/docs/interactive-mode.md
@@ -69,8 +69,12 @@ Navigates between functions. Usage: `go <option>`
 
 Sets configuration options. Usage: `set <option> <value>`
 
-- `set funcwritefile <filename>`: Sets the file where function code will be written when you use the `go to` command.
-- `set writeimports [true/false]`: When using `go *` command, also write all the imports to the file
+- `set funcwritefile <filename>`: Update the file location where function code will be written when using the `go to` command.
+- `set writeimports [true/false]`: When using `go *` command, also write all the imports of the function to the file
+- `set funcdesc <functionId>`: Set the description of the provided function ID with provided value
+    - Example: `set funcdesc 1234 This function does something fishy`
+    - This will set the description to `This function does something fishy`
+    - Note that you don't need to provide the quotes for this. The tool detects the description based on spaces(` `)
 
 ### `trace`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@shriyanss/js-recon",
-    "version": "1.1.0-beta.2",
+    "version": "1.1.0-beta.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@shriyanss/js-recon",
-            "version": "1.1.0-beta.2",
+            "version": "1.1.0-beta.4",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-api-gateway": "^3.829.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shriyanss/js-recon",
-    "version": "1.1.0-beta.3",
+    "version": "1.1.0-beta.4",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,5 +1,5 @@
 const githubURL = "https://github.com/shriyanss/js-recon";
-const version = "1.1.0-beta.3";
+const version = "1.1.0-beta.4";
 const toolDesc = "JS Recon Tool";
 
 let CONFIG = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,10 +262,7 @@ program
 program
     .command("run")
     .description("Run all modules")
-    .requiredOption(
-        "-u, --url <url>",
-        "Target URL"
-    )
+    .requiredOption("-u, --url <url>", "Target URL")
     .option("-o, --output <directory>", "Output directory", "output")
     .option(
         "--strict-scope",

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,8 +263,8 @@ program
     .command("run")
     .description("Run all modules")
     .requiredOption(
-        "-u, --url <url/file>",
-        "Target URL or a file containing a list of URLs (one per line)"
+        "-u, --url <url>",
+        "Target URL"
     )
     .option("-o, --output <directory>", "Output directory", "output")
     .option(

--- a/src/lazyLoad/nuxt_js/nuxt_astParse.ts
+++ b/src/lazyLoad/nuxt_js/nuxt_astParse.ts
@@ -108,6 +108,7 @@ const nuxt_astParse = async (url: string) => {
             const unknownVarAst = parser.parse(`(${func.source})`, {
                 sourceType: "script",
                 plugins: ["jsx", "typescript"],
+                errorRecovery: true
             });
             let memberExpressions = [];
             traverse(unknownVarAst, {

--- a/src/lazyLoad/nuxt_js/nuxt_astParse.ts
+++ b/src/lazyLoad/nuxt_js/nuxt_astParse.ts
@@ -108,7 +108,7 @@ const nuxt_astParse = async (url: string) => {
             const unknownVarAst = parser.parse(`(${func.source})`, {
                 sourceType: "script",
                 plugins: ["jsx", "typescript"],
-                errorRecovery: true
+                errorRecovery: true,
             });
             let memberExpressions = [];
             traverse(unknownVarAst, {

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -5,6 +5,8 @@ import getWebpackConnections from "./next_js/getWebpackConnections.js";
 import getFetchInstances from "./next_js/getFetchInstances.js";
 import resolveFetch from "./next_js/resolveFetch.js";
 import interactive from "./next_js/interactive.js";
+import { existsSync, readFileSync } from "fs";
+import { Chunks } from "../utility/interfaces.js";
 
 const availableTech = {
     next: "Next.JS",
@@ -20,7 +22,7 @@ const map = async (
     formats: string[],
     tech: string,
     list: boolean,
-    interactive_mode: boolean
+    interactive_mode: boolean,
 ) => {
     console.log(chalk.cyan("[i] Running 'map' module"));
 
@@ -43,30 +45,45 @@ const map = async (
     if (!tech) {
         console.log(
             chalk.red(
-                "[!] Please specify a technology with -t/--tech. Run with -l/--list to see available technologies"
-            )
+                "[!] Please specify a technology with -t/--tech. Run with -l/--list to see available technologies",
+            ),
         );
         return;
     }
 
     if (!directory) {
         console.log(
-            chalk.red("[!] Please specify a directory with -d/--directory")
+            chalk.red("[!] Please specify a directory with -d/--directory"),
         );
         return;
     }
 
     if (tech === "next") {
-        let chunks = await getWebpackConnections(directory, output, formats);
+        let chunks: Chunks;
 
-        // now, iterate through them, and check fetch instances
-        chunks = await getFetchInstances(chunks, output, formats);
+        let allOutputFilesAvailable = true;
+        Object.keys(availableFormats).map((key, value) => {
+            if (!existsSync(`${output}.${key}`)) {
+                allOutputFilesAvailable = false;
+            }
+        });
+
+        if (!allOutputFilesAvailable) {
+            // skip regeneration if output file already exists
+            chunks = await getWebpackConnections(directory, output, formats);
+
+            // now, iterate through them, and check fetch instances
+            chunks = await getFetchInstances(chunks, output, formats);
+        } else {
+            // read the JSON file, and load the value
+            chunks = JSON.parse(readFileSync(`${output}.json`, { encoding: "utf8" }));
+        }
 
         // resolve fetch once you've got all
         await resolveFetch(chunks, directory, formats);
 
         if (interactive_mode) {
-            await interactive(chunks);
+            await interactive(chunks, `${output}.json`);
         }
     }
 };

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -22,7 +22,7 @@ const map = async (
     formats: string[],
     tech: string,
     list: boolean,
-    interactive_mode: boolean,
+    interactive_mode: boolean
 ) => {
     console.log(chalk.cyan("[i] Running 'map' module"));
 
@@ -45,15 +45,15 @@ const map = async (
     if (!tech) {
         console.log(
             chalk.red(
-                "[!] Please specify a technology with -t/--tech. Run with -l/--list to see available technologies",
-            ),
+                "[!] Please specify a technology with -t/--tech. Run with -l/--list to see available technologies"
+            )
         );
         return;
     }
 
     if (!directory) {
         console.log(
-            chalk.red("[!] Please specify a directory with -d/--directory"),
+            chalk.red("[!] Please specify a directory with -d/--directory")
         );
         return;
     }
@@ -76,7 +76,9 @@ const map = async (
             chunks = await getFetchInstances(chunks, output, formats);
         } else {
             // read the JSON file, and load the value
-            chunks = JSON.parse(readFileSync(`${output}.json`, { encoding: "utf8" }));
+            chunks = JSON.parse(
+                readFileSync(`${output}.json`, { encoding: "utf8" })
+            );
         }
 
         // resolve fetch once you've got all

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -15,12 +15,12 @@ const availableFormats = {
 };
 
 const map = async (
-    directory,
-    output,
-    formats,
-    tech,
-    list,
-    interactive_mode
+    directory: string,
+    output: string,
+    formats: string[],
+    tech: string,
+    list: boolean,
+    interactive_mode: boolean
 ) => {
     console.log(chalk.cyan("[i] Running 'map' module"));
 

--- a/src/map/next_js/interactive.ts
+++ b/src/map/next_js/interactive.ts
@@ -23,7 +23,7 @@ const interactive = async (chunks: Chunks) => {
         funcWriteFile: undefined,
         commandHistory: [],
         commandHistoryIndex: -1,
-        writeimports: true,
+        writeimports: false,
     };
 
     const ui = createUI();

--- a/src/map/next_js/interactive.ts
+++ b/src/map/next_js/interactive.ts
@@ -12,9 +12,10 @@ export interface State {
     commandHistory: string[];
     commandHistoryIndex: number;
     writeimports: boolean;
+    mapFile: string
 }
 
-const interactive = async (chunks: Chunks) => {
+const interactive = async (chunks: Chunks, map_file:string) => {
     const state = {
         chunks,
         lastCommandStatus: true,
@@ -24,6 +25,7 @@ const interactive = async (chunks: Chunks) => {
         commandHistory: [],
         commandHistoryIndex: -1,
         writeimports: false,
+        mapFile: map_file
     };
 
     const ui = createUI();

--- a/src/map/next_js/interactive.ts
+++ b/src/map/next_js/interactive.ts
@@ -12,10 +12,10 @@ export interface State {
     commandHistory: string[];
     commandHistoryIndex: number;
     writeimports: boolean;
-    mapFile: string
+    mapFile: string;
 }
 
-const interactive = async (chunks: Chunks, map_file:string) => {
+const interactive = async (chunks: Chunks, map_file: string) => {
     const state = {
         chunks,
         lastCommandStatus: true,
@@ -25,7 +25,7 @@ const interactive = async (chunks: Chunks, map_file:string) => {
         commandHistory: [],
         commandHistoryIndex: -1,
         writeimports: false,
-        mapFile: map_file
+        mapFile: map_file,
     };
 
     const ui = createUI();

--- a/src/map/next_js/interactive_helpers/commandHandler.ts
+++ b/src/map/next_js/interactive_helpers/commandHandler.ts
@@ -62,7 +62,10 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                 state.lastCommandStatus = true;
             } else if (option === "nav") {
                 outputBox.log(
-                    commandHelpers.navHistory(state.chunks, state.functionNavHistory)
+                    commandHelpers.navHistory(
+                        state.chunks,
+                        state.functionNavHistory
+                    )
                 );
                 state.lastCommandStatus = true;
             } else {
@@ -237,7 +240,9 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                 } else {
                     // check if the function id exists or not
                     if (!Object.keys(state.chunks).includes(chunkId)) {
-                        outputBox.log(chalk.red(`Chunk ID ${chunkId} not found`))
+                        outputBox.log(
+                            chalk.red(`Chunk ID ${chunkId} not found`)
+                        );
                         state.lastCommandStatus = false;
                     } else {
                         // proceed with modifying chunk name
@@ -245,9 +250,16 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                         state.chunks[chunkId].description = newChunkDesc;
 
                         // write to file also
-                        fs.writeFileSync(state.mapFile, JSON.stringify(state.chunks, null, 2));
+                        fs.writeFileSync(
+                            state.mapFile,
+                            JSON.stringify(state.chunks, null, 2)
+                        );
 
-                        outputBox.log(chalk.green(`Description for ${chunkId} modified: ${newChunkDesc}`));
+                        outputBox.log(
+                            chalk.green(
+                                `Description for ${chunkId} modified: ${newChunkDesc}`
+                            )
+                        );
 
                         state.lastCommandStatus = true;
                     }
@@ -269,7 +281,9 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                 state.lastCommandStatus = false;
             } else {
                 const funcName = text.split(" ")[1];
-                outputBox.log(commandHelpers.traceFunction(state.chunks, funcName));
+                outputBox.log(
+                    commandHelpers.traceFunction(state.chunks, funcName)
+                );
                 state.lastCommandStatus = true;
             }
         }

--- a/src/map/next_js/interactive_helpers/commandHandler.ts
+++ b/src/map/next_js/interactive_helpers/commandHandler.ts
@@ -102,8 +102,13 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                     );
                     state.lastCommandStatus = false;
                 }
-                state.functionNavHistory.push(funcId);
-                state.functionNavHistoryIndex++;
+
+                // before pushing to the function nav history, 
+                // make sure this is not the same as the last one
+                if (state.functionNavHistory[state.functionNavHistoryIndex] !== funcId && Object.keys(chunks).includes(funcId)){
+                    state.functionNavHistory.push(funcId);
+                    state.functionNavHistoryIndex++;
+                }
             } else if (funcName === "back") {
                 if (state.functionNavHistory.length > 0) {
                     if (state.functionNavHistoryIndex > 0) {

--- a/src/map/next_js/interactive_helpers/commandHandler.ts
+++ b/src/map/next_js/interactive_helpers/commandHandler.ts
@@ -103,9 +103,13 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                     state.lastCommandStatus = false;
                 }
 
-                // before pushing to the function nav history, 
+                // before pushing to the function nav history,
                 // make sure this is not the same as the last one
-                if (state.functionNavHistory[state.functionNavHistoryIndex] !== funcId && Object.keys(chunks).includes(funcId)){
+                if (
+                    state.functionNavHistory[state.functionNavHistoryIndex] !==
+                        funcId &&
+                    Object.keys(chunks).includes(funcId)
+                ) {
                     state.functionNavHistory.push(funcId);
                     state.functionNavHistoryIndex++;
                 }

--- a/src/map/next_js/interactive_helpers/commandHandler.ts
+++ b/src/map/next_js/interactive_helpers/commandHandler.ts
@@ -5,6 +5,7 @@ import { helpMenu } from "./helpMenu.js";
 import { printFunction } from "./printer.js";
 import { State } from "../interactive.js";
 import { Widgets } from "blessed";
+import fs from "fs";
 
 interface Screen {
     screen: any;
@@ -14,7 +15,6 @@ interface Screen {
 }
 
 async function handleCommand(text: string, state: State, ui: Screen) {
-    const { chunks } = state;
     const { outputBox, inputBox, screen } = ui;
 
     if (
@@ -55,14 +55,14 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                 outputBox.log(chalk.magenta(usage));
                 state.lastCommandStatus = false;
             } else if (option === "fetch") {
-                outputBox.log(commandHelpers.fetchMenu(chunks));
+                outputBox.log(commandHelpers.fetchMenu(state.chunks));
                 state.lastCommandStatus = true;
             } else if (option === "all") {
-                outputBox.log(commandHelpers.listAllFunctions(chunks));
+                outputBox.log(commandHelpers.listAllFunctions(state.chunks));
                 state.lastCommandStatus = true;
             } else if (option === "nav") {
                 outputBox.log(
-                    commandHelpers.navHistory(chunks, state.functionNavHistory)
+                    commandHelpers.navHistory(state.chunks, state.functionNavHistory)
                 );
                 state.lastCommandStatus = true;
             } else {
@@ -83,16 +83,16 @@ async function handleCommand(text: string, state: State, ui: Screen) {
             } else if (funcName === "to") {
                 const funcId = text.split(" ")[2];
                 // check if the function exists
-                if (chunks[funcId]) {
+                if (state.chunks[funcId]) {
                     const funcCode = await commandHelpers.getFunctionCode(
-                        chunks,
+                        state.chunks,
                         funcId,
                         state
                     );
                     printFunction(
                         outputBox,
                         funcCode,
-                        chunks[funcId]?.description,
+                        state.chunks[funcId]?.description,
                         state.funcWriteFile
                     );
                     state.lastCommandStatus = true;
@@ -108,7 +108,7 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                 if (
                     state.functionNavHistory[state.functionNavHistoryIndex] !==
                         funcId &&
-                    Object.keys(chunks).includes(funcId)
+                    Object.keys(state.chunks).includes(funcId)
                 ) {
                     state.functionNavHistory.push(funcId);
                     state.functionNavHistoryIndex++;
@@ -122,17 +122,17 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                                 state.functionNavHistoryIndex
                             ];
 
-                        if (Object.keys(chunks).includes(funcId)) {
+                        if (Object.keys(state.chunks).includes(funcId)) {
                             const funcCode =
                                 await commandHelpers.getFunctionCode(
-                                    chunks,
+                                    state.chunks,
                                     funcId,
                                     state
                                 );
                             printFunction(
                                 outputBox,
                                 funcCode,
-                                chunks[funcId].description,
+                                state.chunks[funcId].description,
                                 state.funcWriteFile
                             );
                             state.lastCommandStatus = true;
@@ -161,17 +161,17 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                             state.functionNavHistory[
                                 state.functionNavHistoryIndex
                             ];
-                        if (Object.keys(chunks).includes(funcId)) {
+                        if (Object.keys(state.chunks).includes(funcId)) {
                             const funcCode =
                                 await commandHelpers.getFunctionCode(
-                                    chunks,
+                                    state.chunks,
                                     funcId,
                                     state
                                 );
                             printFunction(
                                 outputBox,
                                 funcCode,
-                                chunks[funcId].description,
+                                state.chunks[funcId].description,
                                 state.funcWriteFile
                             );
                             state.lastCommandStatus = true;
@@ -227,6 +227,31 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                     outputBox.log(chalk.magenta(helpMenu.set));
                     state.lastCommandStatus = false;
                 }
+            } else if (option === "funcdesc") {
+                // update the function description
+                const chunkId = text.split(" ")[2];
+
+                if (chunkId === "") {
+                    outputBox.log(chalk.magenta(helpMenu.set));
+                    state.lastCommandStatus = false;
+                } else {
+                    // check if the function id exists or not
+                    if (!Object.keys(state.chunks).includes(chunkId)) {
+                        outputBox.log(chalk.red(`Chunk ID ${chunkId} not found`))
+                        state.lastCommandStatus = false;
+                    } else {
+                        // proceed with modifying chunk name
+                        const newChunkDesc = text.split(" ").slice(3).join(" ");
+                        state.chunks[chunkId].description = newChunkDesc;
+
+                        // write to file also
+                        fs.writeFileSync(state.mapFile, JSON.stringify(state.chunks, null, 2));
+
+                        outputBox.log(chalk.green(`Description for ${chunkId} modified: ${newChunkDesc}`));
+
+                        state.lastCommandStatus = true;
+                    }
+                }
             } else {
                 outputBox.log(chalk.red(option) + " is not a valid option");
                 state.lastCommandStatus = false;
@@ -244,7 +269,7 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                 state.lastCommandStatus = false;
             } else {
                 const funcName = text.split(" ")[1];
-                outputBox.log(commandHelpers.traceFunction(chunks, funcName));
+                outputBox.log(commandHelpers.traceFunction(state.chunks, funcName));
                 state.lastCommandStatus = true;
             }
         }

--- a/src/map/next_js/interactive_helpers/helpMenu.ts
+++ b/src/map/next_js/interactive_helpers/helpMenu.ts
@@ -4,7 +4,7 @@ const helpMenu = {
     clear: "Clear the output box",
     list: "Usage: list <option>\n  fetch: List functions that contain fetch instances\n  all:   List all functions\n  nav:   List navigation history",
     go: "Usage: go <option>\n  to <functionID>: Go to a specific function\n  back:          Go back to the previous function\n  ahead:         Go to the next function",
-    set: "Usage: set <option> <value>\n  funcwritefile <filename>: Set file to write function code to\n  writeimports [true/false]: When using `go *` command, also write all the imports to the file",
+    set: "Usage: set <option> <value>\n  funcwritefile <filename>: Set file to write function code to\n  writeimports [true/false]: When using `go *` command, also write all the imports to the file\n  funcdesc <functionId> <description>: Set the description of the provided function ID with provided value",
     trace: "Usage: trace <functionName>\n  Traces imports for a function",
 };
 

--- a/src/map/next_js/interactive_helpers/keybindings.ts
+++ b/src/map/next_js/interactive_helpers/keybindings.ts
@@ -1,6 +1,8 @@
+import { Widgets } from "blessed";
 import chalk from "chalk";
+import { State } from "../interactive.js";
 
-function setupKeybindings(screen, inputBox, outputBox, state) {
+function setupKeybindings(screen: Widgets.Screen, inputBox: Widgets.TextboxElement, outputBox: Widgets.Log, state: State) {
     // Quit on ctl-c
     screen.key(["C-c", "q"], () => {
         return process.exit(0);
@@ -16,7 +18,10 @@ function setupKeybindings(screen, inputBox, outputBox, state) {
 
     // Clear input box on ctl-c
     inputBox.key(["C-c"], () => {
+        const inputBoxValue = inputBox.value;
+        outputBox.log(`${state.lastCommandStatus ? chalk.bgGreen("%") : chalk.bgRed("%")} ${inputBoxValue}`);
         outputBox.log(chalk.yellow("^C (Use Esc then C-c to exit)"));
+        inputBox.clearValue();
         inputBox.focus();
         state.lastCommandStatus = false;
         screen.render();
@@ -39,13 +44,13 @@ function setupKeybindings(screen, inputBox, outputBox, state) {
     });
 
     // on pressing arrow keys on output box, scroll the output
-    outputBox.key(["up", "down"], (ch, key) => {
+    outputBox.key(["up", "down"], (ch: any, key: { name: string; }) => {
         outputBox.scroll(key.name === "up" ? -1 : 1);
         screen.render();
     });
 
     // on pressing arrow keys on input box, navigate through command history
-    inputBox.key(["up", "down"], (ch, key) => {
+    inputBox.key(["up", "down"], (ch: any, key: { name: string; }) => {
         if (key.name === "up") {
             if (state.commandHistoryIndex > 0) {
                 state.commandHistoryIndex--;

--- a/src/map/next_js/interactive_helpers/keybindings.ts
+++ b/src/map/next_js/interactive_helpers/keybindings.ts
@@ -2,7 +2,12 @@ import { Widgets } from "blessed";
 import chalk from "chalk";
 import { State } from "../interactive.js";
 
-function setupKeybindings(screen: Widgets.Screen, inputBox: Widgets.TextboxElement, outputBox: Widgets.Log, state: State) {
+function setupKeybindings(
+    screen: Widgets.Screen,
+    inputBox: Widgets.TextboxElement,
+    outputBox: Widgets.Log,
+    state: State
+) {
     // Quit on ctl-c
     screen.key(["C-c", "q"], () => {
         return process.exit(0);
@@ -19,7 +24,9 @@ function setupKeybindings(screen: Widgets.Screen, inputBox: Widgets.TextboxEleme
     // Clear input box on ctl-c
     inputBox.key(["C-c"], () => {
         const inputBoxValue = inputBox.value;
-        outputBox.log(`${state.lastCommandStatus ? chalk.bgGreen("%") : chalk.bgRed("%")} ${inputBoxValue}`);
+        outputBox.log(
+            `${state.lastCommandStatus ? chalk.bgGreen("%") : chalk.bgRed("%")} ${inputBoxValue}`
+        );
         outputBox.log(chalk.yellow("^C (Use Esc then C-c to exit)"));
         inputBox.clearValue();
         inputBox.focus();
@@ -44,13 +51,13 @@ function setupKeybindings(screen: Widgets.Screen, inputBox: Widgets.TextboxEleme
     });
 
     // on pressing arrow keys on output box, scroll the output
-    outputBox.key(["up", "down"], (ch: any, key: { name: string; }) => {
+    outputBox.key(["up", "down"], (ch: any, key: { name: string }) => {
         outputBox.scroll(key.name === "up" ? -1 : 1);
         screen.render();
     });
 
     // on pressing arrow keys on input box, navigate through command history
-    inputBox.key(["up", "down"], (ch: any, key: { name: string; }) => {
+    inputBox.key(["up", "down"], (ch: any, key: { name: string }) => {
         if (key.name === "up") {
             if (state.commandHistoryIndex > 0) {
                 state.commandHistoryIndex--;

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -15,8 +15,16 @@ export default async (cmd) => {
 
     // check if the given URL is a file
     if (fs.existsSync(cmd.url)) {
-        console.log(chalk.red(`[!] Please provide a single URL. Parsing a list of URLs isn't available`));
-        console.log(chalk.yellow(`To run the tool against, a list of targets, pass the file in '-u' flag of 'lazyload' module, and it will download the JS files`));
+        console.log(
+            chalk.red(
+                `[!] Please provide a single URL. Parsing a list of URLs isn't available`
+            )
+        );
+        console.log(
+            chalk.yellow(
+                `To run the tool against, a list of targets, pass the file in '-u' flag of 'lazyload' module, and it will download the JS files`
+            )
+        );
         return;
     }
 

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -13,6 +13,13 @@ export default async (cmd) => {
     globalsUtil.setRespCacheFile(cmd.cacheFile);
     globalsUtil.setYes(cmd.yes);
 
+    // check if the given URL is a file
+    if (fs.existsSync(cmd.url)) {
+        console.log(chalk.red(`[!] Please provide a single URL. Parsing a list of URLs isn't available`));
+        console.log(chalk.yellow(`To run the tool against, a list of targets, pass the file in '-u' flag of 'lazyload' module, and it will download the JS files`));
+        return;
+    }
+
     const targetHost = new URL(cmd.url).host;
 
     console.log(chalk.bgGreenBright("[+] Starting analysis..."));

--- a/src/techDetect/index.ts
+++ b/src/techDetect/index.ts
@@ -178,8 +178,8 @@ const frameworkDetect = async (url: string) => {
     } catch (err) {
         console.log(
             chalk.yellow(
-                "[!] Page load timed out, but continuing with current state"
-            )
+                "[!] Page load timed out, but continuing with current state",
+            ),
         );
     }
     await new Promise((resolve) => setTimeout(resolve, 5000));
@@ -201,11 +201,21 @@ const frameworkDetect = async (url: string) => {
     const result_checkSvelte = await checkSvelte($);
 
     // now, also check with the res response
-    const resBody = await res.text();
-    const $res = cheerio.load(resBody);
-    const result_checkNextJS_res = await checkNextJS($res);
-    const result_checkVueJS_res = await checkVueJS($res);
-    const result_checkSvelte_res = await checkSvelte($res);
+    let result_checkNextJS_res = {detected: false, evidence: ""};
+    let result_checkVueJS_res = {detected: false, evidence: ""};
+    let result_checkSvelte_res = {detected: false, evidence: ""};
+    let $res;
+    console.log("res", res, res == null);
+    // if network error was caused, then return
+    if (res === null) {
+        console.log(chalk.red("[!] Fetch request failed after retries"));
+    } else {
+        const resBody = await res.text();
+        $res = cheerio.load(resBody);
+        result_checkNextJS_res = await checkNextJS($res);
+        result_checkVueJS_res = await checkVueJS($res);
+        result_checkSvelte_res = await checkSvelte($res);
+    }
 
     if (
         result_checkNextJS.detected === true ||
@@ -223,7 +233,7 @@ const frameworkDetect = async (url: string) => {
         console.log(chalk.green("[✓] Vue.js detected"));
         console.log(
             chalk.cyan(`[i] Checking Nuxt.JS`),
-            chalk.dim("(Nuxt.JS is built on Vue.js)")
+            chalk.dim("(Nuxt.JS is built on Vue.js)"),
         );
         const result_checkNuxtJS = await checkNuxtJS($);
         const result_checkNuxtJS_res = await checkNuxtJS($res);

--- a/src/techDetect/index.ts
+++ b/src/techDetect/index.ts
@@ -205,7 +205,6 @@ const frameworkDetect = async (url: string) => {
     let result_checkVueJS_res = { detected: false, evidence: "" };
     let result_checkSvelte_res = { detected: false, evidence: "" };
     let $res;
-    console.log("res", res, res == null);
     // if network error was caused, then return
     if (res === null) {
         console.log(chalk.red("[!] Fetch request failed after retries"));

--- a/src/techDetect/index.ts
+++ b/src/techDetect/index.ts
@@ -160,7 +160,7 @@ const checkSvelte = async ($) => {
  *   - name: A string indicating the detected framework, or null if no framework was detected.
  *   - evidence: A string with the evidence of the detection, or an empty string if no framework was detected.
  */
-const frameworkDetect = async (url) => {
+const frameworkDetect = async (url:string) => {
     console.log(chalk.cyan("[i] Detecting front-end framework"));
 
     // get the page source

--- a/src/techDetect/index.ts
+++ b/src/techDetect/index.ts
@@ -178,8 +178,8 @@ const frameworkDetect = async (url: string) => {
     } catch (err) {
         console.log(
             chalk.yellow(
-                "[!] Page load timed out, but continuing with current state",
-            ),
+                "[!] Page load timed out, but continuing with current state"
+            )
         );
     }
     await new Promise((resolve) => setTimeout(resolve, 5000));
@@ -201,9 +201,9 @@ const frameworkDetect = async (url: string) => {
     const result_checkSvelte = await checkSvelte($);
 
     // now, also check with the res response
-    let result_checkNextJS_res = {detected: false, evidence: ""};
-    let result_checkVueJS_res = {detected: false, evidence: ""};
-    let result_checkSvelte_res = {detected: false, evidence: ""};
+    let result_checkNextJS_res = { detected: false, evidence: "" };
+    let result_checkVueJS_res = { detected: false, evidence: "" };
+    let result_checkSvelte_res = { detected: false, evidence: "" };
     let $res;
     console.log("res", res, res == null);
     // if network error was caused, then return
@@ -233,7 +233,7 @@ const frameworkDetect = async (url: string) => {
         console.log(chalk.green("[✓] Vue.js detected"));
         console.log(
             chalk.cyan(`[i] Checking Nuxt.JS`),
-            chalk.dim("(Nuxt.JS is built on Vue.js)"),
+            chalk.dim("(Nuxt.JS is built on Vue.js)")
         );
         const result_checkNuxtJS = await checkNuxtJS($);
         const result_checkNuxtJS_res = await checkNuxtJS($res);

--- a/src/utility/makeReq.ts
+++ b/src/utility/makeReq.ts
@@ -62,7 +62,12 @@ const UAs = [
     "Firefox/Android: Mozilla/5.0 (Android 11; Mobile; rv:68.0) Gecko/68.0 Firefox/84.0",
 ];
 
-const readCache = async (url: string, headers: {}) => {
+const readCache = async (url: string, headers: {}):Promise<Response|null> => {
+    // first, check if the file exists or not
+    if (!fs.existsSync(globals.getRespCacheFile())) {
+        return null;
+    }
+
     // console.log("reading cache for", url);
     // open the cache file, build a Response, and return
     const cache = JSON.parse(
@@ -179,7 +184,7 @@ const makeRequest = async (url: string, args: RequestInit) => {
         }
         return response;
     } else {
-        if (args === undefined) {
+        if (args === undefined || Object.keys(args).length === 0) {
             args = {
                 headers: {
                     "User-Agent": UAs[Math.floor(Math.random() * UAs.length)],
@@ -216,6 +221,7 @@ const makeRequest = async (url: string, args: RequestInit) => {
         }
 
         const preservedRes = res.clone();
+        const preservedRes2 = res.clone();
 
         // check if this is a firewall
         // CF first
@@ -281,7 +287,7 @@ const makeRequest = async (url: string, args: RequestInit) => {
             const resToCache = preservedRes.clone();
             await writeCache(url, args?.headers || {}, resToCache);
         }
-        return preservedRes;
+        return preservedRes2;
     }
 };
 


### PR DESCRIPTION
### Added

- Added `set funcdesc <functionId> <description>` command to interactive mode

### Changed

- Pressing C-c in input box (interactive mode) will now also print the command like OS terminal
- Set the default value of `set writeimports` as `false`
- Do not store dupe and non-existent entries in `state.functionNavHistory` (interactive mode)

### Fixed

- Fix error of body has been read when running the tool for first time
- Print an error when the user passes a URL list (file) to the run command
- Add error recovery in Nuxt ast parse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new interactive command to set function descriptions directly by function ID.
  * Enhanced interactive mode with improved navigation history handling and updated help menu.

* **Bug Fixes**
  * Fixed errors when running the tool for the first time or when handling invalid URL inputs.
  * Improved error recovery during parsing and fetch failures.

* **Improvements**
  * Interactive mode now prints the input command when Ctrl-C is pressed, similar to a terminal.
  * Default setting for writing imports changed to false.
  * Optimized data regeneration to avoid unnecessary processing when output files already exist.
  * Improved type safety and clarity in command-line and interactive features.

* **Documentation**
  * Updated documentation and help menus to reflect new and clarified interactive commands.

* **Chores**
  * Updated version to 1.1.0-beta.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->