### PR TITLE
feat: add configurable max iterations for recursive Next.js crawling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 1.2.2-alpha.12 - (unreleased)
+
+### Added
+
+- Implemented recursive crawling in Next.js modules to discover more JS files
+- Added `--max-iterations` flag to limit recursive crawl iterations in `lazyload` module
+
+### Changed
+
+### Fixed
+
 ## 1.2.2-alpha.11 - 2026.03.01
 
 ### Added

--- a/contributing/nextjs.md
+++ b/contributing/nextjs.md
@@ -19,20 +19,26 @@ This guide explains how to add new JavaScript file discovery techniques for Next
 The Next.js discovery system is built around the **`NextJsCrawler`** class (`src/lazyLoad/next_js/NextJsCrawler.ts`), which implements a **three-phase crawling strategy**:
 
 ### Phase 1: Initial Discovery
+
 Heavyweight methods that run **once** to bootstrap the crawl:
+
 - Script tag parsing (`next_getJSScript`)
 - Webpack runtime analysis (`next_GetLazyResourcesWebpackJs`) – uses Puppeteer
 - `_buildManifest.js` parsing (`next_getLazyResourcesBuildManifestJs`)
 - Subsequent requests with RSC headers (`subsequentRequests`)
 
 ### Phase 2: Recursive Discovery
+
 Lightweight methods that run **multiple times** on newly discovered URLs until convergence:
+
 - Promise.all pattern detection (`next_promiseResolve`)
 - Layout.js href extraction (`next_parseLayoutJs`)
 - Script tag re-parsing on new pages (`next_getJSScript`)
 
 ### Phase 3: Finalization
+
 Post-processing on the final URL set:
+
 - Source map brute-forcing (`next_bruteForceJsFiles`)
 
 ---
@@ -42,11 +48,13 @@ Post-processing on the final URL set:
 ### Initial Discovery Methods
 
 **When to use:**
+
 - The method is **expensive** (e.g., launches a browser, makes many requests)
 - The method doesn't benefit from being run multiple times
 - The method provides a bootstrap set of URLs
 
 **Characteristics:**
+
 - Runs exactly **once** per crawl
 - Added to `initialDiscovery()` in `NextJsCrawler.ts`
 - Examples: Puppeteer-based webpack analysis, manifest parsing
@@ -54,11 +62,13 @@ Post-processing on the final URL set:
 ### Recursive Discovery Methods
 
 **When to use:**
+
 - The method analyzes **JavaScript file contents** to find more JS files
 - The method discovers **client-side paths** that need to be visited
 - The method can find new URLs by examining URLs found in previous passes
 
 **Characteristics:**
+
 - Runs in a **loop** until no new URLs are discovered (max 10 iterations)
 - Takes an array of URLs as input and returns newly discovered URLs
 - Added to `recursivePass()` in `NextJsCrawler.ts`
@@ -84,13 +94,13 @@ const traverse = _traverse.default;
 
 /**
  * Finds JS files referenced in dynamic import() statements.
- * 
+ *
  * @param urls - Array of JS file URLs to analyze
  * @returns Array of newly discovered JS file URLs
  */
 const next_dynamicImports = async (urls: string[]): Promise<string[]> => {
     console.log(chalk.cyan("[i] Analyzing dynamic import() statements"));
-    
+
     const discoveredUrls: string[] = [];
 
     for (const url of urls) {
@@ -130,7 +140,7 @@ const next_dynamicImports = async (urls: string[]): Promise<string[]> => {
     }
 
     const uniqueUrls = [...new Set(discoveredUrls)];
-    
+
     if (uniqueUrls.length > 0) {
         console.log(chalk.green(`[✓] Found ${uniqueUrls.length} JS files from dynamic imports`));
     }
@@ -144,16 +154,20 @@ export default next_dynamicImports;
 ### Step 2: Method Signature Guidelines
 
 **For initial discovery methods:**
+
 ```typescript
-async function next_methodName(url: string): Promise<string[]>
+async function next_methodName(url: string): Promise<string[]>;
 ```
+
 - Takes the base URL as input
 - Returns array of discovered URLs
 
 **For recursive discovery methods:**
+
 ```typescript
-async function next_methodName(baseUrl: string, urls: string[]): Promise<string[]>
+async function next_methodName(baseUrl: string, urls: string[]): Promise<string[]>;
 ```
+
 - Takes base URL and array of URLs to analyze
 - Returns array of **newly** discovered URLs
 - Should handle empty input gracefully
@@ -161,6 +175,7 @@ async function next_methodName(baseUrl: string, urls: string[]): Promise<string[
 ### Step 3: Common Patterns
 
 #### Pattern 1: AST-based Analysis
+
 Use Babel parser to analyze JavaScript syntax:
 
 ```typescript
@@ -183,6 +198,7 @@ traverse(ast, {
 ```
 
 #### Pattern 2: String/Regex Matching
+
 Quick pattern detection without parsing:
 
 ```typescript
@@ -193,6 +209,7 @@ for (const match of matches) {
 ```
 
 #### Pattern 3: Request-Based Discovery
+
 Make HTTP requests to known patterns:
 
 ```typescript
@@ -219,12 +236,13 @@ private async initialDiscovery(): Promise<void> {
     const jsFromDynamicImports = await next_dynamicImports(this.url);
     this.techniqueEfficiencyMapping["next_dynamicImports"] = jsFromDynamicImports;
     this.registerUrls(jsFromDynamicImports);
-    
+
     // ... rest of the method ...
 }
 ```
 
 **Don't forget to add the import at the top:**
+
 ```typescript
 import next_dynamicImports from "./next_dynamicImports.js";
 ```
@@ -252,6 +270,7 @@ private async recursivePass(jsUrls: string[]): Promise<string[]> {
 ```
 
 **Key points:**
+
 - Append to `techniqueEfficiencyMapping` (not replace) for recursive methods
 - Use `registerUrls()` to deduplicate and track new URLs
 - Only add truly new URLs to `newInThisPass`
@@ -261,6 +280,7 @@ private async recursivePass(jsUrls: string[]): Promise<string[]> {
 ## Best Practices
 
 ### 1. Error Handling
+
 Always handle errors gracefully – don't crash the entire crawl:
 
 ```typescript
@@ -275,6 +295,7 @@ try {
 ```
 
 ### 2. URL Resolution
+
 Use `URL` constructor for proper relative URL resolution:
 
 ```typescript
@@ -282,6 +303,7 @@ const absoluteUrl = new URL(relativePath, baseUrl).href;
 ```
 
 ### 3. Deduplication
+
 Always deduplicate before returning:
 
 ```typescript
@@ -289,6 +311,7 @@ return [...new Set(discoveredUrls)];
 ```
 
 ### 4. Performance
+
 - Cache expensive operations (e.g., don't re-fetch the same URL)
 - Use `lazyLoadGlobals.presentInCrawledUrls()` to check if already visited
 - Mark URLs as crawled with `lazyLoadGlobals.addCrawledUrl()`
@@ -298,23 +321,24 @@ import { presentInCrawledUrls, addCrawledUrl } from "../globals.js";
 
 for (const url of urls) {
     if (presentInCrawledUrls(url)) continue;
-    
+
     // ... analyze URL ...
-    
+
     addCrawledUrl(url);
 }
 ```
 
 ### 5. Logging
+
 Use `chalk` for consistent logging:
 
 ```typescript
 import chalk from "chalk";
 
-console.log(chalk.cyan("[i] Starting analysis..."));      // Info
-console.log(chalk.green("[✓] Found 10 files"));           // Success
-console.log(chalk.yellow("[!] Warning message"));          // Warning
-console.log(chalk.red("[!] Error occurred"));              // Error
+console.log(chalk.cyan("[i] Starting analysis...")); // Info
+console.log(chalk.green("[✓] Found 10 files")); // Success
+console.log(chalk.yellow("[!] Warning message")); // Warning
+console.log(chalk.red("[!] Error occurred")); // Error
 ```
 
 ---
@@ -341,12 +365,14 @@ Check `research.json` to see how many URLs your method discovered:
 ### 2. Verify Convergence
 
 Ensure your recursive method doesn't cause infinite loops:
+
 - Check that "Recursive crawl converged" message appears
 - If it hits max iterations (10), investigate why
 
 ### 3. Performance Validation
 
 Monitor execution time:
+
 ```bash
 time npm run start -- run -u https://example.com -y
 ```
@@ -369,16 +395,13 @@ This generates `research.json` with per-method efficiency:
         "https://example.com/_next/static/chunks/main.js",
         "https://example.com/_next/static/chunks/webpack.js"
     ],
-    "next_dynamicImports": [
-        "https://example.com/_next/static/chunks/lazy-component.js"
-    ],
-    "next_promiseResolve": [
-        "https://example.com/_next/static/chunks/pages/about.js"
-    ]
+    "next_dynamicImports": ["https://example.com/_next/static/chunks/lazy-component.js"],
+    "next_promiseResolve": ["https://example.com/_next/static/chunks/pages/about.js"]
 }
 ```
 
 **Analysis tips:**
+
 - **Unique discoveries**: Methods that find URLs no other method finds
 - **Overlap**: Methods that discover the same URLs (candidates for removal)
 - **Efficiency**: URLs found per method execution

--- a/contributing/nextjs.md
+++ b/contributing/nextjs.md
@@ -1,0 +1,384 @@
+# Contributing New Next.js Discovery Methods
+
+This guide explains how to add new JavaScript file discovery techniques for Next.js applications to `js-recon`.
+
+## Table of Contents
+
+- [Architecture Overview](#architecture-overview)
+- [Discovery Method Types](#discovery-method-types)
+- [Adding a New Discovery Method](#adding-a-new-discovery-method)
+- [Integration into NextJsCrawler](#integration-into-nextjscrawler)
+- [Best Practices](#best-practices)
+- [Testing Your Method](#testing-your-method)
+- [Research Mode](#research-mode)
+
+---
+
+## Architecture Overview
+
+The Next.js discovery system is built around the **`NextJsCrawler`** class (`src/lazyLoad/next_js/NextJsCrawler.ts`), which implements a **three-phase crawling strategy**:
+
+### Phase 1: Initial Discovery
+Heavyweight methods that run **once** to bootstrap the crawl:
+- Script tag parsing (`next_getJSScript`)
+- Webpack runtime analysis (`next_GetLazyResourcesWebpackJs`) – uses Puppeteer
+- `_buildManifest.js` parsing (`next_getLazyResourcesBuildManifestJs`)
+- Subsequent requests with RSC headers (`subsequentRequests`)
+
+### Phase 2: Recursive Discovery
+Lightweight methods that run **multiple times** on newly discovered URLs until convergence:
+- Promise.all pattern detection (`next_promiseResolve`)
+- Layout.js href extraction (`next_parseLayoutJs`)
+- Script tag re-parsing on new pages (`next_getJSScript`)
+
+### Phase 3: Finalization
+Post-processing on the final URL set:
+- Source map brute-forcing (`next_bruteForceJsFiles`)
+
+---
+
+## Discovery Method Types
+
+### Initial Discovery Methods
+
+**When to use:**
+- The method is **expensive** (e.g., launches a browser, makes many requests)
+- The method doesn't benefit from being run multiple times
+- The method provides a bootstrap set of URLs
+
+**Characteristics:**
+- Runs exactly **once** per crawl
+- Added to `initialDiscovery()` in `NextJsCrawler.ts`
+- Examples: Puppeteer-based webpack analysis, manifest parsing
+
+### Recursive Discovery Methods
+
+**When to use:**
+- The method analyzes **JavaScript file contents** to find more JS files
+- The method discovers **client-side paths** that need to be visited
+- The method can find new URLs by examining URLs found in previous passes
+
+**Characteristics:**
+- Runs in a **loop** until no new URLs are discovered (max 10 iterations)
+- Takes an array of URLs as input and returns newly discovered URLs
+- Added to `recursivePass()` in `NextJsCrawler.ts`
+- Examples: Promise.all pattern detection, layout href parsing
+
+---
+
+## Adding a New Discovery Method
+
+### Step 1: Create the Method Module
+
+Create a new file in `src/lazyLoad/next_js/` following the naming convention `next_<methodName>.ts`.
+
+#### Example: Detecting dynamic imports
+
+```typescript
+// src/lazyLoad/next_js/next_dynamicImports.ts
+import chalk from "chalk";
+import makeRequest from "../../utility/makeReq.js";
+import parser from "@babel/parser";
+import _traverse from "@babel/traverse";
+const traverse = _traverse.default;
+
+/**
+ * Finds JS files referenced in dynamic import() statements.
+ * 
+ * @param urls - Array of JS file URLs to analyze
+ * @returns Array of newly discovered JS file URLs
+ */
+const next_dynamicImports = async (urls: string[]): Promise<string[]> => {
+    console.log(chalk.cyan("[i] Analyzing dynamic import() statements"));
+    
+    const discoveredUrls: string[] = [];
+
+    for (const url of urls) {
+        try {
+            const response = await makeRequest(url);
+            if (!response?.ok) continue;
+
+            const jsContent = await response.text();
+            const ast = parser.parse(jsContent, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+
+            traverse(ast, {
+                Import(path) {
+                    // Detect: import('path/to/file.js')
+                    const parent = path.parent;
+                    if (
+                        parent.type === "CallExpression" &&
+                        parent.arguments.length > 0 &&
+                        parent.arguments[0].type === "StringLiteral"
+                    ) {
+                        const importPath = parent.arguments[0].value;
+                        if (importPath.endsWith(".js")) {
+                            // Resolve relative to current URL
+                            const resolvedUrl = new URL(importPath, url).href;
+                            discoveredUrls.push(resolvedUrl);
+                        }
+                    }
+                },
+            });
+        } catch (error) {
+            // Skip files that can't be parsed
+            continue;
+        }
+    }
+
+    const uniqueUrls = [...new Set(discoveredUrls)];
+    
+    if (uniqueUrls.length > 0) {
+        console.log(chalk.green(`[✓] Found ${uniqueUrls.length} JS files from dynamic imports`));
+    }
+
+    return uniqueUrls;
+};
+
+export default next_dynamicImports;
+```
+
+### Step 2: Method Signature Guidelines
+
+**For initial discovery methods:**
+```typescript
+async function next_methodName(url: string): Promise<string[]>
+```
+- Takes the base URL as input
+- Returns array of discovered URLs
+
+**For recursive discovery methods:**
+```typescript
+async function next_methodName(baseUrl: string, urls: string[]): Promise<string[]>
+```
+- Takes base URL and array of URLs to analyze
+- Returns array of **newly** discovered URLs
+- Should handle empty input gracefully
+
+### Step 3: Common Patterns
+
+#### Pattern 1: AST-based Analysis
+Use Babel parser to analyze JavaScript syntax:
+
+```typescript
+import parser from "@babel/parser";
+import _traverse from "@babel/traverse";
+const traverse = _traverse.default;
+
+const ast = parser.parse(jsContent, {
+    sourceType: "unambiguous",
+    plugins: ["jsx", "typescript"],
+    errorRecovery: true,
+});
+
+traverse(ast, {
+    // Visitor pattern
+    CallExpression(path) {
+        // Analyze specific AST nodes
+    },
+});
+```
+
+#### Pattern 2: String/Regex Matching
+Quick pattern detection without parsing:
+
+```typescript
+const matches = jsContent.matchAll(/static\/chunks\/[a-zA-Z0-9_\-]+\.js/g);
+for (const match of matches) {
+    discoveredUrls.push(resolveUrl(match[0]));
+}
+```
+
+#### Pattern 3: Request-Based Discovery
+Make HTTP requests to known patterns:
+
+```typescript
+const candidateUrl = `${baseUrl}/_next/static/${hash}/chunk.js`;
+const response = await makeRequest(candidateUrl);
+if (response.status === 200) {
+    discoveredUrls.push(candidateUrl);
+}
+```
+
+---
+
+## Integration into NextJsCrawler
+
+### For Initial Discovery Methods
+
+Add to `initialDiscovery()` in `NextJsCrawler.ts`:
+
+```typescript
+private async initialDiscovery(): Promise<void> {
+    // ... existing methods ...
+
+    // 5. Your new method
+    const jsFromDynamicImports = await next_dynamicImports(this.url);
+    this.techniqueEfficiencyMapping["next_dynamicImports"] = jsFromDynamicImports;
+    this.registerUrls(jsFromDynamicImports);
+    
+    // ... rest of the method ...
+}
+```
+
+**Don't forget to add the import at the top:**
+```typescript
+import next_dynamicImports from "./next_dynamicImports.js";
+```
+
+### For Recursive Discovery Methods
+
+Add to `recursivePass()` in `NextJsCrawler.ts`:
+
+```typescript
+private async recursivePass(jsUrls: string[]): Promise<string[]> {
+    let newInThisPass: string[] = [];
+
+    // ... existing methods ...
+
+    // Your new recursive method
+    const jsFromDynamicImports = await next_dynamicImports(this.url, jsUrls);
+    this.techniqueEfficiencyMapping["next_dynamicImports"] = [
+        ...(this.techniqueEfficiencyMapping["next_dynamicImports"] || []),
+        ...jsFromDynamicImports,
+    ];
+    newInThisPass.push(...this.registerUrls(jsFromDynamicImports));
+
+    return newInThisPass;
+}
+```
+
+**Key points:**
+- Append to `techniqueEfficiencyMapping` (not replace) for recursive methods
+- Use `registerUrls()` to deduplicate and track new URLs
+- Only add truly new URLs to `newInThisPass`
+
+---
+
+## Best Practices
+
+### 1. Error Handling
+Always handle errors gracefully – don't crash the entire crawl:
+
+```typescript
+try {
+    const response = await makeRequest(url);
+    if (!response?.ok) return [];
+    // ... process response ...
+} catch (error) {
+    // Log if needed, but continue
+    return [];
+}
+```
+
+### 2. URL Resolution
+Use `URL` constructor for proper relative URL resolution:
+
+```typescript
+const absoluteUrl = new URL(relativePath, baseUrl).href;
+```
+
+### 3. Deduplication
+Always deduplicate before returning:
+
+```typescript
+return [...new Set(discoveredUrls)];
+```
+
+### 4. Performance
+- Cache expensive operations (e.g., don't re-fetch the same URL)
+- Use `lazyLoadGlobals.presentInCrawledUrls()` to check if already visited
+- Mark URLs as crawled with `lazyLoadGlobals.addCrawledUrl()`
+
+```typescript
+import { presentInCrawledUrls, addCrawledUrl } from "../globals.js";
+
+for (const url of urls) {
+    if (presentInCrawledUrls(url)) continue;
+    
+    // ... analyze URL ...
+    
+    addCrawledUrl(url);
+}
+```
+
+### 5. Logging
+Use `chalk` for consistent logging:
+
+```typescript
+import chalk from "chalk";
+
+console.log(chalk.cyan("[i] Starting analysis..."));      // Info
+console.log(chalk.green("[✓] Found 10 files"));           // Success
+console.log(chalk.yellow("[!] Warning message"));          // Warning
+console.log(chalk.red("[!] Error occurred"));              // Error
+```
+
+---
+
+### 1. Integration Test with Real Sites
+
+Test against known Next.js sites:
+
+```bash
+npm run cleanup && npm run start -- run -u https://nextjs.org -y --research
+```
+
+Check `research.json` to see how many URLs your method discovered:
+
+```json
+{
+    "next_dynamicImports": [
+        "https://nextjs.org/_next/static/chunks/123.js",
+        "https://nextjs.org/_next/static/chunks/456.js"
+    ]
+}
+```
+
+### 2. Verify Convergence
+
+Ensure your recursive method doesn't cause infinite loops:
+- Check that "Recursive crawl converged" message appears
+- If it hits max iterations (10), investigate why
+
+### 3. Performance Validation
+
+Monitor execution time:
+```bash
+time npm run start -- run -u https://example.com -y
+```
+
+---
+
+## Research Mode
+
+Use research mode to validate and compare discovery methods:
+
+```bash
+npm run start -- run -u https://example.com -y --research
+```
+
+This generates `research.json` with per-method efficiency:
+
+```json
+{
+    "next_getJSScript": [
+        "https://example.com/_next/static/chunks/main.js",
+        "https://example.com/_next/static/chunks/webpack.js"
+    ],
+    "next_dynamicImports": [
+        "https://example.com/_next/static/chunks/lazy-component.js"
+    ],
+    "next_promiseResolve": [
+        "https://example.com/_next/static/chunks/pages/about.js"
+    ]
+}
+```
+
+**Analysis tips:**
+- **Unique discoveries**: Methods that find URLs no other method finds
+- **Overlap**: Methods that discover the same URLs (candidates for removal)
+- **Efficiency**: URLs found per method execution

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shriyanss/js-recon",
-    "version": "1.2.2-alpha.11",
+    "version": "1.2.2-alpha.12",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,6 @@
 const githubURL = "https://github.com/shriyanss/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
-const version = "1.2.2-alpha.11";
+const version = "1.2.2-alpha.12";
 const toolDesc = "JS Recon Tool";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ program
     .option("--sourcemap-dir <directory>", "Directory to write source maps", "extracted")
     .option("--research", "Enable research mode", false)
     .option("--research-output <file>", "Output file for research mode", "research.json")
+    .option("--max-iterations <iterations>", "Maximum number of recursive crawl iterations", "10")
     .action(async (cmd) => {
         globalsUtil.setApiGatewayConfigFile(cmd.apiGatewayConfig);
         globalsUtil.setUseApiGateway(cmd.apiGateway);
@@ -81,7 +82,8 @@ program
             cmd.buildId,
             cmd.sourcemapDir,
             cmd.research,
-            cmd.researchOutput
+            cmd.researchOutput,
+            Number(cmd.maxIterations)
         );
     });
 
@@ -282,6 +284,7 @@ program
     .option("--sourcemap-dir <directory>", "Directory to write source maps", "extracted")
     .option("--research", "Enable research mode", false)
     .option("--research-output <file>", "Output file for research mode", "research.json")
+    .option("--max-iterations <iterations>", "Maximum number of recursive crawl iterations", "10")
     .action(async (cmd) => {
         validateAndSetTimeout(cmd.timeout);
         globalsUtil.setAi(cmd.ai?.split(",") || []);

--- a/src/lazyLoad/globals.ts
+++ b/src/lazyLoad/globals.ts
@@ -103,7 +103,6 @@ export const presentInCrawledUrls = (url: string): boolean => {
     return crawled_urls.includes(url);
 };
 
-
 /**
  * Adds a URL to the crawled URLs list if it's not already present.
  * @param url - URL to add to crawled list

--- a/src/lazyLoad/globals.ts
+++ b/src/lazyLoad/globals.ts
@@ -6,6 +6,8 @@ let js_urls: string[] = [];
 let json_urls: string[] = [];
 /** Maximum number of concurrent requests allowed */
 let max_req_queue: number;
+/** List of URLs which has been crawled */
+let crawled_urls: string[] = [];
 
 /**
  * Gets the current scope configuration.
@@ -46,8 +48,15 @@ export const clearJsUrls = (): void => {
  * Adds a JavaScript URL to the global array.
  * @param url - JavaScript URL to add
  */
-export const pushToJsUrls = (url: string): void => {
-    js_urls.push(url);
+export const pushToJsUrls = (url: string | string[]): void => {
+    if (Array.isArray(url)) {
+        js_urls.push(...url);
+    } else {
+        js_urls.push(url);
+    }
+
+    // Remove duplicates
+    js_urls = [...new Set(js_urls)];
 };
 
 /**
@@ -83,4 +92,28 @@ export const getMaxReqQueue = (): number => max_req_queue;
  */
 export const setMaxReqQueue = (newMax: number): void => {
     max_req_queue = newMax;
+};
+
+/**
+ * Checks if a URL is already in the crawled URLs list.
+ * @param url - URL to check
+ * @returns True if URL is already crawled, false otherwise
+ */
+export const presentInCrawledUrls = (url: string): boolean => {
+    return crawled_urls.includes(url);
+};
+
+
+/**
+ * Adds a URL to the crawled URLs list if it's not already present.
+ * @param url - URL to add to crawled list
+ */
+export const addCrawledUrl = (url: string | string[]): void => {
+    if (Array.isArray(url)) {
+        crawled_urls.push(...url);
+    } else {
+        if (!presentInCrawledUrls(url)) {
+            crawled_urls.push(url);
+        }
+    }
 };

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -9,14 +9,8 @@ import makeRequest from "../utility/makeReq.js";
 import * as cheerio from "cheerio";
 
 // Next.js
-import subsequentRequests from "./next_js/next_SubsequentRequests.js";
-import next_getJSScript from "./next_js/next_GetJSScript.js";
-import next_GetLazyResourcesWebpackJs from "./next_js/next_GetLazyResourcesWebpackJs.js";
-import next_getLazyResourcesBuildManifestJs from "./next_js/next_GetLazyResourcesBuildManifestJs.js";
+import NextJsCrawler from "./next_js/NextJsCrawler.js";
 import { next_buildId_RSC } from "./next_js/next_buildId.js";
-import next_promiseResolve from "./next_js/next_promiseResolve.js";
-import next_parseLayoutJs from "./next_js/next_parseLayoutJs.js";
-import next_scriptTagsSubsequentRequests from "./next_js/next_scriptTagsSubsequentRequests.js";
 
 // Nuxt.js
 import nuxt_getFromPageSource from "./nuxt_js/nuxt_getFromPageSource.js";
@@ -50,7 +44,6 @@ import { extractSources } from "./sourcemap.js";
 // import global vars
 import * as lazyLoadGlobals from "./globals.js";
 import * as globals from "../utility/globals.js";
-import next_bruteForceJsFiles from "./next_js/next_bruteForceJsFiles.js";
 import { string } from "zod";
 import vue_severalJsFilesHome from "./vue/vue_severalJsFilesHome.js";
 
@@ -122,7 +115,8 @@ const lazyLoad = async (
     buildId: boolean,
     sourcemapDir: string,
     research: boolean,
-    researchOutput: string
+    researchOutput: string,
+    maxIterations: number
 ) => {
     console.log(chalk.cyan("[i] Loading 'Lazy Load' module"));
 
@@ -175,124 +169,21 @@ const lazyLoad = async (
                 console.log(chalk.green("[✓] Next.js detected"));
                 console.log(chalk.yellow(`Evidence: ${tech.evidence}`));
 
-                // For determining the efficiency of each technique
-                // this is for research purposes
-                let techniqueEfficiecyMapping: {
-                    [key: string]: string[];
-                } = {};
+                const crawler = new NextJsCrawler({
+                    url,
+                    output,
+                    subsequentRequestsFlag,
+                    urlsFile,
+                    threads,
+                    research,
+                    maxIterations,
+                });
 
-                // find the JS files from script of the webpage
-                const jsFilesFromScriptTag = await next_getJSScript(url);
-
-                techniqueEfficiecyMapping["next_getJSScript"] = jsFilesFromScriptTag;
-
-                // get lazy resources
-                const lazyResourcesFromWebpack = await next_GetLazyResourcesWebpackJs(url);
-                techniqueEfficiecyMapping["next_GetLazyResourcesWebpackJs"] = lazyResourcesFromWebpack;
-
-                const lazyResourcesFromBuildManifest = await next_getLazyResourcesBuildManifestJs(url);
-                techniqueEfficiecyMapping["next_getLazyResourcesBuildManifestJs"] = lazyResourcesFromBuildManifest;
-                let lazyResourcesFromSubsequentRequests;
-                let scriptTagsSubsequentRequests;
-
-                if (subsequentRequestsFlag) {
-                    // get JS files from subsequent requests
-                    lazyResourcesFromSubsequentRequests = await subsequentRequests(
-                        url,
-                        urlsFile,
-                        threads,
-                        output,
-                        lazyLoadGlobals.getJsUrls() // Pass the global js_urls
-                    );
-
-                    lazyResourcesFromSubsequentRequests["subsequentRequests"] = lazyResourcesFromSubsequentRequests;
-
-                    // another run for to get the HTML from client side paths
-                    // and parse the script tags
-
-                    scriptTagsSubsequentRequests = await next_scriptTagsSubsequentRequests(url, urlsFile);
-                    techniqueEfficiecyMapping["next_scriptTagsSubsequentRequests"] = scriptTagsSubsequentRequests;
-                }
-
-                // download the resources
-                // but combine them first
-                let jsFilesToDownload: string[] | any = [
-                    ...(jsFilesFromScriptTag || []),
-                    ...(lazyResourcesFromWebpack || []),
-                    ...(lazyResourcesFromBuildManifest || []),
-                    ...(lazyResourcesFromSubsequentRequests || []),
-                    ...(scriptTagsSubsequentRequests || []),
-                ];
-                // Ensure js_urls from globals are included if next_getJSScript or next_getLazyResources populated it.
-                // This is because those functions now push to the global js_urls via setters.
-                // The return values of next_getJSScript and next_getLazyResources might be the same array instance
-                // or a new one depending on their implementation, so explicitly get the global one here.
-                jsFilesToDownload.push(...lazyLoadGlobals.getJsUrls());
-
-                // also, download the JSON files, so push those as well into this list
-                jsFilesToDownload.push(...lazyLoadGlobals.getJsonUrls());
+                const jsFilesToDownload = await crawler.crawl();
 
                 // dedupe the files
-                jsFilesToDownload = [...new Set(jsFilesToDownload)];
-
-                // JS files are also loaded like:
-                // e.v((t) =>
-                // Promise.all(
-                //     [
-                //     "static/chunks/8c89748310820503.js",
-                //     "static/chunks/cc50acdcbae71ebc.js",
-                //     "static/chunks/bedf897aaa1cca78.js",
-                //     ].map((t) => e.l(t)),
-                // ).then(() => t(58485)),
-                // );
-
-                // this behavior was found in my own site, which uses turbopack instead of webpack
-
-                // so, to resolve everything, we need to go through all the files' content
-                // and AST search for this pattern
-
-                const jsFilesFrom_next_promiseResolve = await next_promiseResolve(jsFilesToDownload);
-                techniqueEfficiecyMapping["next_promiseResolve"] = jsFilesFrom_next_promiseResolve;
-                jsFilesToDownload.push(...jsFilesFrom_next_promiseResolve);
-
-                // another method found during research:
-                // when an app is built with turbopack, the .js.map files are present, but unlike webpack,
-                // they aren't present on the bottom of the file
-                // so, the way to find them is to just append `.map` on found JS files and bruteforce them
-
-                const jsFilesSourcemaps = await next_bruteForceJsFiles(jsFilesToDownload);
-                techniqueEfficiecyMapping["next_bruteForceJsFiles"] = jsFilesSourcemaps;
-
-                jsFilesToDownload.push(...jsFilesSourcemaps);
-
-                // layout.*.js contains some UI builder elements
-                // parsing those gives us some client-side paths
-                // for example, the following code snippet is extracted, and returns a valid client side-path:
-                // (0, r.jsx)("div", {
-                //   className: "border-b border-gray-600 pb-2",
-                //   children: (0, r.jsxs)(l(), {
-                //     href: "/profile/".concat(t.auth.username),
-                //     className: "flex flex-row space-x-2 items-center",
-                //     onClick: () => a(!1),
-                //     children: [
-                //       (0, r.jsx)(er.A, { size: "20" }),
-                //       (0, r.jsx)("p", { children: "Profile" }),
-                //     ],
-                //   }),
-                // }),
-                // it is often nested in element names `children`, which is mostly an array
-                // e.g.
-                // children: [..., (0, r.jsx)("div", {...}), ....]
-
-                // so, we need to parse this to find such patterns
-
-                const layoutJsFiles = await next_parseLayoutJs(url, jsFilesToDownload);
-                techniqueEfficiecyMapping["next_parseLayoutJs"] = layoutJsFiles;
-                jsFilesToDownload.push(...layoutJsFiles);
-
-                // dedupe the files
-                jsFilesToDownload = [...new Set(jsFilesToDownload)];
-                await downloadFiles(jsFilesToDownload, output);
+                const dedupedFiles = [...new Set(jsFilesToDownload)];
+                await downloadFiles(dedupedFiles, output);
 
                 if (buildId) {
                     // get the buildId
@@ -311,7 +202,7 @@ const lazyLoad = async (
                 // if the research mode is enabled, then write the technique efficiency to a file
                 if (research) {
                     // prettify the JSON and write
-                    fs.writeFileSync(researchOutput, JSON.stringify(techniqueEfficiecyMapping, null, 4));
+                    fs.writeFileSync(researchOutput, JSON.stringify(crawler.techniqueEfficiencyMapping, null, 4));
                     console.log(
                         chalk.green("[✓] Research mode enabled. Technique efficiency written to " + researchOutput)
                     );

--- a/src/lazyLoad/next_js/NextJsCrawler.ts
+++ b/src/lazyLoad/next_js/NextJsCrawler.ts
@@ -218,9 +218,7 @@ class NextJsCrawler {
         }
 
         // Phase 3 – brute-force .map files on the final set
-        const allJsUrls = [...this.discoveredUrls].filter(
-            (u) => u.endsWith(".js") || u.endsWith(".js.map")
-        );
+        const allJsUrls = [...this.discoveredUrls].filter((u) => u.endsWith(".js") || u.endsWith(".js.map"));
         const jsFromBrute = await next_bruteForceJsFiles(allJsUrls);
         this.techniqueEfficiencyMapping["next_bruteForceJsFiles"] = jsFromBrute;
         this.registerUrls(jsFromBrute);

--- a/src/lazyLoad/next_js/NextJsCrawler.ts
+++ b/src/lazyLoad/next_js/NextJsCrawler.ts
@@ -1,0 +1,232 @@
+import chalk from "chalk";
+import { URL } from "url";
+
+import next_getJSScript from "./next_GetJSScript.js";
+import next_GetLazyResourcesWebpackJs from "./next_GetLazyResourcesWebpackJs.js";
+import next_getLazyResourcesBuildManifestJs from "./next_GetLazyResourcesBuildManifestJs.js";
+import subsequentRequests from "./next_SubsequentRequests.js";
+import next_promiseResolve from "./next_promiseResolve.js";
+import next_parseLayoutJs from "./next_parseLayoutJs.js";
+import next_scriptTagsSubsequentRequests from "./next_scriptTagsSubsequentRequests.js";
+import next_bruteForceJsFiles from "./next_bruteForceJsFiles.js";
+
+import * as lazyLoadGlobals from "../globals.js";
+
+interface NextJsCrawlerOptions {
+    url: string;
+    output: string;
+    subsequentRequestsFlag: boolean;
+    urlsFile: string;
+    threads: number;
+    research: boolean;
+    maxIterations: number;
+}
+
+/**
+ * Encapsulates the Next.js JS file discovery logic with recursive crawling.
+ *
+ * After running all discovery methods once, the crawler re-runs path-sensitive
+ * methods (promiseResolve, parseLayoutJs, getJSScript) on any *newly* found
+ * URLs until no new JS files are discovered, ensuring full coverage.
+ */
+class NextJsCrawler {
+    private readonly url: string;
+    private readonly output: string;
+    private readonly subsequentRequestsFlag: boolean;
+    private readonly urlsFile: string;
+    private readonly threads: number;
+    private readonly research: boolean;
+
+    /** All JS/JSON URLs discovered so far (deduplicated). */
+    private discoveredUrls: Set<string>;
+
+    /** Page URLs that have already been visited for script-tag extraction. */
+    private visitedPageUrls: Set<string>;
+
+    /** Per-technique efficiency mapping (for research mode). */
+    public techniqueEfficiencyMapping: Record<string, string[]>;
+
+    /** Maximum number of recursive passes before giving up. */
+    private MAX_ITERATIONS: number;
+
+    constructor(options: NextJsCrawlerOptions) {
+        this.url = options.url;
+        this.output = options.output;
+        this.subsequentRequestsFlag = options.subsequentRequestsFlag;
+        this.urlsFile = options.urlsFile;
+        this.threads = options.threads;
+        this.research = options.research;
+        this.MAX_ITERATIONS = options.maxIterations;
+
+        this.discoveredUrls = new Set();
+        this.visitedPageUrls = new Set();
+        this.techniqueEfficiencyMapping = {};
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    /** Register newly found URLs and return only the ones that are truly new. */
+    private registerUrls(urls: string[]): string[] {
+        const newUrls: string[] = [];
+        for (const u of urls) {
+            if (!this.discoveredUrls.has(u)) {
+                this.discoveredUrls.add(u);
+                newUrls.push(u);
+            }
+        }
+        return newUrls;
+    }
+
+    /** Snapshot the current size so we can detect growth. */
+    private get size(): number {
+        return this.discoveredUrls.size;
+    }
+
+    // ── initial discovery (run-once methods) ─────────────────────────────
+
+    /**
+     * Runs the heavyweight / one-shot discovery methods that only need to
+     * execute once (puppeteer-based webpack analysis, build-manifest, etc.).
+     */
+    private async initialDiscovery(): Promise<void> {
+        // 1. Script tags on the landing page
+        const jsFromScriptTag = await next_getJSScript(this.url);
+        this.techniqueEfficiencyMapping["next_getJSScript"] = jsFromScriptTag;
+        this.registerUrls(jsFromScriptTag);
+        this.visitedPageUrls.add(this.url);
+
+        // 2. Webpack runtime analysis (puppeteer – expensive, run once)
+        const jsFromWebpack = await next_GetLazyResourcesWebpackJs(this.url);
+        this.techniqueEfficiencyMapping["next_GetLazyResourcesWebpackJs"] = jsFromWebpack;
+        lazyLoadGlobals.pushToJsUrls(jsFromWebpack);
+        this.registerUrls(jsFromWebpack);
+
+        // 3. _buildManifest.js
+        const jsFromBuildManifest = await next_getLazyResourcesBuildManifestJs(this.url);
+        this.techniqueEfficiencyMapping["next_getLazyResourcesBuildManifestJs"] = jsFromBuildManifest;
+        lazyLoadGlobals.pushToJsUrls(jsFromBuildManifest);
+        this.registerUrls(jsFromBuildManifest);
+
+        // 4. Subsequent requests (RSC / script-tags on known endpoints)
+        if (this.subsequentRequestsFlag) {
+            const jsFromSubsequent = await subsequentRequests(
+                this.url,
+                this.urlsFile,
+                this.threads,
+                this.output,
+                lazyLoadGlobals.getJsUrls()
+            );
+            this.techniqueEfficiencyMapping["subsequentRequests"] = [...jsFromSubsequent];
+            this.registerUrls([...jsFromSubsequent]);
+
+            const jsFromScriptTagsSR = await next_scriptTagsSubsequentRequests(this.url, this.urlsFile);
+            this.techniqueEfficiencyMapping["next_scriptTagsSubsequentRequests"] = jsFromScriptTagsSR;
+            lazyLoadGlobals.pushToJsUrls(jsFromScriptTagsSR);
+            this.registerUrls(jsFromScriptTagsSR);
+        }
+
+        // Also pull in anything the globals accumulated
+        this.registerUrls(lazyLoadGlobals.getJsUrls());
+        this.registerUrls(lazyLoadGlobals.getJsonUrls());
+    }
+
+    // ── recursive discovery ──────────────────────────────────────────────
+
+    /**
+     * Runs the lightweight methods that can discover *more* URLs from an
+     * existing set of JS file URLs. These are cheap enough to repeat.
+     *
+     * @param jsUrls The JS URLs to analyse in this pass.
+     * @returns Newly discovered URLs in this pass.
+     */
+    private async recursivePass(jsUrls: string[]): Promise<string[]> {
+        let newInThisPass: string[] = [];
+
+        // Promise.all pattern analysis on JS file contents
+        const jsFromPromise = await next_promiseResolve(jsUrls);
+        this.techniqueEfficiencyMapping["next_promiseResolve"] = [
+            ...(this.techniqueEfficiencyMapping["next_promiseResolve"] || []),
+            ...jsFromPromise,
+        ];
+        newInThisPass.push(...this.registerUrls(jsFromPromise));
+
+        // Layout.js parsing → discovers new client-side page paths → visits them
+        const jsFromLayout = await next_parseLayoutJs(this.url, jsUrls);
+        this.techniqueEfficiencyMapping["next_parseLayoutJs"] = [
+            ...(this.techniqueEfficiencyMapping["next_parseLayoutJs"] || []),
+            ...jsFromLayout,
+        ];
+        newInThisPass.push(...this.registerUrls(jsFromLayout));
+
+        // For every new page URL that parseLayoutJs may have visited,
+        // also run getJSScript to pick up script tags we haven't seen.
+        // We detect "page URLs" as non-.js URLs in the new set.
+        for (const u of newInThisPass) {
+            try {
+                const parsed = new URL(u);
+                const isJsFile = parsed.pathname.endsWith(".js") || parsed.pathname.endsWith(".js.map");
+                if (!isJsFile && !this.visitedPageUrls.has(u)) {
+                    this.visitedPageUrls.add(u);
+                    const extra = await next_getJSScript(u);
+                    newInThisPass.push(...this.registerUrls(extra));
+                }
+            } catch {
+                // invalid URL, skip
+            }
+        }
+
+        return newInThisPass;
+    }
+
+    // ── public API ───────────────────────────────────────────────────────
+
+    /**
+     * Main entry-point.  Runs initial discovery, then iterates recursive
+     * passes until convergence (no new URLs) or the iteration cap.
+     *
+     * @returns The complete, deduplicated list of JS/asset URLs to download.
+     */
+    async crawl(): Promise<string[]> {
+        // Phase 1 – initial heavyweight discovery
+        await this.initialDiscovery();
+
+        // Phase 2 – recursive lightweight passes
+        let currentBatch = [...this.discoveredUrls];
+        let iteration = 0;
+
+        while (iteration < this.MAX_ITERATIONS) {
+            iteration++;
+            const sizeBefore = this.size;
+
+            console.log(chalk.cyan(`[i] Recursive crawl pass ${iteration} – ${sizeBefore} URLs known`));
+
+            const newUrls = await this.recursivePass(currentBatch);
+
+            if (newUrls.length === 0) {
+                console.log(chalk.green(`[✓] Recursive crawl converged after ${iteration} pass(es)`));
+                break;
+            }
+
+            console.log(chalk.green(`[+] Pass ${iteration} discovered ${newUrls.length} new URL(s)`));
+
+            // Next pass only analyses the newly found URLs
+            currentBatch = newUrls;
+        }
+
+        if (iteration >= this.MAX_ITERATIONS) {
+            console.log(chalk.yellow(`[!] Reached max recursive crawl iterations (${this.MAX_ITERATIONS})`));
+        }
+
+        // Phase 3 – brute-force .map files on the final set
+        const allJsUrls = [...this.discoveredUrls].filter(
+            (u) => u.endsWith(".js") || u.endsWith(".js.map")
+        );
+        const jsFromBrute = await next_bruteForceJsFiles(allJsUrls);
+        this.techniqueEfficiencyMapping["next_bruteForceJsFiles"] = jsFromBrute;
+        this.registerUrls(jsFromBrute);
+
+        return [...this.discoveredUrls];
+    }
+}
+
+export default NextJsCrawler;

--- a/src/lazyLoad/next_js/next_GetJSScript.ts
+++ b/src/lazyLoad/next_js/next_GetJSScript.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { URL } from "url";
 import * as cheerio from "cheerio";
 import makeRequest from "../../utility/makeReq.js";
-import { getJsUrls, pushToJsUrls } from "../globals.js";
+import { getJsUrls } from "../globals.js";
 
 /**
  * Scrapes all lazy-loaded JavaScript file URLs from the provided Next.js page.
@@ -17,6 +17,7 @@ import { getJsUrls, pushToJsUrls } from "../globals.js";
  * pointing to JavaScript files found in the page.
  */
 const next_getJSScript = async (url: string): Promise<string[]> => {
+    const toReturn: string[] = [];
     // get the page source
     const res = await makeRequest(url, {});
     const pageSource = await res.text();
@@ -38,14 +39,14 @@ const next_getJSScript = async (url: string): Promise<string[]> => {
             if (src.startsWith("/")) {
                 const absoluteUrl = new URL(url).origin + src;
                 if (!getJsUrls().includes(absoluteUrl)) {
-                    pushToJsUrls(absoluteUrl);
+                    toReturn.push(absoluteUrl);
                 }
             } else if (src.startsWith("http")) {
                 const urlObj = new URL(src);
                 const ext = urlObj.pathname.split(".").pop();
                 if (ext === "js") {
                     if (!getJsUrls().includes(src)) {
-                        pushToJsUrls(src);
+                        toReturn.push(src);
                     }
                 }
             } else if (src.match(/^[^/]/)) {
@@ -56,11 +57,11 @@ const next_getJSScript = async (url: string): Promise<string[]> => {
                 const directory = new URL(url).origin + pathParts.join("/") + "/";
 
                 if (!getJsUrls().includes(directory + src)) {
-                    pushToJsUrls(directory + src);
+                    toReturn.push(directory + src);
                 }
             } else {
                 if (!getJsUrls().includes(src)) {
-                    pushToJsUrls(src);
+                    toReturn.push(src);
                 }
             }
         } else {
@@ -92,7 +93,7 @@ const next_getJSScript = async (url: string): Promise<string[]> => {
                     }
                     if (js_path_dir) {
                         // Ensure js_path_dir was found
-                        pushToJsUrls(js_path_dir + "/" + filename);
+                        toReturn.push(js_path_dir + "/" + filename);
                     }
                 }
             }
@@ -102,7 +103,7 @@ const next_getJSScript = async (url: string): Promise<string[]> => {
     // causes too much noise after using it with subsequent requests
     // console.log(chalk.green(`[✓] Found ${getJsUrls().length} JS files from the script tags`));
 
-    return getJsUrls();
+    return toReturn;
 };
 
 export default next_getJSScript;

--- a/src/lazyLoad/next_js/next_promiseResolve.ts
+++ b/src/lazyLoad/next_js/next_promiseResolve.ts
@@ -3,7 +3,67 @@ import makeRequest from "../../utility/makeReq.js";
 import parser from "@babel/parser";
 import _traverse from "@babel/traverse";
 import resolvePath from "../../utility/resolvePath.js";
+import { addCrawledUrl } from "../globals.js";
 const traverse = _traverse.default;
+
+const next_promiseResolveWorker = async (url: string, jsDirBase: string): Promise<string[]> => {
+    let toReturn: string[] = [];
+    // get the contents of the file
+    const req = await makeRequest(url);
+    if (!req || !req.ok) return toReturn;
+
+    const data = await req.text();
+
+    try {
+        const ast = parser.parse(data, {
+            sourceType: "unambiguous",
+            plugins: ["jsx", "typescript"],
+            errorRecovery: true,
+        });
+
+        let matches: string[] = [];
+        traverse(ast, {
+            CallExpression(path) {
+                const { node } = path;
+
+                // Check for Promise.all([...].map(...)) pattern
+                if (
+                    node.callee.type === "MemberExpression" &&
+                    node.callee.object.type === "Identifier" &&
+                    node.callee.object.name === "Promise" &&
+                    node.callee.property.type === "Identifier" &&
+                    node.callee.property.name === "all"
+                ) {
+                    const arg = node.arguments[0];
+                    if (
+                        arg &&
+                        arg.type === "CallExpression" &&
+                        arg.callee.type === "MemberExpression" &&
+                        arg.callee.property.type === "Identifier" &&
+                        arg.callee.property.name === "map" &&
+                        arg.callee.object.type === "ArrayExpression"
+                    ) {
+                        arg.callee.object.elements.forEach((element) => {
+                            if (element && element.type === "StringLiteral") {
+                                matches.push(element.value);
+                            }
+                        });
+                    }
+                }
+            },
+        });
+
+        // now that we got the match, we can use it to build the final URL
+        for (const match of matches) {
+            const jsFileName = match.replace("static/chunks/", "/");
+            const jsFileUrl = jsDirBase + jsFileName;
+
+            toReturn.push(jsFileUrl);
+        }
+    } catch (e) { }
+
+    return toReturn;
+};
 
 const next_promiseResolve = async (urls: string[]) => {
     console.log(chalk.cyan("[i] Check for Promise.all pattern"));
@@ -20,59 +80,10 @@ const next_promiseResolve = async (urls: string[]) => {
     }
 
     for (const url of urls) {
-        // get the contents of the file
-        const req = await makeRequest(url);
-        if (!req || !req.ok) continue;
-
-        const data = await req.text();
-
-        try {
-            const ast = parser.parse(data, {
-                sourceType: "unambiguous",
-                plugins: ["jsx", "typescript"],
-                errorRecovery: true,
-            });
-
-            let matches: string[] = [];
-            traverse(ast, {
-                CallExpression(path) {
-                    const { node } = path;
-
-                    // Check for Promise.all([...].map(...)) pattern
-                    if (
-                        node.callee.type === "MemberExpression" &&
-                        node.callee.object.type === "Identifier" &&
-                        node.callee.object.name === "Promise" &&
-                        node.callee.property.type === "Identifier" &&
-                        node.callee.property.name === "all"
-                    ) {
-                        const arg = node.arguments[0];
-                        if (
-                            arg &&
-                            arg.type === "CallExpression" &&
-                            arg.callee.type === "MemberExpression" &&
-                            arg.callee.property.type === "Identifier" &&
-                            arg.callee.property.name === "map" &&
-                            arg.callee.object.type === "ArrayExpression"
-                        ) {
-                            arg.callee.object.elements.forEach((element) => {
-                                if (element && element.type === "StringLiteral") {
-                                    matches.push(element.value);
-                                }
-                            });
-                        }
-                    }
-                },
-            });
-
-            // now that we got the match, we can use it to build the final URL
-            for (const match of matches) {
-                const jsFileName = match.replace("static/chunks/", "/");
-                const jsFileUrl = jsDirBase + jsFileName;
-
-                toReturn.push(jsFileUrl);
-            }
-        } catch (e) {}
+        const result = await next_promiseResolveWorker(url, jsDirBase!);
+        toReturn.push(...result);
+        // add the URL to the crawled URL
+        addCrawledUrl(url);
     }
 
     return toReturn;

--- a/src/lazyLoad/next_js/next_promiseResolve.ts
+++ b/src/lazyLoad/next_js/next_promiseResolve.ts
@@ -60,7 +60,7 @@ const next_promiseResolveWorker = async (url: string, jsDirBase: string): Promis
 
             toReturn.push(jsFileUrl);
         }
-    } catch (e) { }
+    } catch (e) {}
 
     return toReturn;
 };

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -86,7 +86,8 @@ const processUrl = async (
         false,
         cmd.sourcemapDir,
         cmd.research,
-        cmd.researchOutput
+        cmd.researchOutput,
+        Number(cmd.maxIterations)
     );
     console.log(chalk.bgGreen("[+] Lazyload complete."));
 
@@ -140,7 +141,8 @@ const processUrl = async (
         true,
         cmd.sourcemapDir,
         cmd.research,
-        cmd.researchOutput
+        cmd.researchOutput,
+        Number(cmd.maxIterations)
     );
     console.log(chalk.bgGreen("[+] Lazyload with subsequent requests complete."));
 


### PR DESCRIPTION
- Add `--max-iterations` CLI option to control recursive crawl depth (default: 10)
- Refactor Next.js crawling into `NextJsCrawler` class for better organization
- Add crawled URL tracking to prevent duplicate processing
- Modify `pushToJsUrls` to accept arrays and automatically deduplicate
- Add `addCrawledUrl` and `presentInCrawledUrls` helper functions
- Update `next_getJSScript` and `next_promiseResolve` to return arrays instead