### PR TITLE
refactor: replace generic exit(1) and return statements with unique e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Added `-k` as shorthand flag to the `run` module
+- Added standard exit codes to the application
 
 ### Fixed
 

--- a/src/analyze/index.ts
+++ b/src/analyze/index.ts
@@ -69,7 +69,7 @@ const analyze = async (
 
     if (!allValidated) {
         console.log(chalk.red("[!] Some rules are invalid"));
-        process.exit(1);
+        process.exit(20);
     }
 
     if (validate) {

--- a/src/api_gateway/genReq.ts
+++ b/src/api_gateway/genReq.ts
@@ -185,7 +185,7 @@ const get = async (url: string, headers: {} = {}): Promise<string> => {
 
     if (isFireWallBlocking) {
         console.log(chalk.magenta("[!] Please try again without API Gateway"));
-        process.exit(1);
+        process.exit(18);
     }
 
     return body;

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,7 @@ program
             for (const aiType of globalsUtil.getAi()) {
                 if (aiType !== "" && !validAiOptions.includes(aiType)) {
                     console.log(chalk.red(`[!] Invalid AI option: ${aiType}`));
-                    return;
+                    process.exit(1);
                 }
             }
         }
@@ -256,7 +256,7 @@ program
             for (const aiType of globalsUtil.getAi()) {
                 if (aiType !== "" && !validAiOptions.includes(aiType)) {
                     console.log(chalk.red(`[!] Invalid AI option: ${aiType}`));
-                    return;
+                    process.exit(2);
                 }
             }
         }

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -84,7 +84,7 @@ const lazyLoad = async (
         urls = [url];
     } else {
         console.log(chalk.red("[!] Invalid URL or file path"));
-        return;
+        process.exit(3);
     }
 
     for (const url of urls) {

--- a/src/lazyLoad/next_js/next_SubsequentRequests.ts
+++ b/src/lazyLoad/next_js/next_SubsequentRequests.ts
@@ -51,7 +51,7 @@ const subsequentRequests = async (url, urlsFile, threads, output, js_urls): Prom
         console.log(chalk.red(`[!] URLs file ${urlsFile} does not exist`));
         console.log(chalk.yellow(`[!] Please run strings module first with -e flag`));
         console.log(chalk.yellow(`[!] Example: js-recon strings -d <directory> -e`));
-        process.exit(1);
+        process.exit(17);
     }
     const endpoints = JSON.parse(fs.readFileSync(urlsFile, "utf8")).paths;
 

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -44,7 +44,7 @@ const map = async (
     for (const format of formats) {
         if (!Object.keys(availableFormats).includes(format)) {
             console.log(chalk.red(`[!] Invalid format: ${format}`));
-            return;
+            process.exit(4);
         }
     }
 
@@ -54,12 +54,12 @@ const map = async (
                 "[!] Please specify a technology with -t/--tech. Run with -l/--list to see available technologies"
             )
         );
-        return;
+        process.exit(5);
     }
 
     if (!directory) {
         console.log(chalk.red("[!] Please specify a directory with -d/--directory"));
-        return;
+        process.exit(6);
     }
 
     if (tech === "next") {

--- a/src/map/next_js/getWebpackConnections.ts
+++ b/src/map/next_js/getWebpackConnections.ts
@@ -29,7 +29,7 @@ const getWebpackConnections = async (directory, output, formats) => {
                         "[!] OpenAI API key not found. Please provide it via --openai-api-key or OPENAI_API_KEY environment variable."
                     )
                 );
-                process.exit(1);
+                process.exit(19);
             }
         }
         console.log(chalk.cyan(`[i] AI provider "${provider}" initialized.`));

--- a/src/refactor/index.ts
+++ b/src/refactor/index.ts
@@ -16,7 +16,7 @@ const refactor = async (mappedJson: string, outputDir: string, tech: string, lis
     // check if the file exists
     if (!fs.existsSync(mappedJson)) {
         console.log(chalk.red("[!] Mapped JSON file does not exist"));
-        process.exit(1);
+        process.exit(7);
     }
 
     if (list) {
@@ -30,13 +30,13 @@ const refactor = async (mappedJson: string, outputDir: string, tech: string, lis
     // verify if the tech provided is valid
     if (!Object.keys(availableTechs).includes(tech)) {
         console.log(chalk.red("[!] Invalid technology provided"));
-        process.exit(1);
+        process.exit(8);
     }
 
     // check if the output directory already exists
     if (fs.existsSync(outputDir)) {
         console.log(chalk.red("[!] Output directory already exists"));
-        process.exit(1);
+        process.exit(9);
     } else {
         fs.mkdirSync(outputDir);
     }

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -43,7 +43,7 @@ const processUrl = async (url, outputDir, workingDir, cmd, isBatch) => {
 
     if (globalsUtil.getTech() === "") {
         console.log(chalk.bgRed("[!] Technology not detected. Quitting."));
-        return;
+        process.exit(10);
     }
 
     if (globalsUtil.getTech() !== "next") {
@@ -143,13 +143,13 @@ export default async (cmd) => {
                     `[i] For advanced users: use the individual modules separately. See docs at ${CONFIG.modulesDocs}`
                 )
             );
-            return;
+            process.exit(11);
         }
 
         let urlTest = new URL(cmd.url);
         if (!urlTest) {
             console.log(chalk.red("[!] Invalid URL"));
-            return;
+            process.exit(12);
         }
 
         await processUrl(cmd.url, cmd.output, ".", cmd, false);
@@ -171,7 +171,7 @@ export default async (cmd) => {
             }
         }
         if (!allPassed) {
-            return;
+            process.exit(13);
         }
 
         // first of all, make a new directory for the tool output
@@ -187,7 +187,7 @@ export default async (cmd) => {
                     `[i] For advanced users: use the individual modules separately. See docs at ${CONFIG.modulesDocs}`
                 )
             );
-            return;
+            process.exit(14);
         }
         fs.mkdirSync(toolOutputDir);
 

--- a/src/strings/index.ts
+++ b/src/strings/index.ts
@@ -82,7 +82,7 @@ const strings = async (
     // check if the directory exists
     if (!fs.existsSync(directory)) {
         console.log(chalk.red("[!] Directory does not exist"));
-        return;
+        process.exit(15);
     }
 
     console.log(chalk.cyan(`[i] Scanning ${directory} directory`));
@@ -179,7 +179,7 @@ const strings = async (
     // if -p is enabled, but not -e, or the same case with the --openapi flag
     if ((permutate_option && !extract_urls) || (openapi_option && !extract_urls)) {
         console.log(chalk.red("[!] Please enable -e flag for -p or --openapi flag"));
-        return;
+        process.exit(16);
     }
 
     // if the -e flag is enabled, extract the URLs also


### PR DESCRIPTION
Added standard exit codes.

# Exit Codes

This document lists the custom exit codes used in the application and their meanings.

| Exit Code | Command    | Reason for Exit                                                                                                                                         |
| --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1         | `map`      | Invalid AI option provided. The `--ai` option received a value that is not supported.                                                                   |
| 2         | `run`      | Invalid AI option provided. The `--ai` option received a value that is not supported.                                                                   |
| 3         | `lazyload` | Invalid URL or file path provided. The `-u` or `--url` option received a value that is not a valid URL or an existing file path.                        |
| 4         | `map`      | Invalid format provided. The `--format` option received a value that is not supported.                                                                  |
| 5         | `map`      | Missing technology. The `-t` or `--tech` option was not specified.                                                                                      |
| 6         | `map`      | Missing directory. The `-d` or `--directory` option was not specified.                                                                                  |
| 7         | `refactor` | Mapped JSON file does not exist. The `-m` or `--mapped-json` option received a value that is not an existing file path.                                 |
| 8         | `refactor` | Invalid technology provided. The `-t` or `--tech` option received a value that is not supported.                                                        |
| 9         | `refactor` | Output directory already exists. The `-o` or `--output` option received a value that is an existing directory path.                                     |
| 10        | `run`      | Technology not detected. The tool was unable to detect the technology used by the target URL.                                                           |
| 11        | `run`      | Output directory already exists. The `-o` or `--output` option received a value that is an existing directory path.                                     |
| 12        | `run`      | Invalid URL provided. The `-u` or `--url` option received a value that is not a valid URL.                                                              |
| 13        | `run`      | Invalid URL in file. The file provided to the `-u` or `--url` option contains an invalid URL.                                                           |
| 14        | `run`      | Tool output directory already exists. The default output directory `js_recon_run_output` already exists when running in batch mode.                     |
| 15        | `strings`  | Directory does not exist. The `-d` or `--directory` option received a value that is not an existing directory path.                                     |
| 16        | `strings`  | Missing `-e` flag. The `-p` or `--openapi` flag was used without the `-e` flag.                                                                         |
| 17        | `lazyload` | Subsequent requests URLs file does not exist. This is an internal error, but can be caused if the `strings` module is not run with the `-e` flag first. |
| 18        | `run`      | Firewall blocking API Gateway. The tool detected a firewall blocking the AWS API Gateway. Please try again without the API Gateway.                     |
| 19        | `map`      | OpenAI API key not found. Please provide it via `--openai-api-key` or `OPENAI_API_KEY` environment variable.                                            |
| 20        | `analyze`  | Invalid rules found. Some of the rules provided are invalid.                                                                                            |
