### PR TITLE
v1.3.1-alpha.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ extracted_urls*
 .vscode/*
 output*/
 mapped.json
+mapped-openapi.postman_collection.json
 endpoints.json
 endpoints.txt
 test.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 1.3.1-alpha.2 - (unreleased)
+
+### Added
+
+- Added taint analysis in the `analyze` engine for Next.js
+
+### Changed
+
+### Fixed
+
+- Invalidate request cache if the memory is full
+
 ## 1.3.1-alpha.1 - 2026.05.13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,31 @@
 # Change Log
 
-## 1.3.1-alpha.2 - (unreleased)
+## 1.3.1-alpha.2 - 2026-05-18
 
 ### Added
 
 - Added taint analysis in the `analyze` engine for Next.js
 - Download JS files as soon as they are discovered (`lazyload`)
 - Recursively resolve HTTP requests in Next.js (`map`)
+- Stream JS file downloads during Vue.js discovery — downloads start as soon as each discovery step finds files instead of waiting for the full pipeline (`lazyload`)
+- Resolve `UnaryExpression` nodes (`!x`, `void 0`, `-x`, `typeof x`) so request bodies surface real boolean/null values instead of `[unsupported node type: UnaryExpression]` (`map`)
+- Resolve `ArrayExpression` nodes recursively so array body fields render their element shape instead of `[unsupported node type: ArrayExpression]` (`map`)
+- Resolve `JSON.stringify(variable)` calls by tracing the argument, replacing the opaque `[call:JSON.stringify()]` placeholder (`map`)
+- Resolve `new URLSearchParams({...})` to a real query string, using `{key}` placeholders for values that can't be statically resolved (`map`)
+- Partial-concatenation fallback for binary `+` expressions so resolvable fragments are preserved when one side is unresolved (`map`)
 
 ### Changed
+
+- Nested `JSON.stringify(expr)` inside a body object now resolves `expr` instead of emitting `[call to object...]` (`map`)
 
 ### Fixed
 
 - Invalidate request cache if the memory is full
+- Progress bars no longer hide the terminal cursor permanently when they exit without a clean `stop()` — all bars now use `hideCursor: false` (`lazyload`)
+- Removed the concurrent download progress bar in the Vue.js section that was causing display corruption — discovery `console.log` calls no longer collide with the bar's render line (`lazyload`)
+- API spec / Postman collection URLs no longer get `{{baseUrl}}` prepended to already-absolute URLs — full URLs are now reduced to their pathname (`map`)
+- Spread elements that can't be resolved are now skipped instead of being emitted as fake `"...spread": "[spread:e]"` body fields (`map`)
+- Request bodies that reduce to an empty `{}` after resolution are now omitted from the Postman collection (`map`)
 
 ## 1.3.1-alpha.1 - 2026.05.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Added taint analysis in the `analyze` engine for Next.js
+- Download JS files as soon as they are discovered (`lazyload`)
+- Recursively resolve HTTP requests in Next.js (`map`)
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "build": "rm -rf build/ && tsc",
         "start": "node build/index.js",
         "test": "node build/index.js -h",
-        "cleanup": "rm -rf build output .resp_cache.json endpoints.json extracted_urls{.txt,.json,-openapi.json} strings.json mapped{-openapi.json,.json} analyze.json test{.yaml,.js} shriyanss-js-recon-*.tgz js-recon.db report.{html,md} js_recon_run_output *_test.js extracted/ research.json && tsc"
+        "cleanup": "rm -rf build output .resp_cache.json endpoints.json extracted_urls{.txt,.json,-openapi.json} strings.json mapped{-openapi.json,.json,-openapi.postman_collection.json} analyze.json test{.yaml,.js} shriyanss-js-recon-*.tgz js-recon.db report.{html,md} js_recon_run_output *_test.js extracted/ research.json && tsc"
     },
     "keywords": [],
     "author": "Shriyans Sudhi",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shriyanss/js-recon",
-    "version": "1.3.1-alpha.1",
+    "version": "1.3.1-alpha.2",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/src/analyze/engine/astEngine.ts
+++ b/src/analyze/engine/astEngine.ts
@@ -31,11 +31,16 @@ const esqueryEngine = async (rule: Rule, mappedJsonData: Chunks): Promise<Engine
 
     for (const chunk of Object.values(mappedJsonData)) {
         // first of all, load the code in ast
-        const ast = parser.parse(chunk.code, {
-            sourceType: "unambiguous",
-            plugins: ["jsx", "typescript"],
-            errorRecovery: true,
-        });
+        let ast;
+        try {
+            ast = parser.parse(chunk.code, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+        } catch {
+            continue;
+        }
 
         let matchList: { [key: string]: { node: Node; scope: Node; allNodes?: Node[] } } = {};
         const completedSteps: Set<string> = new Set();

--- a/src/analyze/engine/astEngine.ts
+++ b/src/analyze/engine/astEngine.ts
@@ -12,6 +12,7 @@ import { highlight } from "cli-highlight";
 import { resolveFunctionIdentifier } from "../helpers/engineHelpers/resolveFunctionIdentifier.js";
 import { findMemberExpressionAssignment } from "../helpers/engineHelpers/findMemberExpressionAssignment.js";
 import { findDirectAssignment } from "../helpers/engineHelpers/findDirectAssignment.js";
+import { computeTaint, sinkConsumesTaint, TaintInfo } from "../helpers/engineHelpers/taintFlow.js";
 import { EngineOutput } from "../helpers/outputHelper.js";
 
 /**
@@ -38,6 +39,9 @@ const esqueryEngine = async (rule: Rule, mappedJsonData: Chunks): Promise<Engine
 
         let matchList: { [key: string]: { node: Node; scope: Node; allNodes?: Node[] } } = {};
         const completedSteps: Set<string> = new Set();
+        // Cache taint info per "source step name" so we don't recompute when several
+        // sink steps share the same source step.
+        const taintCache: { [sourceStep: string]: TaintInfo } = {};
 
         // iterate through the steps in the rule
         for (const step of rule.steps) {
@@ -67,7 +71,26 @@ const esqueryEngine = async (rule: Rule, mappedJsonData: Chunks): Promise<Engine
                 }
 
                 // match the query against what is there in the user defined config file
-                const matches: Node[] = esquery(searchRoot, selector);
+                let matches: Node[] = esquery(searchRoot, selector);
+
+                // Optional data-flow filter: only keep matches whose value-side actually
+                // consumes a value tainted by the named source step's matches. This is
+                // what distinguishes a real source→sink finding from accidental
+                // source-and-sink-in-the-same-bundle co-occurrence.
+                if (matches.length > 0 && step.esquery.taintFrom) {
+                    const sourceStepName = step.esquery.taintFrom;
+                    const sourceMatch = matchList[sourceStepName];
+                    if (!sourceMatch) {
+                        // No source matched — nothing can be tainted from it.
+                        continue;
+                    }
+                    if (!taintCache[sourceStepName]) {
+                        const sourceNodes = sourceMatch.allNodes || [sourceMatch.node];
+                        taintCache[sourceStepName] = computeTaint(ast, sourceNodes);
+                    }
+                    const taint = taintCache[sourceStepName];
+                    matches = matches.filter((m) => sinkConsumesTaint(ast, m, taint));
+                }
 
                 if (matches.length > 0) {
                     // store the first match as the "primary" node so later steps can reference it,

--- a/src/analyze/helpers/engineHelpers/taintFlow.ts
+++ b/src/analyze/helpers/engineHelpers/taintFlow.ts
@@ -56,9 +56,9 @@ const expressionIsTainted = (path: NodePath, taint: TaintInfo): boolean => {
                 parent &&
                 ((parent.type === "MemberExpression" && parent.property === p.node && !parent.computed) ||
                     (parent.type === "ObjectProperty" && parent.key === p.node && !parent.computed) ||
-                    parent.type === "VariableDeclarator" && (parent as any).id === p.node ||
-                    parent.type === "FunctionDeclaration" && (parent as any).id === p.node ||
-                    parent.type === "ClassDeclaration" && (parent as any).id === p.node)
+                    (parent.type === "VariableDeclarator" && (parent as any).id === p.node) ||
+                    (parent.type === "FunctionDeclaration" && (parent as any).id === p.node) ||
+                    (parent.type === "ClassDeclaration" && (parent as any).id === p.node))
             ) {
                 return;
             }

--- a/src/analyze/helpers/engineHelpers/taintFlow.ts
+++ b/src/analyze/helpers/engineHelpers/taintFlow.ts
@@ -169,10 +169,15 @@ const getSinkValueNodes = (sink: Node): Node[] => {
             const args = (sink as any).arguments as Node[];
             return args.filter((a) => a && a.type !== "SpreadElement");
         }
-        case "ObjectProperty":
-            return [(sink as any).value as Node];
-        case "JSXAttribute":
-            return [(sink as any).value as Node];
+        case "ObjectProperty": {
+            const v = (sink as any).value as Node | null | undefined;
+            return v ? [v] : [];
+        }
+        case "JSXAttribute": {
+            // Boolean JSX attributes (e.g. `<div hidden />`) have no value node.
+            const v = (sink as any).value as Node | null | undefined;
+            return v ? [v] : [];
+        }
         default:
             return [sink];
     }

--- a/src/analyze/helpers/engineHelpers/taintFlow.ts
+++ b/src/analyze/helpers/engineHelpers/taintFlow.ts
@@ -1,0 +1,211 @@
+import { Node } from "@babel/types";
+import _traverse, { NodePath, Binding } from "@babel/traverse";
+const traverse = _traverse.default;
+
+export type TaintInfo = {
+    bindings: Set<NodePath>;
+    memberChains: Set<string>;
+    sourceNodes: Set<Node>;
+};
+
+const memberChainString = (node: Node): string | null => {
+    if (node.type === "Identifier") return node.name;
+    if (node.type === "ThisExpression") return "this";
+    if (node.type === "MemberExpression") {
+        if (node.computed) return null;
+        if (node.property.type !== "Identifier") return null;
+        const obj = memberChainString(node.object);
+        if (!obj) return null;
+        return `${obj}.${node.property.name}`;
+    }
+    return null;
+};
+
+const collectIdsFromPattern = (node: Node): string[] => {
+    if (!node) return [];
+    if (node.type === "Identifier") return [node.name];
+    if (node.type === "ObjectPattern") {
+        return node.properties.flatMap((p) => {
+            if (p.type === "ObjectProperty") return collectIdsFromPattern(p.value as Node);
+            if (p.type === "RestElement") return collectIdsFromPattern(p.argument as Node);
+            return [];
+        });
+    }
+    if (node.type === "ArrayPattern") {
+        return node.elements.flatMap((e) => (e ? collectIdsFromPattern(e as Node) : []));
+    }
+    if (node.type === "AssignmentPattern") return collectIdsFromPattern(node.left as Node);
+    if (node.type === "RestElement") return collectIdsFromPattern(node.argument as Node);
+    return [];
+};
+
+const expressionIsTainted = (path: NodePath, taint: TaintInfo): boolean => {
+    if (taint.sourceNodes.has(path.node)) return true;
+    let tainted = false;
+    const visit = (p: NodePath) => {
+        if (tainted) return;
+        if (taint.sourceNodes.has(p.node)) {
+            tainted = true;
+            p.stop();
+            return;
+        }
+        if (p.node.type === "Identifier") {
+            // skip identifiers that are property keys / declarations themselves
+            const parent = p.parent;
+            if (
+                parent &&
+                ((parent.type === "MemberExpression" && parent.property === p.node && !parent.computed) ||
+                    (parent.type === "ObjectProperty" && parent.key === p.node && !parent.computed) ||
+                    parent.type === "VariableDeclarator" && (parent as any).id === p.node ||
+                    parent.type === "FunctionDeclaration" && (parent as any).id === p.node ||
+                    parent.type === "ClassDeclaration" && (parent as any).id === p.node)
+            ) {
+                return;
+            }
+            const binding = p.scope.getBinding(p.node.name);
+            if (binding && taint.bindings.has(binding.path)) {
+                tainted = true;
+                p.stop();
+                return;
+            }
+        }
+        if (p.node.type === "MemberExpression") {
+            const chain = memberChainString(p.node);
+            if (chain && taint.memberChains.has(chain)) {
+                tainted = true;
+                p.stop();
+                return;
+            }
+        }
+    };
+    visit(path);
+    if (!tainted) {
+        path.traverse({
+            enter(p) {
+                visit(p);
+            },
+        });
+    }
+    return tainted;
+};
+
+/**
+ * Compute the taint info for a chunk AST given the source nodes (URL-derived reads).
+ *
+ * Performs scope-aware iterative propagation:
+ *   - Variable declarators / assignment expressions whose right-hand side
+ *     contains a tainted source node or references a tainted binding/member
+ *     chain are themselves tainted.
+ *   - Tainted bindings are tracked by their declaration NodePath; tainted
+ *     member chains (e.g. `R.current`) are tracked as strings.
+ */
+export const computeTaint = (ast: Node, sourceNodes: Node[]): TaintInfo => {
+    const taint: TaintInfo = {
+        bindings: new Set<NodePath>(),
+        memberChains: new Set<string>(),
+        sourceNodes: new Set<Node>(sourceNodes),
+    };
+
+    // Bound iteration count to avoid pathological cases
+    const maxRounds = 8;
+    for (let round = 0; round < maxRounds; round++) {
+        let changed = false;
+
+        traverse(ast, {
+            VariableDeclarator(path) {
+                if (!path.node.init) return;
+                const initPath = path.get("init") as NodePath;
+                if (!expressionIsTainted(initPath, taint)) return;
+                const names = collectIdsFromPattern(path.node.id as Node);
+                for (const name of names) {
+                    const binding = path.scope.getBinding(name);
+                    if (binding && !taint.bindings.has(binding.path)) {
+                        taint.bindings.add(binding.path);
+                        changed = true;
+                    }
+                }
+            },
+            AssignmentExpression(path) {
+                const rightPath = path.get("right") as NodePath;
+                if (!expressionIsTainted(rightPath, taint)) return;
+                const left = path.node.left as Node;
+                if (left.type === "Identifier") {
+                    const binding = path.scope.getBinding(left.name);
+                    if (binding && !taint.bindings.has(binding.path)) {
+                        taint.bindings.add(binding.path);
+                        changed = true;
+                    }
+                } else if (left.type === "MemberExpression") {
+                    const chain = memberChainString(left);
+                    if (chain && !taint.memberChains.has(chain)) {
+                        taint.memberChains.add(chain);
+                        changed = true;
+                    }
+                } else if (left.type === "ObjectPattern" || left.type === "ArrayPattern") {
+                    const names = collectIdsFromPattern(left);
+                    for (const name of names) {
+                        const binding = path.scope.getBinding(name);
+                        if (binding && !taint.bindings.has(binding.path)) {
+                            taint.bindings.add(binding.path);
+                            changed = true;
+                        }
+                    }
+                }
+            },
+        });
+
+        if (!changed) break;
+    }
+
+    return taint;
+};
+
+const getSinkValueNodes = (sink: Node): Node[] => {
+    switch (sink.type) {
+        case "AssignmentExpression":
+            return [sink.right as Node];
+        case "CallExpression":
+        case "NewExpression": {
+            const args = (sink as any).arguments as Node[];
+            return args.filter((a) => a && a.type !== "SpreadElement");
+        }
+        case "ObjectProperty":
+            return [(sink as any).value as Node];
+        case "JSXAttribute":
+            return [(sink as any).value as Node];
+        default:
+            return [sink];
+    }
+};
+
+/**
+ * Returns true when `sinkNode` consumes a value tainted by the URL source(s) used
+ * to compute `taint`. Walks the sink's value-side subtree (RHS for assignments,
+ * arguments for calls/new, value for object/JSX properties) and looks for:
+ *   - direct references to a tainted source subtree,
+ *   - identifiers whose binding is in `taint.bindings`,
+ *   - member-expression chains in `taint.memberChains`.
+ *
+ * To resolve scope-aware bindings, we re-traverse the AST and pick up paths
+ * whose nodes match one of the value-side subtrees.
+ */
+export const sinkConsumesTaint = (ast: Node, sinkNode: Node, taint: TaintInfo): boolean => {
+    const valueRoots = new Set<Node>(getSinkValueNodes(sinkNode));
+    if (valueRoots.size === 0) return false;
+
+    let consumed = false;
+    traverse(ast, {
+        enter(path) {
+            if (consumed) {
+                path.stop();
+                return;
+            }
+            if (!valueRoots.has(path.node)) return;
+            if (expressionIsTainted(path, taint)) {
+                consumed = true;
+                path.stop();
+            }
+        },
+    });
+    return consumed;
+};

--- a/src/analyze/helpers/schemas.ts
+++ b/src/analyze/helpers/schemas.ts
@@ -22,6 +22,7 @@ const esqueryStepSchema = z.object({
     type: z.literal("esquery"),
     query: z.string(),
     inScopeOf: z.string().optional(),
+    taintFrom: z.string().optional(),
 });
 
 const PostMessageFuncResolverStepSchema = z.object({

--- a/src/analyze/types/index.ts
+++ b/src/analyze/types/index.ts
@@ -42,6 +42,11 @@ export type EsqueryStep = {
     // optional: scope the esquery to the subtree rooted at a previously matched step's node.
     // when set, esquery runs against `matchList[<name>].node` instead of the whole chunk AST.
     inScopeOf?: string;
+    // optional: require the matched node to actually consume a value tainted from the
+    // matches of the named source step (data-flow check). When set, esquery matches
+    // are filtered to only those whose value-side subtree references a tainted
+    // binding/member-chain or directly contains a source subtree.
+    taintFrom?: string;
 };
 
 export type PostMessageFuncResolverStep = {

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,6 @@
 const githubURL = "https://github.com/shriyanss/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
-const version = "1.3.1-alpha.1";
+const version = "1.3.1-alpha.2";
 const toolDesc = "JS Recon Tool";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests
 

--- a/src/lazyLoad/downloadQueue.ts
+++ b/src/lazyLoad/downloadQueue.ts
@@ -6,6 +6,11 @@ import makeRequest from "../utility/makeReq.js";
 import { getURLDirectory } from "../utility/urlUtils.js";
 import { getScope } from "./globals.js";
 
+export interface DownloadQueueOptions {
+    /** Called after each URL is processed (downloaded, ignored, or failed). */
+    onProgress?: (processed: number, total: number, downloaded: number) => void;
+}
+
 const PRETTIER_SIZE_LIMIT = 500 * 1024;
 
 /**
@@ -36,13 +41,21 @@ export class DownloadQueue {
 
     /** Stats */
     private downloadCount = 0;
+    private processedCount = 0;
     private ignoredFiles: string[] = [];
     private ignoredDomains: string[] = [];
 
-    constructor(output: string, concurrency: number) {
+    private readonly onProgress?: DownloadQueueOptions["onProgress"];
+
+    constructor(output: string, concurrency: number, options: DownloadQueueOptions = {}) {
         this.output = output;
         this.concurrency = Math.max(1, concurrency);
+        this.onProgress = options.onProgress;
         fs.mkdirSync(output, { recursive: true });
+    }
+
+    get totalEnqueued(): number {
+        return this.seen.size;
     }
 
     /**
@@ -182,6 +195,9 @@ export class DownloadQueue {
             this.downloadCount++;
         } catch (err) {
             console.error(chalk.red(`[!] Failed to download: ${url} : ${err}`));
+        } finally {
+            this.processedCount++;
+            this.onProgress?.(this.processedCount, this.seen.size, this.downloadCount);
         }
     }
 }

--- a/src/lazyLoad/downloadQueue.ts
+++ b/src/lazyLoad/downloadQueue.ts
@@ -155,7 +155,10 @@ export class DownloadQueue {
             }
 
             const rawText = await res.text();
-            const file = url.match(/\.json/) ? rawText : `// File Source: ${url}\n${rawText}`;
+            // .js.map payloads are JSON — adding a `//` banner would break strict
+            // JSON parsing later in the same function (parser: "json").
+            const file =
+                url.match(/\.json/) || url.match(/\.js\.map/) ? rawText : `// File Source: ${url}\n${rawText}`;
 
             let filename: string | undefined;
             try {

--- a/src/lazyLoad/downloadQueue.ts
+++ b/src/lazyLoad/downloadQueue.ts
@@ -157,8 +157,7 @@ export class DownloadQueue {
             const rawText = await res.text();
             // .js.map payloads are JSON — adding a `//` banner would break strict
             // JSON parsing later in the same function (parser: "json").
-            const file =
-                url.match(/\.json/) || url.match(/\.js\.map/) ? rawText : `// File Source: ${url}\n${rawText}`;
+            const file = url.match(/\.json/) || url.match(/\.js\.map/) ? rawText : `// File Source: ${url}\n${rawText}`;
 
             let filename: string | undefined;
             try {

--- a/src/lazyLoad/downloadQueue.ts
+++ b/src/lazyLoad/downloadQueue.ts
@@ -1,0 +1,187 @@
+import chalk from "chalk";
+import path from "path";
+import fs from "fs";
+import prettier from "prettier";
+import makeRequest from "../utility/makeReq.js";
+import { getURLDirectory } from "../utility/urlUtils.js";
+import { getScope } from "./globals.js";
+
+const PRETTIER_SIZE_LIMIT = 500 * 1024;
+
+/**
+ * A concurrent download queue that starts downloading JS files as soon as URLs
+ * are pushed, without waiting for discovery to finish.
+ *
+ * Usage:
+ *   const q = new DownloadQueue(output, concurrency);
+ *   q.push(someUrls);          // starts downloading immediately
+ *   q.push(moreUrls);          // safe to call any time
+ *   await q.drain();           // wait for all downloads to complete
+ */
+export class DownloadQueue {
+    private readonly output: string;
+    private readonly concurrency: number;
+
+    /** Tracks every URL ever enqueued to avoid duplicate downloads. */
+    private readonly seen = new Set<string>();
+
+    /** Pending URLs waiting for a free worker slot. */
+    private readonly pending: string[] = [];
+
+    /** Number of worker coroutines currently executing a download. */
+    private activeWorkers = 0;
+
+    /** Callbacks waiting for the queue to empty. */
+    private drainCallbacks: (() => void)[] = [];
+
+    /** Stats */
+    private downloadCount = 0;
+    private ignoredFiles: string[] = [];
+    private ignoredDomains: string[] = [];
+
+    constructor(output: string, concurrency: number) {
+        this.output = output;
+        this.concurrency = Math.max(1, concurrency);
+        fs.mkdirSync(output, { recursive: true });
+    }
+
+    /**
+     * Enqueue URLs for download. Already-seen URLs are silently skipped.
+     * New workers are spawned immediately up to the configured concurrency.
+     */
+    push(urls: string[]): void {
+        const fresh: string[] = [];
+        for (const u of urls) {
+            if (!this.seen.has(u)) {
+                this.seen.add(u);
+                fresh.push(u);
+            }
+        }
+        if (fresh.length === 0) return;
+
+        this.pending.push(...fresh);
+        this.spawnWorkers();
+    }
+
+    /** Returns a Promise that resolves once all pending downloads are complete. */
+    drain(): Promise<void> {
+        if (this.activeWorkers === 0 && this.pending.length === 0) {
+            return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+            this.drainCallbacks.push(resolve);
+        });
+    }
+
+    /** Print a summary of ignored files. */
+    printSummary(): void {
+        if (this.ignoredFiles.length > 0) {
+            console.log(
+                chalk.yellow(
+                    `[i] Ignored ${this.ignoredFiles.length} JS files across ${this.ignoredDomains.length} domain(s) - ${this.ignoredDomains.join(", ")}`
+                )
+            );
+        }
+        if (this.downloadCount > 0) {
+            console.log(chalk.green(`[✓] Downloaded ${this.downloadCount} JS chunks to ${this.output} directory`));
+        }
+    }
+
+    // ── internals ────────────────────────────────────────────────────────
+
+    private spawnWorkers(): void {
+        while (this.activeWorkers < this.concurrency && this.pending.length > 0) {
+            this.activeWorkers++;
+            this.runWorker();
+        }
+    }
+
+    private async runWorker(): Promise<void> {
+        while (this.pending.length > 0) {
+            const url = this.pending.shift()!;
+            await this.processOne(url);
+        }
+        this.activeWorkers--;
+        if (this.activeWorkers === 0 && this.pending.length === 0) {
+            const callbacks = this.drainCallbacks.splice(0);
+            for (const cb of callbacks) cb();
+        }
+    }
+
+    private async processOne(url: string): Promise<void> {
+        try {
+            if (!url.match(/(\.js|\.json|\.js\.map)/)) {
+                console.log(chalk.yellow(`[i] Ignored ${url}`));
+                return;
+            }
+
+            const { host, directory } = getURLDirectory(url);
+
+            if (!getScope().includes("*") && !getScope().includes(host)) {
+                this.ignoredFiles.push(url);
+                if (!this.ignoredDomains.includes(host)) {
+                    this.ignoredDomains.push(host);
+                }
+                return;
+            }
+
+            const childDir = path.join(this.output, host, directory);
+            fs.mkdirSync(childDir, { recursive: true });
+
+            let res;
+            try {
+                res = await makeRequest(url, {});
+            } catch {
+                console.error(chalk.red(`[!] Failed to download: ${url}`));
+                return;
+            }
+
+            if (!res) {
+                console.error(chalk.red(`[!] Failed to download: ${url}`));
+                return;
+            }
+
+            const rawText = await res.text();
+            const file = url.match(/\.json/) ? rawText : `// File Source: ${url}\n${rawText}`;
+
+            let filename: string | undefined;
+            try {
+                filename = url
+                    .split("/")
+                    .pop()
+                    ?.match(/[a-zA-Z0-9\.\-_]+\.js(on)?(\.map)?/)?.[0];
+            } catch {
+                for (const chunk of url.split("/")) {
+                    if (chunk.match(/\.js(on)?$/)) {
+                        filename = chunk;
+                        break;
+                    }
+                }
+            }
+
+            if (!filename) {
+                console.warn(chalk.yellow(`[!] Could not determine filename for URL: ${url}. Skipping.`));
+                return;
+            }
+
+            const filePath = path.join(childDir, filename);
+            try {
+                if (url.match(/\.json/) || url.match(/\.js\.map/)) {
+                    const formatted =
+                        file.length <= PRETTIER_SIZE_LIMIT ? await prettier.format(file, { parser: "json" }) : file;
+                    fs.writeFileSync(filePath, formatted);
+                } else {
+                    const formatted =
+                        file.length <= PRETTIER_SIZE_LIMIT ? await prettier.format(file, { parser: "babel" }) : file;
+                    fs.writeFileSync(filePath, formatted);
+                }
+            } catch {
+                console.error(chalk.red(`[!] Failed to write file: ${filePath}`));
+                return;
+            }
+            this.downloadCount++;
+        } catch (err) {
+            console.error(chalk.red(`[!] Failed to download: ${url} : ${err}`));
+        }
+    }
+}

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -331,15 +331,15 @@ const lazyLoad = async (
                 await downloadFiles(jsFilesToDownload, output);
 
                 extractSourceMaps(output, sourcemapDir);
-            } else {
-                console.log(chalk.red("[!] Framework not detected :("));
-                console.log(chalk.magenta(CONFIG.notFoundMessage));
-                console.log(chalk.yellow("[i] Trying to download loaded JS files"));
-                const js_urls = await downloadLoadedJs(url);
-                if (js_urls && js_urls.length > 0) {
-                    console.log(chalk.green(`[✓] Found ${js_urls.length} JS chunks`));
-                    await downloadFiles(js_urls, output);
-                }
+            }
+        } else {
+            console.log(chalk.red("[!] Framework not detected :("));
+            console.log(chalk.magenta(CONFIG.notFoundMessage));
+            console.log(chalk.yellow("[i] Trying to download loaded JS files"));
+            const js_urls = await downloadLoadedJs(url);
+            if (js_urls && js_urls.length > 0) {
+                console.log(chalk.green(`[✓] Found ${js_urls.length} JS chunks`));
+                await downloadFiles(js_urls, output);
             }
         }
     }

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -1,5 +1,4 @@
 import chalk from "chalk";
-import cliProgress from "cli-progress";
 import fs from "fs";
 import frameworkDetect from "./techDetect/index.js";
 import CONFIG from "../globalConfig.js";
@@ -218,47 +217,21 @@ const lazyLoad = async (
                 console.log(chalk.green("[✓] Vue.js detected"));
                 console.log(chalk.yellow(`Evidence: ${tech.evidence}`));
 
-                const downloadBar = new cliProgress.SingleBar(
-                    {
-                        format:
-                            chalk.cyan("[i] Downloading JS files ") +
-                            "[{bar}] {percentage}% | {value}/{total} | {downloaded} downloaded",
-                        barCompleteChar: "█",
-                        barIncompleteChar: "░",
-                        hideCursor: true,
-                        clearOnComplete: false,
-                        stopOnComplete: false,
-                    },
-                    cliProgress.Presets.shades_classic
-                );
-                let downloadBarStarted = false;
-
-                const queue = new DownloadQueue(output, threads, {
-                    onProgress: (processed, total, downloaded) => {
-                        if (!downloadBarStarted) {
-                            downloadBar.start(total, processed, { downloaded });
-                            downloadBarStarted = true;
-                        } else {
-                            downloadBar.setTotal(total);
-                            downloadBar.update(processed, { downloaded });
-                        }
-                    },
-                });
+                const queue = new DownloadQueue(output, threads);
+                const onFilesDiscovered = (files: string[]) => queue.push(files);
 
                 // run the full discovery pipeline against the entry URL
-                const { jsFiles, clientSidePaths } = await vue_discoverJsFiles(url, maxJsSizeMb);
-                queue.push(jsFiles);
+                const { clientSidePaths } = await vue_discoverJsFiles(url, maxJsSizeMb, onFilesDiscovered);
 
                 // recurse the same pipeline through every client-side path we found
-                const recursivelyDiscovered = await vue_recursiveClientSidePathDownload(
+                await vue_recursiveClientSidePathDownload(
                     clientSidePaths,
                     threads,
-                    maxJsSizeMb
+                    maxJsSizeMb,
+                    onFilesDiscovered
                 );
-                queue.push(recursivelyDiscovered);
 
                 await queue.drain();
-                if (downloadBarStarted) downloadBar.stop();
                 queue.printSummary();
 
                 // extract the source maps

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import cliProgress from "cli-progress";
 import fs from "fs";
 import frameworkDetect from "./techDetect/index.js";
 import CONFIG from "../globalConfig.js";
@@ -217,7 +218,32 @@ const lazyLoad = async (
                 console.log(chalk.green("[✓] Vue.js detected"));
                 console.log(chalk.yellow(`Evidence: ${tech.evidence}`));
 
-                const queue = new DownloadQueue(output, threads);
+                const downloadBar = new cliProgress.SingleBar(
+                    {
+                        format:
+                            chalk.cyan("[i] Downloading JS files ") +
+                            "[{bar}] {percentage}% | {value}/{total} | {downloaded} downloaded",
+                        barCompleteChar: "█",
+                        barIncompleteChar: "░",
+                        hideCursor: true,
+                        clearOnComplete: false,
+                        stopOnComplete: false,
+                    },
+                    cliProgress.Presets.shades_classic
+                );
+                let downloadBarStarted = false;
+
+                const queue = new DownloadQueue(output, threads, {
+                    onProgress: (processed, total, downloaded) => {
+                        if (!downloadBarStarted) {
+                            downloadBar.start(total, processed, { downloaded });
+                            downloadBarStarted = true;
+                        } else {
+                            downloadBar.setTotal(total);
+                            downloadBar.update(processed, { downloaded });
+                        }
+                    },
+                });
 
                 // run the full discovery pipeline against the entry URL
                 const { jsFiles, clientSidePaths } = await vue_discoverJsFiles(url, maxJsSizeMb);
@@ -232,6 +258,7 @@ const lazyLoad = async (
                 queue.push(recursivelyDiscovered);
 
                 await queue.drain();
+                if (downloadBarStarted) downloadBar.stop();
                 queue.printSummary();
 
                 // extract the source maps

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -36,6 +36,7 @@ import react_sourcemapUrls from "./react/react_sourcemapUrls.js";
 // generic
 import downloadFiles from "./downloadFilesUtil.js";
 import downloadLoadedJs from "./downloadLoadedJsUtil.js";
+import { DownloadQueue } from "./downloadQueue.js";
 
 // for rebuilding source maps
 import { readdirSync, readFileSync, writeFileSync, mkdirSync } from "fs";
@@ -170,6 +171,8 @@ const lazyLoad = async (
                 console.log(chalk.green("[✓] Next.js detected"));
                 console.log(chalk.yellow(`Evidence: ${tech.evidence}`));
 
+                const queue = new DownloadQueue(output, threads);
+
                 const crawler = new NextJsCrawler({
                     url,
                     output,
@@ -178,13 +181,12 @@ const lazyLoad = async (
                     threads,
                     research,
                     maxIterations,
+                    onUrlsDiscovered: (urls) => queue.push(urls),
                 });
 
-                const jsFilesToDownload = await crawler.crawl();
-
-                // dedupe the files
-                const dedupedFiles = [...new Set(jsFilesToDownload)];
-                await downloadFiles(dedupedFiles, output);
+                await crawler.crawl();
+                await queue.drain();
+                queue.printSummary();
 
                 if (buildId) {
                     // get the buildId
@@ -215,8 +217,11 @@ const lazyLoad = async (
                 console.log(chalk.green("[✓] Vue.js detected"));
                 console.log(chalk.yellow(`Evidence: ${tech.evidence}`));
 
+                const queue = new DownloadQueue(output, threads);
+
                 // run the full discovery pipeline against the entry URL
                 const { jsFiles, clientSidePaths } = await vue_discoverJsFiles(url, maxJsSizeMb);
+                queue.push(jsFiles);
 
                 // recurse the same pipeline through every client-side path we found
                 const recursivelyDiscovered = await vue_recursiveClientSidePathDownload(
@@ -224,11 +229,10 @@ const lazyLoad = async (
                     threads,
                     maxJsSizeMb
                 );
+                queue.push(recursivelyDiscovered);
 
-                const jsFilesToDownload = [...new Set([...jsFiles, ...recursivelyDiscovered])];
-
-                // finally, download these
-                await downloadFiles(jsFilesToDownload, output);
+                await queue.drain();
+                queue.printSummary();
 
                 // extract the source maps
                 await extractSourceMaps(output, sourcemapDir);
@@ -236,62 +240,56 @@ const lazyLoad = async (
                 console.log(chalk.green("[✓] Nuxt.js detected"));
                 console.log(chalk.yellow(`Evidence: ${tech.evidence}`));
 
-                let jsFilesToDownload: string[] = [];
+                const queue = new DownloadQueue(output, threads);
 
                 // find the files from the page source
                 const jsFilesFromPageSource = await nuxt_getFromPageSource(url);
-                const jsFilesFromStringAnalysis = await nuxt_stringAnalysisJSFiles(url);
+                queue.push(jsFilesFromPageSource);
 
-                jsFilesToDownload.push(...jsFilesFromPageSource);
-                jsFilesToDownload.push(...jsFilesFromStringAnalysis);
-                // dedupe the files
-                jsFilesToDownload = [...new Set(jsFilesToDownload)];
+                const jsFilesFromStringAnalysis = await nuxt_stringAnalysisJSFiles(url);
+                queue.push(jsFilesFromStringAnalysis);
+
+                const firstBatch = [...new Set([...jsFilesFromPageSource, ...jsFilesFromStringAnalysis])];
 
                 let jsFilesFromAST = [];
                 console.log(chalk.cyan("[i] Analyzing functions in the files found"));
-                for (const jsFile of jsFilesToDownload) {
+                for (const jsFile of firstBatch) {
                     jsFilesFromAST.push(...(await nuxt_astParse(jsFile)));
                 }
+                queue.push(jsFilesFromAST);
+                queue.push(lazyLoadGlobals.getJsUrls());
 
-                jsFilesToDownload.push(...jsFilesFromAST);
-
-                jsFilesToDownload.push(...lazyLoadGlobals.getJsUrls());
-
-                // dedupe the files
-                jsFilesToDownload = [...new Set(jsFilesToDownload)];
-
-                await downloadFiles(jsFilesToDownload, output);
+                await queue.drain();
+                queue.printSummary();
             } else if (tech.name === "svelte") {
                 console.log(chalk.green("[✓] Svelte detected"));
                 console.log(chalk.yellow(`Evidence: ${tech.evidence}`));
 
-                let jsFilesToDownload = [];
+                const queue = new DownloadQueue(output, threads);
 
                 // find the files from the page source
                 const jsFilesFromPageSource = await svelte_getFromPageSource(url);
-                jsFilesToDownload.push(...jsFilesFromPageSource);
+                queue.push(jsFilesFromPageSource);
 
                 // analyze the strings now
                 const jsFilesFromStringAnalysis = await svelte_stringAnalysisJSFiles(url);
-                jsFilesToDownload.push(...jsFilesFromStringAnalysis);
+                queue.push(jsFilesFromStringAnalysis);
 
-                // dedupe the files
-                jsFilesToDownload = [...new Set(jsFilesToDownload)];
-
-                await downloadFiles(jsFilesToDownload, output);
+                await queue.drain();
+                queue.printSummary();
             } else if (tech.name === "angular") {
                 console.log(chalk.green("[✓] Angular detected"));
                 console.log(chalk.yellow(`Evidence: ${tech.evidence}`));
 
-                let jsFilesToDownload = [];
+                const queue = new DownloadQueue(output, threads);
 
                 // find the files from the page source
                 const jsFilesFromPageSource = await angular_getFromPageSource(url);
-                jsFilesToDownload.push(...jsFilesFromPageSource);
+                queue.push(jsFilesFromPageSource);
 
                 // files using the main.js
                 let mainJsUrl: string | undefined;
-                for (const jsFile of jsFilesToDownload) {
+                for (const jsFile of jsFilesFromPageSource) {
                     if (jsFile.match(/main[a-zA-Z0-9\-]*\.js/)) {
                         mainJsUrl = jsFile;
                         break;
@@ -300,35 +298,32 @@ const lazyLoad = async (
 
                 if (mainJsUrl) {
                     const jsFilesFromMainJs = await angular_getFromMainJs(mainJsUrl);
-                    jsFilesToDownload.push(...jsFilesFromMainJs);
+                    queue.push(jsFilesFromMainJs);
                 }
 
-                // dedupe the files
-                jsFilesToDownload = [...new Set(jsFilesToDownload)];
-
-                await downloadFiles(jsFilesToDownload, output);
+                await queue.drain();
+                queue.printSummary();
             } else if (tech.name === "react") {
                 console.log(chalk.green("[✓] React detected"));
                 console.log(chalk.yellow(`Evidence: ${tech.evidence}`));
 
-                let jsFilesToDownload = [];
+                const queue = new DownloadQueue(output, threads);
 
                 // get the files from the page source
                 const jsFilesFromPageSource = await react_getScriptTags(url, maxJsSizeMb);
-                jsFilesToDownload.push(...jsFilesFromPageSource);
+                queue.push(jsFilesFromPageSource);
 
                 // find the webpack chunk path builder function
-                const getWebpackChunkPaths = await react_webpackChunkPaths(url, maxJsSizeMb, jsFilesToDownload);
-                jsFilesToDownload.push(...getWebpackChunkPaths);
+                const getWebpackChunkPaths = await react_webpackChunkPaths(url, maxJsSizeMb, jsFilesFromPageSource);
+                queue.push(getWebpackChunkPaths);
 
                 // check existing JS files for inline sourcemap references
-                const sourcemapUrls = await react_sourcemapUrls(jsFilesToDownload);
-                jsFilesToDownload.push(...sourcemapUrls);
+                const allDiscovered = [...new Set([...jsFilesFromPageSource, ...getWebpackChunkPaths])];
+                const sourcemapUrls = await react_sourcemapUrls(allDiscovered);
+                queue.push(sourcemapUrls);
 
-                // dedupe the files
-                jsFilesToDownload = [...new Set(jsFilesToDownload)];
-
-                await downloadFiles(jsFilesToDownload, output);
+                await queue.drain();
+                queue.printSummary();
 
                 extractSourceMaps(output, sourcemapDir);
             }
@@ -339,7 +334,10 @@ const lazyLoad = async (
             const js_urls = await downloadLoadedJs(url);
             if (js_urls && js_urls.length > 0) {
                 console.log(chalk.green(`[✓] Found ${js_urls.length} JS chunks`));
-                await downloadFiles(js_urls, output);
+                const queue = new DownloadQueue(output, threads);
+                queue.push(js_urls);
+                await queue.drain();
+                queue.printSummary();
             }
         }
     }

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -224,12 +224,7 @@ const lazyLoad = async (
                 const { clientSidePaths } = await vue_discoverJsFiles(url, maxJsSizeMb, onFilesDiscovered);
 
                 // recurse the same pipeline through every client-side path we found
-                await vue_recursiveClientSidePathDownload(
-                    clientSidePaths,
-                    threads,
-                    maxJsSizeMb,
-                    onFilesDiscovered
-                );
+                await vue_recursiveClientSidePathDownload(clientSidePaths, threads, maxJsSizeMb, onFilesDiscovered);
 
                 await queue.drain();
                 queue.printSummary();

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -75,8 +75,10 @@ const extractSourceMaps = async (assetsDir: string, outputDir: string) => {
     let counter = 0;
 
     for (const mapFile of mapFiles) {
-        // read the file while skipping the first line
-        const mapContent = readFileSync(mapFile, "utf-8").split("\n").slice(1).join("\n");
+        const raw = readFileSync(mapFile, "utf-8");
+        // Older runs prepended a `// File Source: ...` banner to .js.map files;
+        // current runs write pure JSON. Strip the leading banner if present.
+        const mapContent = raw.startsWith("//") ? raw.split("\n").slice(1).join("\n") : raw;
         const { files } = extractSources(mapContent);
 
         for (const file of files) {

--- a/src/lazyLoad/next_js/NextJsCrawler.ts
+++ b/src/lazyLoad/next_js/NextJsCrawler.ts
@@ -21,6 +21,8 @@ interface NextJsCrawlerOptions {
     threads: number;
     research: boolean;
     maxIterations: number;
+    /** Called with newly discovered downloadable URLs as they are found. */
+    onUrlsDiscovered?: (urls: string[]) => void;
 }
 
 /**
@@ -50,6 +52,9 @@ class NextJsCrawler {
     /** Maximum number of recursive passes before giving up. */
     private MAX_ITERATIONS: number;
 
+    /** Callback invoked with newly discovered downloadable URLs. */
+    private readonly onUrlsDiscovered?: (urls: string[]) => void;
+
     constructor(options: NextJsCrawlerOptions) {
         this.url = options.url;
         this.output = options.output;
@@ -58,6 +63,7 @@ class NextJsCrawler {
         this.threads = options.threads;
         this.research = options.research;
         this.MAX_ITERATIONS = options.maxIterations;
+        this.onUrlsDiscovered = options.onUrlsDiscovered;
 
         this.discoveredUrls = new Set();
         this.visitedPageUrls = new Set();
@@ -78,6 +84,20 @@ class NextJsCrawler {
         return newUrls;
     }
 
+    /** Emit newly discovered downloadable assets to the onUrlsDiscovered callback. */
+    private emitDownloadable(urls: string[]): void {
+        if (!this.onUrlsDiscovered) return;
+        const downloadable = urls.filter((u) => {
+            try {
+                const p = new URL(u).pathname;
+                return p.endsWith(".js") || p.endsWith(".js.map");
+            } catch {
+                return false;
+            }
+        });
+        if (downloadable.length > 0) this.onUrlsDiscovered(downloadable);
+    }
+
     /** Snapshot the current size so we can detect growth. */
     private get size(): number {
         return this.discoveredUrls.size;
@@ -96,7 +116,7 @@ class NextJsCrawler {
             ...(this.techniqueEfficiencyMapping["next_getJSScript"] || []),
             ...jsFromScriptTag,
         ];
-        this.registerUrls(jsFromScriptTag);
+        this.emitDownloadable(this.registerUrls(jsFromScriptTag));
         this.visitedPageUrls.add(this.url);
 
         // 1b. Client-side paths from <a href> tags on the landing page.
@@ -107,19 +127,19 @@ class NextJsCrawler {
             ...(this.techniqueEfficiencyMapping["next_getClientSidePaths"] || []),
             ...pathsFromAnchors,
         ];
-        this.registerUrls(pathsFromAnchors);
+        this.emitDownloadable(this.registerUrls(pathsFromAnchors));
 
         // 2. Webpack runtime analysis (puppeteer – expensive, run once)
         const jsFromWebpack = await next_GetLazyResourcesWebpackJs(this.url);
         this.techniqueEfficiencyMapping["next_GetLazyResourcesWebpackJs"] = jsFromWebpack;
         lazyLoadGlobals.pushToJsUrls(jsFromWebpack);
-        this.registerUrls(jsFromWebpack);
+        this.emitDownloadable(this.registerUrls(jsFromWebpack));
 
         // 3. _buildManifest.js
         const jsFromBuildManifest = await next_getLazyResourcesBuildManifestJs(this.url);
         this.techniqueEfficiencyMapping["next_getLazyResourcesBuildManifestJs"] = jsFromBuildManifest;
         lazyLoadGlobals.pushToJsUrls(jsFromBuildManifest);
-        this.registerUrls(jsFromBuildManifest);
+        this.emitDownloadable(this.registerUrls(jsFromBuildManifest));
 
         // 4. Subsequent requests (RSC / script-tags on known endpoints)
         if (this.subsequentRequestsFlag) {
@@ -131,17 +151,17 @@ class NextJsCrawler {
                 lazyLoadGlobals.getJsUrls()
             );
             this.techniqueEfficiencyMapping["subsequentRequests"] = [...jsFromSubsequent];
-            this.registerUrls([...jsFromSubsequent]);
+            this.emitDownloadable(this.registerUrls([...jsFromSubsequent]));
 
             const jsFromScriptTagsSR = await next_scriptTagsSubsequentRequests(this.url, this.urlsFile);
             this.techniqueEfficiencyMapping["next_scriptTagsSubsequentRequests"] = jsFromScriptTagsSR;
             lazyLoadGlobals.pushToJsUrls(jsFromScriptTagsSR);
-            this.registerUrls(jsFromScriptTagsSR);
+            this.emitDownloadable(this.registerUrls(jsFromScriptTagsSR));
         }
 
         // Also pull in anything the globals accumulated
-        this.registerUrls(lazyLoadGlobals.getJsUrls());
-        this.registerUrls(lazyLoadGlobals.getJsonUrls());
+        this.emitDownloadable(this.registerUrls(lazyLoadGlobals.getJsUrls()));
+        this.emitDownloadable(this.registerUrls(lazyLoadGlobals.getJsonUrls()));
     }
 
     // ── recursive discovery ──────────────────────────────────────────────
@@ -162,7 +182,9 @@ class NextJsCrawler {
             ...(this.techniqueEfficiencyMapping["next_promiseResolve"] || []),
             ...jsFromPromise,
         ];
-        newInThisPass.push(...this.registerUrls(jsFromPromise));
+        const newFromPromise = this.registerUrls(jsFromPromise);
+        this.emitDownloadable(newFromPromise);
+        newInThisPass.push(...newFromPromise);
 
         // Layout.js parsing → discovers new client-side page paths → visits them
         const jsFromLayout = await next_parseLayoutJs(this.url, jsUrls);
@@ -170,7 +192,9 @@ class NextJsCrawler {
             ...(this.techniqueEfficiencyMapping["next_parseLayoutJs"] || []),
             ...jsFromLayout,
         ];
-        newInThisPass.push(...this.registerUrls(jsFromLayout));
+        const newFromLayout = this.registerUrls(jsFromLayout);
+        this.emitDownloadable(newFromLayout);
+        newInThisPass.push(...newFromLayout);
 
         // Build a queue of unvisited page URLs to walk. Seed it with:
         //   - unvisited page URLs from the input batch (anchor-derived URLs
@@ -221,6 +245,7 @@ class NextJsCrawler {
             ];
 
             const newFromScripts = this.registerUrls(extra);
+            this.emitDownloadable(newFromScripts);
             newInThisPass.push(...newFromScripts);
             for (const x of newFromScripts) enqueueIfPage(x);
 
@@ -232,6 +257,7 @@ class NextJsCrawler {
                 ...morePaths,
             ];
             const newFromAnchors = this.registerUrls(morePaths);
+            this.emitDownloadable(newFromAnchors);
             newInThisPass.push(...newFromAnchors);
             for (const x of newFromAnchors) enqueueIfPage(x);
         }
@@ -282,7 +308,7 @@ class NextJsCrawler {
         const allJsUrls = [...this.discoveredUrls].filter((u) => u.endsWith(".js") || u.endsWith(".js.map"));
         const jsFromBrute = await next_bruteForceJsFiles(allJsUrls);
         this.techniqueEfficiencyMapping["next_bruteForceJsFiles"] = jsFromBrute;
-        this.registerUrls(jsFromBrute);
+        this.emitDownloadable(this.registerUrls(jsFromBrute));
 
         // Only return downloadable assets. Anchor-derived page URLs live in
         // discoveredUrls to drive the crawl, but must not reach downloadFiles.

--- a/src/lazyLoad/next_js/next_GetJSScript.ts
+++ b/src/lazyLoad/next_js/next_GetJSScript.ts
@@ -5,6 +5,8 @@ import * as cheerio from "cheerio";
 import makeRequest from "../../utility/makeReq.js";
 import { getJsUrls } from "../globals.js";
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
  * Scrapes all lazy-loaded JavaScript file URLs from the provided Next.js page.
  *
@@ -18,8 +20,15 @@ import { getJsUrls } from "../globals.js";
  */
 const next_getJSScript = async (url: string): Promise<string[]> => {
     const toReturn: string[] = [];
-    // get the page source
-    const res = await makeRequest(url, {});
+    // get the page source — retry until the request succeeds
+    let res: Response | null = null;
+    while (!res) {
+        res = await makeRequest(url, {});
+        if (!res) {
+            console.log(chalk.yellow(`[!] Request to ${url} failed, retrying...`));
+            await sleep(1000);
+        }
+    }
     const pageSource = await res.text();
 
     // cheerio to parse the page source
@@ -69,7 +78,7 @@ const next_getJSScript = async (url: string): Promise<string[]> => {
             // to get these, simply regex from the JS script
 
             const js_script = $(scriptTag).html();
-            const matches = js_script.match(/static\/chunks\/[a-zA-Z0-9_\-~.]+\.js/g);
+            const matches = js_script?.match(/static\/chunks\/[a-zA-Z0-9_\-~.]+\.js/g);
 
             if (matches) {
                 const uniqueMatches = [...new Set(matches)];

--- a/src/lazyLoad/next_js/next_GetJSScript.ts
+++ b/src/lazyLoad/next_js/next_GetJSScript.ts
@@ -18,16 +18,23 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
  * @returns {Promise<string[]>} - A promise that resolves to an array of absolute URLs
  * pointing to JavaScript files found in the page.
  */
+const MAX_FETCH_ATTEMPTS = 5;
+
 const next_getJSScript = async (url: string): Promise<string[]> => {
     const toReturn: string[] = [];
-    // get the page source — retry until the request succeeds
+    // get the page source — bounded retry so an unreachable host can't hang the crawler
     let res: Response | null = null;
-    while (!res) {
+    for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
         res = await makeRequest(url, {});
-        if (!res) {
-            console.log(chalk.yellow(`[!] Request to ${url} failed, retrying...`));
+        if (res) break;
+        if (attempt < MAX_FETCH_ATTEMPTS) {
+            console.log(chalk.yellow(`[!] Request to ${url} failed, retrying (${attempt}/${MAX_FETCH_ATTEMPTS})...`));
             await sleep(1000);
         }
+    }
+    if (!res) {
+        console.log(chalk.red(`[!] Giving up on ${url} after ${MAX_FETCH_ATTEMPTS} attempts`));
+        return toReturn;
     }
     const pageSource = await res.text();
 

--- a/src/lazyLoad/next_js/next_SubsequentRequests.ts
+++ b/src/lazyLoad/next_js/next_SubsequentRequests.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import cliProgress from "cli-progress";
 import fs from "fs";
 import path from "path";
 import { getURLDirectory } from "../../utility/urlUtils.js";
@@ -42,8 +43,6 @@ const subsequentRequests = async (url, urlsFile, threads, output, js_urls): Prom
     max_queue = threads;
     let staticJSURLs = [];
 
-    console.log(chalk.cyan(`[i] Fetching JS files from subsequent requests`));
-
     // open the urls file, and load the paths (JSON)
     if (!fs.existsSync(urlsFile)) {
         console.log(chalk.red(`[!] URLs file ${urlsFile} does not exist`));
@@ -55,6 +54,21 @@ const subsequentRequests = async (url, urlsFile, threads, output, js_urls): Prom
 
     // add `/` to endpoints
     endpoints.push("/");
+
+    const progressBar = new cliProgress.SingleBar(
+        {
+            format:
+                chalk.cyan("[i] Fetching JS files from subsequent requests ") +
+                "[{bar}] {percentage}% | {value}/{total} | {phase}",
+            barCompleteChar: "█",
+            barIncompleteChar: "░",
+            hideCursor: true,
+            clearOnComplete: false,
+            stopOnComplete: false,
+        },
+        cliProgress.Presets.shades_classic
+    );
+    progressBar.start(endpoints.length * 2, 0, { phase: "RSC" });
 
     let js_contents = {};
 
@@ -120,6 +134,7 @@ const subsequentRequests = async (url, urlsFile, threads, output, js_urls): Prom
             queue--;
             console.log(chalk.red(`[!] Error fetching ${reqUrl}: ${e}`));
         }
+        progressBar.increment(1, { phase: "RSC" });
     });
 
     await Promise.all(reqPromises);
@@ -137,6 +152,10 @@ const subsequentRequests = async (url, urlsFile, threads, output, js_urls): Prom
         // make the request to get the contents of the webpage
 
         const req = await makeRequest(reqUrl);
+        if (!req) {
+            progressBar.increment(1, { phase: "HTML" });
+            continue;
+        }
         const resText = await req.text();
         const $ = cheerio.load(resText);
 
@@ -161,7 +180,10 @@ const subsequentRequests = async (url, urlsFile, threads, output, js_urls): Prom
                 }
             }
         });
+        progressBar.increment(1, { phase: "HTML" });
     }
+
+    progressBar.stop();
 
     // build the full URL from path
     jsFilesFromPageHtml = jsFilesFromPageHtml.map((file) => {

--- a/src/lazyLoad/next_js/next_SubsequentRequests.ts
+++ b/src/lazyLoad/next_js/next_SubsequentRequests.ts
@@ -88,7 +88,7 @@ const subsequentRequests = async (url, urlsFile, threads, output, js_urls): Prom
                 },
             });
 
-            if (res && res.status === 200 && res.headers.get("content-type").includes("text/x-component")) {
+            if (res && res.status === 200 && res.headers.get("content-type")?.includes("text/x-component")) {
                 const text = await res.text();
                 js_contents[endpoint] = text;
 

--- a/src/lazyLoad/next_js/next_SubsequentRequests.ts
+++ b/src/lazyLoad/next_js/next_SubsequentRequests.ts
@@ -62,7 +62,7 @@ const subsequentRequests = async (url, urlsFile, threads, output, js_urls): Prom
                 "[{bar}] {percentage}% | {value}/{total} | {phase}",
             barCompleteChar: "█",
             barIncompleteChar: "░",
-            hideCursor: true,
+            hideCursor: false,
             clearOnComplete: false,
             stopOnComplete: false,
         },

--- a/src/lazyLoad/next_js/next_scriptTagsSubsequentRequests.ts
+++ b/src/lazyLoad/next_js/next_scriptTagsSubsequentRequests.ts
@@ -18,7 +18,15 @@ const next_scriptTagsSubsequentRequests = async (url: string, endpointsFile: str
 
     // go through all endpoints, and parse them
     for (const endpoint of endpoints) {
-        const reqUrl = new URL(endpoint, url).href;
+        // skip anything that isn't a valid relative path or absolute URL
+        if (!/^(\/|https?:\/\/)/.test(endpoint)) continue;
+
+        let reqUrl: string;
+        try {
+            reqUrl = new URL(endpoint, url).href;
+        } catch {
+            continue;
+        }
         const jsUrlsFromEndpoint = await next_getJSScript(reqUrl);
         jsUrls.push(...jsUrlsFromEndpoint);
     }

--- a/src/lazyLoad/techDetect/checkReact.ts
+++ b/src/lazyLoad/techDetect/checkReact.ts
@@ -15,8 +15,18 @@ const checkReact = async ($: cheerio.CheerioAPI, url: string): Promise<{ detecte
                     // get the src
                     const src = attrValue;
 
-                    // get the content of the src file
-                    const res = await makeRequest(new URL(src, url).href, {});
+                    // Resolve src against the page URL — skip if it's malformed
+                    // (e.g. `data:`, `javascript:` schemes, invalid URIs).
+                    let resolvedUrl: string;
+                    try {
+                        resolvedUrl = new URL(src, url).href;
+                    } catch {
+                        continue;
+                    }
+
+                    // makeRequest returns Response | null — skip when the fetch failed.
+                    const res = await makeRequest(resolvedUrl, {});
+                    if (!res) continue;
                     const body = await res.text();
 
                     // check if the body contains "react" or "react-dom"

--- a/src/lazyLoad/techDetect/checkReact.ts
+++ b/src/lazyLoad/techDetect/checkReact.ts
@@ -16,7 +16,7 @@ const checkReact = async ($: cheerio.CheerioAPI, url: string): Promise<{ detecte
                     const src = attrValue;
 
                     // get the content of the src file
-                    const res = await makeRequest((new URL(src, url)).href, {});
+                    const res = await makeRequest(new URL(src, url).href, {});
                     const body = await res.text();
 
                     // check if the body contains "react" or "react-dom"

--- a/src/lazyLoad/techDetect/checkReact.ts
+++ b/src/lazyLoad/techDetect/checkReact.ts
@@ -16,7 +16,7 @@ const checkReact = async ($: cheerio.CheerioAPI, url: string): Promise<{ detecte
                     const src = attrValue;
 
                     // get the content of the src file
-                    const res = await makeRequest(src, {});
+                    const res = await makeRequest((new URL(src, url)).href, {});
                     const body = await res.text();
 
                     // check if the body contains "react" or "react-dom"

--- a/src/lazyLoad/techDetect/index.ts
+++ b/src/lazyLoad/techDetect/index.ts
@@ -24,8 +24,23 @@ import { checkReact } from "./checkReact.js";
 const frameworkDetect = async (url: string): Promise<{ name: string; evidence: string }> => {
     console.log(chalk.cyan("[i] Detecting front-end framework"));
 
-    // get the page source
+    // get the page source. Drain the body immediately into a string — if we
+    // wait until after the puppeteer + downstream check* calls, the Response
+    // body gets invalidated (undici flips bodyUsed=true mid-flight when the
+    // response is held idle alongside other in-flight fetches).
     const res = await makeRequest(url, {});
+    let resBody: string | null = null;
+    if (res !== null) {
+        try {
+            resBody = await res.text();
+        } catch (err) {
+            console.log(
+                chalk.yellow(
+                    `[!] Could not read fetch response body for ${url} (${(err as any)?.message || err}); using browser-rendered source only.`
+                )
+            );
+        }
+    }
 
     // get the page source in the browser
     const browser = await puppeteer.launch({
@@ -80,8 +95,7 @@ const frameworkDetect = async (url: string): Promise<{ name: string; evidence: s
     // if network error was caused, then return
     if (res === null) {
         console.log(chalk.red("[!] Fetch request failed after retries"));
-    } else {
-        const resBody = await res.text();
+    } else if (resBody !== null) {
         $res = cheerio.load(resBody);
         result_checkNextJS_res = await checkNextJS($res);
         result_checkVueJS_res = await checkVueJS($res, url);
@@ -98,7 +112,7 @@ const frameworkDetect = async (url: string): Promise<{ name: string; evidence: s
         console.log(chalk.green("[✓] Vue.js detected"));
         console.log(chalk.cyan(`[i] Checking Nuxt.JS`), chalk.dim("(Nuxt.JS is built on Vue.js)"));
         const result_checkNuxtJS = await checkNuxtJS($);
-        const result_checkNuxtJS_res = await checkNuxtJS($res);
+        const result_checkNuxtJS_res = $res ? await checkNuxtJS($res) : { detected: false, evidence: "" };
         if (result_checkNuxtJS.detected === true || result_checkNuxtJS_res.detected === true) {
             const evidence =
                 result_checkNuxtJS.evidence !== "" ? result_checkNuxtJS.evidence : result_checkNuxtJS_res.evidence;

--- a/src/lazyLoad/vue/vue_discoverJsFiles.ts
+++ b/src/lazyLoad/vue/vue_discoverJsFiles.ts
@@ -7,6 +7,7 @@ import vue_jsImports from "./vue_jsImports.js";
 import vue_reconstructSourceMaps from "./vue_reconstructSourceMaps.js";
 import vue_getClientSidePaths from "./vue_getClientSidePaths.js";
 import vue_viteMapDeps from "./vue_viteMapDeps.js";
+import vue_stringJsFiles from "./vue_stringJsFiles.js";
 
 export interface VueDiscoveryResult {
     jsFiles: string[];
@@ -55,6 +56,13 @@ const vue_discoverJsFiles = async (url: string, maxJsSizeMb: number = 2): Promis
     jsFiles.push(...fromImports);
     if (fromImports.length > 0) {
         console.log(chalk.green(`[✓] Found ${fromImports.length} files from import statements`));
+    }
+
+    // scan string literals inside known JS files for .js references
+    const fromStringRefs = await vue_stringJsFiles(jsFiles, maxJsSizeMb);
+    jsFiles.push(...fromStringRefs);
+    if (fromStringRefs.length > 0) {
+        console.log(chalk.green(`[✓] Found ${fromStringRefs.length} files from string literal JS references`));
     }
 
     // reconstruct sourceMappingURL references

--- a/src/lazyLoad/vue/vue_discoverJsFiles.ts
+++ b/src/lazyLoad/vue/vue_discoverJsFiles.ts
@@ -21,53 +21,65 @@ export interface VueDiscoveryResult {
  * runtime.js chunks, single/several JS files on home, import statements,
  * source-map reconstruction) into one reusable flow, and also surfaces the
  * client-side paths found in the discovered files so callers can recurse.
+ *
+ * @param onFilesDiscovered Called with each batch of newly found URLs so the
+ *   caller can start downloading them immediately rather than waiting for the
+ *   full pipeline to finish.
  */
-const vue_discoverJsFiles = async (url: string, maxJsSizeMb: number = 2): Promise<VueDiscoveryResult> => {
+const vue_discoverJsFiles = async (
+    url: string,
+    maxJsSizeMb: number = 2,
+    onFilesDiscovered?: (files: string[]) => void
+): Promise<VueDiscoveryResult> => {
     let jsFiles: string[] = [];
 
+    const emit = (files: string[]) => {
+        jsFiles.push(...files);
+        if (files.length > 0 && onFilesDiscovered) {
+            onFilesDiscovered(files.map((f) => (f.startsWith("//") ? "https:" + f : f)));
+        }
+    };
+
     // first, get all the JS files from the page source
-    const fromPageSrc = await vue_pageSrc(url);
-    jsFiles.push(...fromPageSrc);
+    emit(await vue_pageSrc(url));
 
     // method 1: through runtime.<hash>.js
-    const fromRuntimeJs = await vue_runtimeJs(url);
-    jsFiles.push(...fromRuntimeJs);
+    emit(await vue_runtimeJs(url));
 
     // single JS file on the page (typically dev-mode)
     const fromSingleJs = await vue_singleJsFileOnHome(url);
-    jsFiles.push(...fromSingleJs);
+    emit(fromSingleJs);
     if (fromSingleJs.length > 0) {
         console.log(chalk.green(`[✓] Found ${fromSingleJs.length} files from the single JS file on home`));
     }
 
     // several JS files referenced directly on the page
-    const fromSeveralJs = await vue_severalJsFilesHome(url);
-    jsFiles.push(...fromSeveralJs);
+    emit(await vue_severalJsFilesHome(url));
 
     // scan page-loaded JS files for Vite's __vite__mapDeps chunk manifest
     const fromViteMapDeps = await vue_viteMapDeps(jsFiles, maxJsSizeMb);
-    jsFiles.push(...fromViteMapDeps);
+    emit(fromViteMapDeps);
     if (fromViteMapDeps.length > 0) {
         console.log(chalk.green(`[✓] Found ${fromViteMapDeps.length} files from __vite__mapDeps`));
     }
 
     // walk the import graph of everything found so far
     const fromImports = await vue_jsImports(url, jsFiles, maxJsSizeMb);
-    jsFiles.push(...fromImports);
+    emit(fromImports);
     if (fromImports.length > 0) {
         console.log(chalk.green(`[✓] Found ${fromImports.length} files from import statements`));
     }
 
     // scan string literals inside known JS files for .js references
     const fromStringRefs = await vue_stringJsFiles(jsFiles, maxJsSizeMb);
-    jsFiles.push(...fromStringRefs);
+    emit(fromStringRefs);
     if (fromStringRefs.length > 0) {
         console.log(chalk.green(`[✓] Found ${fromStringRefs.length} files from string literal JS references`));
     }
 
     // reconstruct sourceMappingURL references
     const fromSourceMaps = await vue_reconstructSourceMaps(url, jsFiles);
-    jsFiles.push(...fromSourceMaps);
+    emit(fromSourceMaps);
     if (fromSourceMaps.length > 0) {
         console.log(chalk.green(`[✓] Found ${fromSourceMaps.length} files from reconstructing source maps`));
     }

--- a/src/lazyLoad/vue/vue_getClientSidePaths.ts
+++ b/src/lazyLoad/vue/vue_getClientSidePaths.ts
@@ -157,7 +157,7 @@ const vue_getClientSidePaths = async (url: string, jsFiles: string[], maxJsSizeM
         });
 
         processed++;
-        if (toReturn.length !== pathsBefore) skipped = Math.max(0, skipped);
+        if (toReturn.length === pathsBefore) skipped++;
         bar.update(processed, { paths: toReturn.length, skipped });
     }
 

--- a/src/lazyLoad/vue/vue_getClientSidePaths.ts
+++ b/src/lazyLoad/vue/vue_getClientSidePaths.ts
@@ -20,7 +20,7 @@ const vue_getClientSidePaths = async (url: string, jsFiles: string[], maxJsSizeM
                 "[{bar}] {percentage}% | {value}/{total} files | {paths} paths | {skipped} skipped",
             barCompleteChar: "█",
             barIncompleteChar: "░",
-            hideCursor: true,
+            hideCursor: false,
             clearOnComplete: false,
             stopOnComplete: false,
         },

--- a/src/lazyLoad/vue/vue_getClientSidePaths.ts
+++ b/src/lazyLoad/vue/vue_getClientSidePaths.ts
@@ -1,6 +1,7 @@
 import makeRequest from "../../utility/makeReq.js";
 import _traverse from "@babel/traverse";
 import chalk from "chalk";
+import cliProgress from "cli-progress";
 import parser from "@babel/parser";
 import t from "@babel/types";
 
@@ -10,28 +11,49 @@ const vue_getClientSidePaths = async (url: string, jsFiles: string[], maxJsSizeM
     const MAX_JS_SIZE_BYTES = maxJsSizeMb * 1024 * 1024;
     let toReturn: string[] = [];
 
-    console.log(chalk.cyan(`[i] Extracting client-side paths from ${jsFiles.length} JS files...`));
-
     const baseOrigin = new URL(url).origin;
+
+    const bar = new cliProgress.SingleBar(
+        {
+            format:
+                chalk.cyan("[i] Extracting client-side paths ") +
+                "[{bar}] {percentage}% | {value}/{total} files | {paths} paths | {skipped} skipped",
+            barCompleteChar: "█",
+            barIncompleteChar: "░",
+            hideCursor: true,
+            clearOnComplete: false,
+            stopOnComplete: false,
+        },
+        cliProgress.Presets.shades_classic
+    );
+
+    let processed = 0;
+    let skipped = 0;
+    bar.start(jsFiles.length, 0, { paths: 0, skipped: 0 });
 
     // iterate through all those
     for (const jsFile of jsFiles) {
         if (!jsFile.endsWith(".js")) {
+            processed++;
+            skipped++;
+            bar.update(processed, { paths: toReturn.length, skipped });
             continue;
         }
         const req = await makeRequest(jsFile);
 
         if (req == null) {
-            console.log(chalk.red(`[!] Failed to fetch ${jsFile}`));
+            processed++;
+            skipped++;
+            bar.update(processed, { paths: toReturn.length, skipped });
             continue;
         }
 
         const jsContent = await req.text();
 
         if (jsContent.length > MAX_JS_SIZE_BYTES) {
-            console.log(
-                chalk.yellow(`[!] Skipping large file (${(jsContent.length / 1024 / 1024).toFixed(1)} MB): ${jsFile}`)
-            );
+            processed++;
+            skipped++;
+            bar.update(processed, { paths: toReturn.length, skipped });
             continue;
         }
 
@@ -45,11 +67,14 @@ const vue_getClientSidePaths = async (url: string, jsFiles: string[], maxJsSizeM
                 errorRecovery: true,
             });
         } catch {
-            console.log(chalk.red(`[!] Failed to parse ${jsFile}`));
+            processed++;
+            skipped++;
+            bar.update(processed, { paths: toReturn.length, skipped });
             continue;
         }
 
         const jsFileOrigin = new URL(jsFile).origin;
+        const pathsBefore = toReturn.length;
 
         traverse(ast, {
             ObjectProperty(path) {
@@ -130,7 +155,13 @@ const vue_getClientSidePaths = async (url: string, jsFiles: string[], maxJsSizeM
                 }
             },
         });
+
+        processed++;
+        if (toReturn.length !== pathsBefore) skipped = Math.max(0, skipped);
+        bar.update(processed, { paths: toReturn.length, skipped });
     }
+
+    bar.stop();
 
     if (toReturn.length > 0) {
         console.log(chalk.green(`[+] Found ${toReturn.length} client-side paths from JS files!`));

--- a/src/lazyLoad/vue/vue_recursiveClientSidePathDownload.ts
+++ b/src/lazyLoad/vue/vue_recursiveClientSidePathDownload.ts
@@ -89,7 +89,11 @@ const vue_recursiveClientSidePathDownload = async (
                 while (cursor < batch.length) {
                     const path = batch[cursor++];
                     try {
-                        const { jsFiles, clientSidePaths: newPaths } = await vue_discoverJsFiles(path, maxJsSizeMb, onFilesDiscovered);
+                        const { jsFiles, clientSidePaths: newPaths } = await vue_discoverJsFiles(
+                            path,
+                            maxJsSizeMb,
+                            onFilesDiscovered
+                        );
 
                         for (const file of jsFiles) {
                             allJsFiles.add(file);

--- a/src/lazyLoad/vue/vue_recursiveClientSidePathDownload.ts
+++ b/src/lazyLoad/vue/vue_recursiveClientSidePathDownload.ts
@@ -19,7 +19,8 @@ const STAGNATION_LIMIT = 3;
 const vue_recursiveClientSidePathDownload = async (
     clientSidePaths: string[],
     threads: number = 1,
-    maxJsSizeMb: number = 2
+    maxJsSizeMb: number = 2,
+    onFilesDiscovered?: (files: string[]) => void
 ): Promise<string[]> => {
     const allJsFiles = new Set<string>();
     const visitedPaths = new Set<string>();
@@ -47,7 +48,7 @@ const vue_recursiveClientSidePathDownload = async (
                 "[{bar}] {percentage}% | {value}/{total} paths | round {round} | {jsFiles} JS files | {stagnant} stagnant",
             barCompleteChar: "█",
             barIncompleteChar: "░",
-            hideCursor: true,
+            hideCursor: false,
             clearOnComplete: false,
             stopOnComplete: false,
             etaBuffer: 50,
@@ -88,7 +89,7 @@ const vue_recursiveClientSidePathDownload = async (
                 while (cursor < batch.length) {
                     const path = batch[cursor++];
                     try {
-                        const { jsFiles, clientSidePaths: newPaths } = await vue_discoverJsFiles(path, maxJsSizeMb);
+                        const { jsFiles, clientSidePaths: newPaths } = await vue_discoverJsFiles(path, maxJsSizeMb, onFilesDiscovered);
 
                         for (const file of jsFiles) {
                             allJsFiles.add(file);

--- a/src/lazyLoad/vue/vue_stringJsFiles.ts
+++ b/src/lazyLoad/vue/vue_stringJsFiles.ts
@@ -14,6 +14,10 @@ import { extractStrings } from "../../strings/index.js";
  */
 const resolveJsString = (str: string, jsFileUrl: string): string | null => {
     try {
+        if (str.startsWith("http://") || str.startsWith("https://")) {
+            return new URL(str).href;
+        }
+
         const fileUrl = new URL(jsFileUrl);
 
         if (str.startsWith("./") || str.startsWith("../")) {

--- a/src/lazyLoad/vue/vue_stringJsFiles.ts
+++ b/src/lazyLoad/vue/vue_stringJsFiles.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import cliProgress from "cli-progress";
 import makeRequest from "../../utility/makeReq.js";
 import parser from "@babel/parser";
 import { extractStrings } from "../../strings/index.js";
@@ -111,24 +112,44 @@ const vue_stringJsFiles = async (knownJsFiles: string[], maxJsSizeMb: number = 2
     const allFound = new Set<string>();
     const crawled = new Set<string>(knownJsFiles);
 
-    for (const jsFile of knownJsFiles) {
-        const discovered = await fetchAndExtractJsStrings(jsFile, maxJsSizeMb);
-        for (const u of discovered) allFound.add(u);
-    }
+    const bar = new cliProgress.SingleBar(
+        {
+            format:
+                chalk.cyan("[i] Scanning JS string refs ") +
+                "[{bar}] {percentage}% | {value}/{total} files | {refs} refs found",
+            barCompleteChar: "█",
+            barIncompleteChar: "░",
+            hideCursor: true,
+            clearOnComplete: false,
+            stopOnComplete: false,
+        },
+        cliProgress.Presets.shades_classic
+    );
 
-    // crawl newly discovered URLs that weren't in the original set
-    let foundNew = true;
-    while (foundNew) {
-        foundNew = false;
-        for (const u of [...allFound]) {
+    let processed = 0;
+    const queue = [...knownJsFiles];
+
+    bar.start(queue.length, 0, { refs: 0 });
+
+    const processFile = async (url: string) => {
+        const discovered = await fetchAndExtractJsStrings(url, maxJsSizeMb);
+        for (const u of discovered) {
+            allFound.add(u);
             if (!crawled.has(u)) {
-                foundNew = true;
                 crawled.add(u);
-                const discovered = await fetchAndExtractJsStrings(u, maxJsSizeMb);
-                for (const newU of discovered) allFound.add(newU);
+                queue.push(u);
+                bar.setTotal(queue.length);
             }
         }
+        processed++;
+        bar.update(processed, { refs: allFound.size });
+    };
+
+    for (let i = 0; i < queue.length; i++) {
+        await processFile(queue[i]);
     }
+
+    bar.stop();
 
     return [...allFound];
 };

--- a/src/lazyLoad/vue/vue_stringJsFiles.ts
+++ b/src/lazyLoad/vue/vue_stringJsFiles.ts
@@ -119,7 +119,7 @@ const vue_stringJsFiles = async (knownJsFiles: string[], maxJsSizeMb: number = 2
                 "[{bar}] {percentage}% | {value}/{total} files | {refs} refs found",
             barCompleteChar: "█",
             barIncompleteChar: "░",
-            hideCursor: true,
+            hideCursor: false,
             clearOnComplete: false,
             stopOnComplete: false,
         },

--- a/src/lazyLoad/vue/vue_stringJsFiles.ts
+++ b/src/lazyLoad/vue/vue_stringJsFiles.ts
@@ -1,0 +1,135 @@
+import chalk from "chalk";
+import makeRequest from "../../utility/makeReq.js";
+import parser from "@babel/parser";
+import { extractStrings } from "../../strings/index.js";
+
+/**
+ * Resolves a .js string found in a bundle to an absolute URL.
+ *
+ * Handles three forms:
+ *   - `./Feature.hash.js` or `../chunk.js`  → standard relative resolution
+ *   - `/static/chunk.js`                     → absolute path on same origin
+ *   - `assets/feat.hash.js`                  → find where "assets" appears in
+ *     the JS file's URL path and anchor there
+ */
+const resolveJsString = (str: string, jsFileUrl: string): string | null => {
+    try {
+        const fileUrl = new URL(jsFileUrl);
+
+        if (str.startsWith("./") || str.startsWith("../")) {
+            return new URL(str, jsFileUrl).href;
+        }
+
+        if (str.startsWith("/")) {
+            return new URL(str, fileUrl.origin).href;
+        }
+
+        // Relative path without a leading dot, e.g. "assets/feat.hash.js"
+        const strParts = str.split("/");
+        const strDirParts = strParts.slice(0, -1); // directory segments of the string
+
+        if (strDirParts.length === 0) {
+            // bare filename — resolve relative to the JS file's directory
+            const dirUrl = jsFileUrl.substring(0, jsFileUrl.lastIndexOf("/") + 1);
+            return dirUrl + str;
+        }
+
+        // urlPathParts: e.g. ['cdn', 'assets', 'app.js'] for /cdn/assets/app.js
+        const urlPathParts = fileUrl.pathname.split("/").filter((p) => p);
+
+        // Find the rightmost occurrence of strDirParts[0] in the URL path, then
+        // verify the subsequent segments also match before committing.
+        for (let i = urlPathParts.length - 1; i >= 0; i--) {
+            if (urlPathParts[i] !== strDirParts[0]) continue;
+
+            let match = true;
+            for (let j = 1; j < strDirParts.length; j++) {
+                if (urlPathParts[i + j] !== strDirParts[j]) {
+                    match = false;
+                    break;
+                }
+            }
+
+            if (match) {
+                const baseParts = urlPathParts.slice(0, i);
+                const basePath = "/" + (baseParts.length > 0 ? baseParts.join("/") + "/" : "");
+                return fileUrl.origin + basePath + str;
+            }
+        }
+
+        // Fallback: treat as relative to the JS file's directory
+        const dirUrl = jsFileUrl.substring(0, jsFileUrl.lastIndexOf("/") + 1);
+        return dirUrl + str;
+    } catch {
+        return null;
+    }
+};
+
+const fetchAndExtractJsStrings = async (url: string, maxJsSizeMb: number): Promise<Set<string>> => {
+    const MAX_BYTES = maxJsSizeMb * 1024 * 1024;
+    const found = new Set<string>();
+
+    const req = await makeRequest(url);
+    if (req == null) return found;
+
+    const text = await req.text();
+    if (text.length > MAX_BYTES) return found;
+
+    let ast: any;
+    try {
+        ast = parser.parse(text, {
+            sourceType: "unambiguous",
+            plugins: ["jsx", "typescript"],
+            errorRecovery: true,
+        });
+    } catch {
+        return found;
+    }
+
+    const strings = extractStrings(ast);
+
+    for (const s of strings) {
+        if (!s.endsWith(".js")) continue;
+
+        const resolved = resolveJsString(s, url);
+        if (resolved) found.add(resolved);
+    }
+
+    return found;
+};
+
+/**
+ * Discovers additional JS chunk URLs by scanning string literals inside every
+ * known JS file for references that end in `.js` and resolving them against
+ * the file's own URL.
+ */
+const vue_stringJsFiles = async (
+    knownJsFiles: string[],
+    maxJsSizeMb: number = 2
+): Promise<string[]> => {
+    const allFound = new Set<string>();
+    const crawled = new Set<string>(knownJsFiles);
+
+    for (const jsFile of knownJsFiles) {
+        const discovered = await fetchAndExtractJsStrings(jsFile, maxJsSizeMb);
+        for (const u of discovered) allFound.add(u);
+    }
+
+    // crawl newly discovered URLs that weren't in the original set
+    let foundNew = true;
+    while (foundNew) {
+        foundNew = false;
+        for (const u of [...allFound]) {
+            if (!crawled.has(u)) {
+                foundNew = true;
+                crawled.add(u);
+                const discovered = await fetchAndExtractJsStrings(u, maxJsSizeMb);
+                for (const newU of discovered) allFound.add(newU);
+            }
+        }
+    }
+
+    return [...allFound];
+};
+
+export default vue_stringJsFiles;

--- a/src/lazyLoad/vue/vue_stringJsFiles.ts
+++ b/src/lazyLoad/vue/vue_stringJsFiles.ts
@@ -103,10 +103,7 @@ const fetchAndExtractJsStrings = async (url: string, maxJsSizeMb: number): Promi
  * known JS file for references that end in `.js` and resolving them against
  * the file's own URL.
  */
-const vue_stringJsFiles = async (
-    knownJsFiles: string[],
-    maxJsSizeMb: number = 2
-): Promise<string[]> => {
+const vue_stringJsFiles = async (knownJsFiles: string[], maxJsSizeMb: number = 2): Promise<string[]> => {
     const allFound = new Set<string>();
     const crawled = new Set<string>(knownJsFiles);
 

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -20,6 +20,7 @@ import getExports from "./next_js/getExports.js";
 // Vue.JS
 import getViteConnections from "./vue_js/getViteConnections.js";
 import vueInteractive from "./vue_js/interactive.js";
+import vue_resolveFetch from "./vue_js/vue_resolveFetch.js";
 
 const availableTech = {
     next: "Next.JS",
@@ -161,8 +162,27 @@ const map = async (
             chunks = JSON.parse(readFileSync(`${output}.json`, { encoding: "utf8" }));
         }
 
+        // Resolve fetch instances across all Vue.JS files
+        await vue_resolveFetch(directory);
+
         if (interactive_mode) {
             await vueInteractive(chunks, `${output}.json`);
+        }
+
+        // Generate OpenAPI spec and Postman collection if enabled
+        if (getOpenapi() === true) {
+            const openapiSpec = generateOpenapiV3Spec(getOpenapiOutput(), chunks);
+            const openapiJson = JSON.stringify(openapiSpec, null, 2);
+            fs.writeFileSync(getOpenapiOutputFile(), openapiJson);
+            console.log(chalk.green(`[✓] Generated OpenAPI spec at ${getOpenapiOutputFile()}`));
+
+            const postmanCollection = generatePostmanCollection(getOpenapiOutput());
+            const openapiOutputFile = getOpenapiOutputFile();
+            const postmanOutputFile = openapiOutputFile.endsWith(".json")
+                ? openapiOutputFile.replace(/\.json$/, ".postman_collection.json")
+                : `${openapiOutputFile}.postman_collection.json`;
+            fs.writeFileSync(postmanOutputFile, JSON.stringify(postmanCollection, null, 2));
+            console.log(chalk.green(`[✓] Generated Postman Collection at ${postmanOutputFile}`));
         }
     }
 };

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -6,6 +6,7 @@ import getWebpackConnections from "./next_js/getWebpackConnections.js";
 import getTurbopackConnections from "./next_js/getTurbopackConnections.js";
 import getFetchInstances from "./next_js/getFetchInstances.js";
 import resolveFetch from "./next_js/resolveFetch.js";
+import resolveNewRequest from "./next_js/resolveNewRequest.js";
 import interactive from "./next_js/interactive.js";
 import { existsSync, readFileSync } from "fs";
 import { Chunks } from "../utility/interfaces.js";
@@ -121,6 +122,9 @@ const map = async (
 
         // also, the axios instances
         await resolveAxios(chunks, directory);
+
+        // wrapper-class HTTP requests:  new X({url, method, ...})
+        await resolveNewRequest(chunks, directory);
 
         if (interactive_mode) {
             await interactive(chunks, `${output}.json`);

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -14,6 +14,7 @@ import getAxiosInstances from "./next_js/getAxiosInstances.js";
 import resolveAxios from "./next_js/resolveAxios.js";
 import { getOpenapi, getOpenapiOutput, getOpenapiOutputFile } from "../utility/globals.js";
 import { generateOpenapiV3Spec } from "../utility/openapiGenerator.js";
+import { generatePostmanCollection } from "../utility/postmanGenerator.js";
 import getExports from "./next_js/getExports.js";
 
 // Vue.JS
@@ -139,6 +140,17 @@ const map = async (
             // write to file
             fs.writeFileSync(getOpenapiOutputFile(), openapiJson);
             console.log(chalk.green(`[✓] Generated OpenAPI spec at ${getOpenapiOutputFile()}`));
+
+            // Also emit a Postman Collection v2.1 — Bruno/Insomnia/Postman use its
+            // nested `item` arrays to render real folder hierarchies on import,
+            // which a flat OpenAPI tag list can't represent.
+            const postmanCollection = generatePostmanCollection(getOpenapiOutput());
+            const openapiOutputFile = getOpenapiOutputFile();
+            const postmanOutputFile = openapiOutputFile.endsWith(".json")
+                ? openapiOutputFile.replace(/\.json$/, ".postman_collection.json")
+                : `${openapiOutputFile}.postman_collection.json`;
+            fs.writeFileSync(postmanOutputFile, JSON.stringify(postmanCollection, null, 2));
+            console.log(chalk.green(`[✓] Generated Postman Collection at ${postmanOutputFile}`));
         }
     } else if (tech === "vue") {
         let chunks: Chunks;

--- a/src/map/next_js/getExports.ts
+++ b/src/map/next_js/getExports.ts
@@ -21,11 +21,16 @@ const getExports = async (chunks: Chunks): Promise<Chunks> => {
         const chunkCode = chunk.code;
 
         // parse it with ast
-        const ast = parser.parse(chunkCode, {
-            sourceType: "unambiguous",
-            plugins: ["jsx", "typescript"],
-            errorRecovery: true,
-        });
+        let ast;
+        try {
+            ast = parser.parse(chunkCode, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+        } catch {
+            continue;
+        }
 
         // declare the exportname var
         let chunkSecondArg: string;

--- a/src/map/next_js/getFetchInstances.ts
+++ b/src/map/next_js/getFetchInstances.ts
@@ -51,11 +51,16 @@ const getFetchInstances = async (chunks: Chunks, output: string, formats: string
 
     //   iterate through the chunks, and check fetch instances
     for (let chunk of Object.values(chunks)) {
-        const chunkAst = parser.parse(chunk.code, {
-            sourceType: "module",
-            plugins: ["jsx", "typescript"],
-            errorRecovery: true,
-        });
+        let chunkAst;
+        try {
+            chunkAst = parser.parse(chunk.code, {
+                sourceType: "module",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+        } catch {
+            continue;
+        }
         const fetchAliases = new Set();
         const fetchCalls = new Set();
         traverse(chunkAst, {

--- a/src/map/next_js/resolveAxios.ts
+++ b/src/map/next_js/resolveAxios.ts
@@ -8,6 +8,13 @@ import { processAxiosCall } from "./resolveAxiosHelpers/processAxiosCall.js";
 import { ArrowFunctionExpression, FunctionDeclaration, Node } from "@babel/types";
 import { handleZDotCreate, processZDotCreateCall } from "./resolveAxiosHelpers/handleZDotCreate.js";
 import { directCallsWithoutAssignment } from "./resolveAxiosHelpers/directCallsWithoutAssignment.js";
+import { collectInterceptorHeaders } from "./resolveAxiosHelpers/interceptorHeaders.js";
+
+// Headers injected globally by axios request interceptors. Populated once at
+// the start of `resolveAxios` and read by the per-call processors so every
+// emitted endpoint reflects them.
+let globalInterceptorHeaders: { [key: string]: string } = {};
+export const getGlobalInterceptorHeaders = (): { [key: string]: string } => globalInterceptorHeaders;
 
 const traverse = _traverse.default;
 
@@ -46,6 +53,18 @@ export const getThirdArg = (ast: Node): string => {
  */
 const resolveAxios = async (chunks: Chunks, directory: string) => {
     console.log(chalk.cyan("[i] Resolving axios instances"));
+
+    // Discover headers added by axios request interceptors up-front. The same
+    // set applies to every request that flows through the shared axios client,
+    // so we attach it to each emitted endpoint below.
+    globalInterceptorHeaders = collectInterceptorHeaders(chunks);
+    if (Object.keys(globalInterceptorHeaders).length > 0) {
+        console.log(
+            chalk.cyan(
+                `[i] Detected ${Object.keys(globalInterceptorHeaders).length} interceptor-injected header(s): ${Object.keys(globalInterceptorHeaders).join(", ")}`
+            )
+        );
+    }
 
     const { axiosExportedFrom, axiosImportedTo } = findAxiosClients(chunks);
 

--- a/src/map/next_js/resolveAxios.ts
+++ b/src/map/next_js/resolveAxios.ts
@@ -64,11 +64,16 @@ const resolveAxios = async (chunks: Chunks, directory: string) => {
         const chunkCode = chunk.code;
         let axiosCallsFound = false;
 
-        const ast = parser.parse(chunkCode, {
-            sourceType: "unambiguous",
-            plugins: ["jsx", "typescript"],
-            errorRecovery: true,
-        });
+        let ast;
+        try {
+            ast = parser.parse(chunkCode, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+        } catch {
+            continue;
+        }
 
         // First, check for the n(...).Z.create() pattern
         const zDotCreateInstances: { [key: string]: string } = {};

--- a/src/map/next_js/resolveAxiosHelpers/astNodeToJsonString.ts
+++ b/src/map/next_js/resolveAxiosHelpers/astNodeToJsonString.ts
@@ -26,8 +26,8 @@ export const astNodeToJsonString = (node: Node, code: string): string => {
                         const value = astNodeToJsonString(prop.value, code);
                         return `${key}: ${value}`;
                     } else if (prop.type === "SpreadElement") {
-                        // Handle spread elements by trying to resolve them, or returning a placeholder
-                        return `"...${astNodeToJsonString(prop.argument, code)}"`;
+                        // Skip spread elements — they're code artifacts, not real body keys.
+                        return null;
                     }
                     return null; // Or handle other property types if necessary
                 })

--- a/src/map/next_js/resolveAxiosHelpers/findCrossChunkParams.ts
+++ b/src/map/next_js/resolveAxiosHelpers/findCrossChunkParams.ts
@@ -38,11 +38,16 @@ export const findCrossChunkParameters = (
     // Process each importing chunk
     for (const [importingChunkName, importingChunk] of importingChunks) {
         const chunkCode = importingChunk.code;
-        const ast = parser.parse(chunkCode, {
-            sourceType: "unambiguous",
-            plugins: ["jsx", "typescript"],
-            errorRecovery: true,
-        });
+        let ast;
+        try {
+            ast = parser.parse(chunkCode, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+        } catch {
+            continue;
+        }
 
         // Step 1: Find the third parameter in function declarations
         let thirdArg = "";

--- a/src/map/next_js/resolveAxiosHelpers/interceptorHeaders.ts
+++ b/src/map/next_js/resolveAxiosHelpers/interceptorHeaders.ts
@@ -130,10 +130,7 @@ export const collectInterceptorHeaders = (chunks: Chunks): { [key: string]: stri
         if (!methodNode?.body?.body) return null;
         for (const stmt of methodNode.body.body) {
             if (stmt.type === "ReturnStatement" && stmt.argument) {
-                if (
-                    stmt.argument.type === "FunctionExpression" ||
-                    stmt.argument.type === "ArrowFunctionExpression"
-                ) {
+                if (stmt.argument.type === "FunctionExpression" || stmt.argument.type === "ArrowFunctionExpression") {
                     return stmt.argument;
                 }
                 if (stmt.argument.type === "Identifier") {
@@ -173,10 +170,7 @@ export const collectInterceptorHeaders = (chunks: Chunks): { [key: string]: stri
 
                 if (arg.type === "CallExpression") {
                     const argCallee = arg.callee;
-                    if (
-                        argCallee.type === "MemberExpression" &&
-                        argCallee.property?.type === "Identifier"
-                    ) {
+                    if (argCallee.type === "MemberExpression" && argCallee.property?.type === "Identifier") {
                         const methodName = argCallee.property.name;
                         const matches = staticMethodIndex.get(methodName);
                         if (matches) {

--- a/src/map/next_js/resolveAxiosHelpers/interceptorHeaders.ts
+++ b/src/map/next_js/resolveAxiosHelpers/interceptorHeaders.ts
@@ -1,0 +1,203 @@
+import _traverse from "@babel/traverse";
+import parser from "@babel/parser";
+import { Chunks } from "../../../utility/interfaces.js";
+
+const traverse = _traverse.default;
+
+/**
+ * Detects HTTP headers injected by axios request interceptors so they can be
+ * surfaced on every traced call.
+ *
+ * Apps in this codebase wire global headers via:
+ *
+ *   axios.interceptors.request.use(X.Z.authHeaderInterceptor());
+ *
+ * where `authHeaderInterceptor()` returns `async function(e) { ... e.headers.X = "v" ... }`.
+ * The interceptor body assigns request headers, so any axios call going through
+ * this client implicitly carries those headers — but the tool used to miss them
+ * entirely because it only looked at per-call `headers:` options.
+ *
+ * Algorithm:
+ *   1. Scan every chunk for `*.interceptors.request.use(<arg>)` registrations.
+ *   2. Resolve `<arg>` to a function expression. Three argument shapes are common:
+ *        a. `<member>.<member>()` — a static class method returning a function.
+ *        b. `<localFunc>()` — local helper returning a function.
+ *        c. an inline function expression.
+ *   3. Find static class methods cross-chunk via `findStaticMethodInChunks` and
+ *      grab their return expression.
+ *   4. Walk the resolved function body and extract every assignment of the form
+ *      `<param>.headers.<key> = <literal>` or `<param>.headers["<key>"] = <literal>`.
+ *
+ * Returns a map of header name → header value collected across every interceptor
+ * found in the bundle.
+ */
+export const collectInterceptorHeaders = (chunks: Chunks): { [key: string]: string } => {
+    const headers: { [key: string]: string } = {};
+
+    const astCache = new Map<string, any>();
+    const parseAst = (chunkId: string, code: string): any | null => {
+        if (astCache.has(chunkId)) return astCache.get(chunkId);
+        try {
+            const ast = parser.parse(code, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+            astCache.set(chunkId, ast);
+            return ast;
+        } catch {
+            astCache.set(chunkId, null);
+            return null;
+        }
+    };
+
+    // Pre-build an index of static class methods by name so we can resolve
+    // `<X>.<Y>.<methodName>()` calls across chunks. Webpack class methods land
+    // as `static methodName() { return function(...){...} }` blocks.
+    const staticMethodIndex = new Map<string, Array<{ chunkId: string; node: any; ast: any }>>();
+
+    for (const [chunkId, chunk] of Object.entries(chunks)) {
+        const ast = parseAst(chunkId, chunk.code);
+        if (!ast) continue;
+        traverse(ast, {
+            ClassMethod(p) {
+                if (!p.node.static) return;
+                const key: any = p.node.key;
+                const methodName = key.type === "Identifier" ? key.name : null;
+                if (!methodName) return;
+                const arr = staticMethodIndex.get(methodName) ?? [];
+                arr.push({ chunkId, node: p.node, ast });
+                staticMethodIndex.set(methodName, arr);
+            },
+        });
+    }
+
+    const extractHeadersFromFunctionBody = (body: any) => {
+        if (!body) return;
+        const visitNode = (node: any) => {
+            if (!node || typeof node !== "object") return;
+            if (
+                node.type === "AssignmentExpression" &&
+                node.operator === "=" &&
+                node.left?.type === "MemberExpression" &&
+                node.left.object?.type === "MemberExpression" &&
+                node.left.object.property?.type === "Identifier" &&
+                node.left.object.property.name === "headers"
+            ) {
+                let key: string | null = null;
+                if (!node.left.computed && node.left.property?.type === "Identifier") {
+                    key = node.left.property.name;
+                } else if (node.left.computed && node.left.property?.type === "StringLiteral") {
+                    key = node.left.property.value;
+                }
+                let value: string | null = null;
+                if (node.right?.type === "StringLiteral") {
+                    value = node.right.value;
+                } else if (node.right?.type === "NumericLiteral") {
+                    value = String(node.right.value);
+                } else if (node.right?.type === "BooleanLiteral") {
+                    value = String(node.right.value);
+                } else if (node.right?.type === "BinaryExpression" && node.right.operator === "+") {
+                    // e.g. `"Bearer " + o` — capture the literal prefix.
+                    if (node.right.left?.type === "StringLiteral") {
+                        value = `${node.right.left.value}<token>`;
+                    } else if (node.right.right?.type === "StringLiteral") {
+                        value = `<value>${node.right.right.value}`;
+                    } else {
+                        value = "<value>";
+                    }
+                } else {
+                    value = `<${node.right?.type ?? "value"}>`;
+                }
+                if (key && value !== null) headers[key] = value;
+            }
+            for (const k of Object.keys(node)) {
+                if (k === "loc" || k === "start" || k === "end" || k === "leadingComments" || k === "trailingComments")
+                    continue;
+                const v = (node as any)[k];
+                if (Array.isArray(v)) {
+                    for (const item of v) visitNode(item);
+                } else if (v && typeof v === "object" && typeof v.type === "string") {
+                    visitNode(v);
+                }
+            }
+        };
+        visitNode(body);
+    };
+
+    // Given a static method node, return the returned function expression (if any).
+    const getReturnedFunction = (methodNode: any): any | null => {
+        if (!methodNode?.body?.body) return null;
+        for (const stmt of methodNode.body.body) {
+            if (stmt.type === "ReturnStatement" && stmt.argument) {
+                if (
+                    stmt.argument.type === "FunctionExpression" ||
+                    stmt.argument.type === "ArrowFunctionExpression"
+                ) {
+                    return stmt.argument;
+                }
+                if (stmt.argument.type === "Identifier") {
+                    // returns a named function — not handled here.
+                    return null;
+                }
+            }
+        }
+        return null;
+    };
+
+    for (const [chunkId, chunk] of Object.entries(chunks)) {
+        const ast = parseAst(chunkId, chunk.code);
+        if (!ast) continue;
+
+        traverse(ast, {
+            CallExpression(p) {
+                const callee: any = p.node.callee;
+                // Match `<X>.interceptors.request.use(<arg>)`.
+                if (
+                    callee.type !== "MemberExpression" ||
+                    callee.property?.type !== "Identifier" ||
+                    callee.property.name !== "use" ||
+                    callee.object?.type !== "MemberExpression" ||
+                    callee.object.property?.type !== "Identifier" ||
+                    callee.object.property.name !== "request" ||
+                    callee.object.object?.type !== "MemberExpression" ||
+                    callee.object.object.property?.type !== "Identifier" ||
+                    callee.object.object.property.name !== "interceptors"
+                ) {
+                    return;
+                }
+                const arg = p.node.arguments[0];
+                if (!arg) return;
+
+                let fnBody: any = null;
+
+                if (arg.type === "CallExpression") {
+                    const argCallee = arg.callee;
+                    if (
+                        argCallee.type === "MemberExpression" &&
+                        argCallee.property?.type === "Identifier"
+                    ) {
+                        const methodName = argCallee.property.name;
+                        const matches = staticMethodIndex.get(methodName);
+                        if (matches) {
+                            for (const m of matches) {
+                                const returnedFn = getReturnedFunction(m.node);
+                                if (returnedFn) {
+                                    fnBody = returnedFn.body;
+                                    extractHeadersFromFunctionBody(fnBody);
+                                }
+                            }
+                            return;
+                        }
+                    }
+                } else if (arg.type === "FunctionExpression" || arg.type === "ArrowFunctionExpression") {
+                    fnBody = arg.body;
+                }
+
+                if (fnBody) extractHeadersFromFunctionBody(fnBody);
+            },
+        });
+    }
+
+    return headers;
+};

--- a/src/map/next_js/resolveAxiosHelpers/processAxiosCall.ts
+++ b/src/map/next_js/resolveAxiosHelpers/processAxiosCall.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import chalk from "chalk";
 import { resolveNodeValue, substituteVariablesInString } from "../utils.js";
 import { astNodeToJsonString } from "./astNodeToJsonString.js";
+import { resolveBodyArg } from "./traceBody.js";
 import * as globals from "../../../utility/globals.js";
 import globalConfig from "../../../globalConfig.js";
 import { handleAxiosCreate } from "./handleAxiosCreate.js";
@@ -76,6 +77,17 @@ export const processAxiosCall = (
     // Get the webpack require function name (third arg) for enhanced resolution
     const thirdArgName = getThirdArg(ast);
 
+    // Axios HTTP-method calling conventions:
+    //   axios.get(url[, config])           — body lives only inside config.data (rare)
+    //   axios.delete(url[, config])        — same as get
+    //   axios.head/options(url[, config])  — same as get
+    //   axios.post(url[, body[, config]])  — body is the 2nd argument
+    //   axios.put/patch(url, body, config) — same as post
+    // For body-less methods we must treat arg[1] as config, not body, otherwise we
+    // mislabel query/header params as request bodies.
+    const bodyBearingMethods = new Set(["POST", "PUT", "PATCH"]);
+    const methodHasBodyArg = bodyBearingMethods.has(callMethod);
+
     if (path.parentPath.isCallExpression()) {
         const args = path.parentPath.node.arguments;
         if (args.length > 0) {
@@ -116,6 +128,8 @@ export const processAxiosCall = (
         if (args.length > 1) {
             const axiosSecondArg = args[1];
             if (axiosSecondArg.type === "ObjectExpression") {
+                // For body-less methods this whole object IS the config; for body-bearing
+                // methods only the inner `data` property is the body.
                 const headersProp = axiosSecondArg.properties.find(
                     (p) => p.type === "ObjectProperty" && p.key.type === "Identifier" && p.key.name === "headers"
                 );
@@ -147,8 +161,8 @@ export const processAxiosCall = (
                 }
 
                 if (dataProp && dataProp.type === "ObjectProperty") {
-                    callBody = astNodeToJsonString(dataProp.value, chunkCode);
-                } else if (!dataProp) {
+                    callBody = resolveBodyArg(dataProp.value, path.parentPath, ast, chunkCode, chunks, chunkName);
+                } else if (!dataProp && methodHasBodyArg) {
                     const otherProps = axiosSecondArg.properties.filter(
                         (p) => !(p.type === "ObjectProperty" && p.key.type === "Identifier" && p.key.name === "headers")
                     );
@@ -157,8 +171,8 @@ export const processAxiosCall = (
                         callBody = astNodeToJsonString(bodyObject, chunkCode);
                     }
                 }
-            } else {
-                callBody = astNodeToJsonString(axiosSecondArg, chunkCode);
+            } else if (methodHasBodyArg) {
+                callBody = resolveBodyArg(axiosSecondArg, path.parentPath, ast, chunkCode, chunks, chunkName);
             }
         }
     }

--- a/src/map/next_js/resolveAxiosHelpers/processAxiosCall.ts
+++ b/src/map/next_js/resolveAxiosHelpers/processAxiosCall.ts
@@ -9,7 +9,7 @@ import { resolveBodyArg } from "./traceBody.js";
 import * as globals from "../../../utility/globals.js";
 import globalConfig from "../../../globalConfig.js";
 import { handleAxiosCreate } from "./handleAxiosCreate.js";
-import { getThirdArg } from "../resolveAxios.js";
+import { getThirdArg, getGlobalInterceptorHeaders } from "../resolveAxios.js";
 
 /**
  * Gets the HTTP method from a method name.
@@ -188,21 +188,26 @@ export const processAxiosCall = (
         }
     }
 
+    // Merge globally-applied interceptor headers with per-call headers. Per-call
+    // values win on overlap since they're explicit overrides.
+    const interceptorHeaders = getGlobalInterceptorHeaders();
+    const mergedHeaders: { [key: string]: string } = { ...interceptorHeaders, ...callHeaders };
+
     console.log(chalk.blue(`[+] Found axios call in chunk ${chunkName} ("${functionFile}":${functionFileLine})`));
     console.log(chalk.green(`    URL: ${callUrl}`));
     console.log(chalk.green(`    Method: ${callMethod}`));
     if (callBody) {
         console.log(chalk.green(`    Body: ${callBody}`));
     }
-    if (Object.keys(callHeaders).length > 0) {
-        console.log(chalk.green(`    Headers: ${JSON.stringify(callHeaders)}`));
+    if (Object.keys(mergedHeaders).length > 0) {
+        console.log(chalk.green(`    Headers: ${JSON.stringify(mergedHeaders)}`));
     }
 
     globals.addOpenapiOutput({
         url: callUrl || "",
         method: callMethod || "",
         path: callUrl || "",
-        headers: callHeaders || {},
+        headers: mergedHeaders || {},
         body: callBody || "",
         chunkId: chunkName,
         functionFile: functionFile,

--- a/src/map/next_js/resolveAxiosHelpers/processDirectAxiosCall.ts
+++ b/src/map/next_js/resolveAxiosHelpers/processDirectAxiosCall.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import chalk from "chalk";
 import { resolveNodeValue, resolveStringOps, substituteVariablesInString } from "../utils.js";
 import { astNodeToJsonString } from "./astNodeToJsonString.js";
+import { resolveBodyArg } from "./traceBody.js";
 import * as globals from "../../../utility/globals.js";
 import globalConfig from "../../../globalConfig.js";
 import { getThirdArg } from "../resolveAxios.js";
@@ -72,9 +73,14 @@ export const processDirectAxiosCall = (
             }
         }
 
-        if (args.length > 1) {
+        // Axios calling convention is method-dependent. For body-less methods
+        // (GET/DELETE/HEAD/OPTIONS) `args[1]` is the config, not a body — surfacing
+        // it as "Body" misclassifies headers and query params as request payloads.
+        const bodyBearingMethods = new Set(["POST", "PUT", "PATCH"]);
+        const methodHasBodyArg = bodyBearingMethods.has(callMethod);
+        if (methodHasBodyArg && args.length > 1) {
             const axiosSecondArg = args[1];
-            callBody = astNodeToJsonString(axiosSecondArg, chunkCode);
+            callBody = resolveBodyArg(axiosSecondArg, path.parentPath, ast, chunkCode, chunks, chunkName);
         }
 
         if (args.length > 2) {

--- a/src/map/next_js/resolveAxiosHelpers/processDirectAxiosCall.ts
+++ b/src/map/next_js/resolveAxiosHelpers/processDirectAxiosCall.ts
@@ -8,7 +8,7 @@ import { astNodeToJsonString } from "./astNodeToJsonString.js";
 import { resolveBodyArg } from "./traceBody.js";
 import * as globals from "../../../utility/globals.js";
 import globalConfig from "../../../globalConfig.js";
-import { getThirdArg } from "../resolveAxios.js";
+import { getThirdArg, getGlobalInterceptorHeaders } from "../resolveAxios.js";
 
 const getHttpMethod = (methodName: string): string | null => {
     const upperCaseMethod = methodName.toUpperCase();
@@ -124,6 +124,9 @@ export const processDirectAxiosCall = (
         }
     }
 
+    const interceptorHeaders = getGlobalInterceptorHeaders();
+    const mergedHeaders: { [key: string]: string } = { ...interceptorHeaders, ...callHeaders };
+
     console.log(
         chalk.blue(`[+] Found direct axios call in chunk ${chunkName} ("${functionFile}":${functionFileLine})`)
     );
@@ -132,15 +135,15 @@ export const processDirectAxiosCall = (
     if (callBody) {
         console.log(chalk.green(`    Body: ${callBody}`));
     }
-    if (Object.keys(callHeaders).length > 0) {
-        console.log(chalk.green(`    Headers: ${JSON.stringify(callHeaders)}`));
+    if (Object.keys(mergedHeaders).length > 0) {
+        console.log(chalk.green(`    Headers: ${JSON.stringify(mergedHeaders)}`));
     }
 
     globals.addOpenapiOutput({
         url: callUrl || "",
         method: callMethod || "",
         path: callUrl || "",
-        headers: callHeaders || {},
+        headers: mergedHeaders || {},
         body: callBody || "",
         chunkId: chunkName,
         functionFile: functionFile,

--- a/src/map/next_js/resolveAxiosHelpers/traceAxiosInstanceExports.ts
+++ b/src/map/next_js/resolveAxiosHelpers/traceAxiosInstanceExports.ts
@@ -85,11 +85,16 @@ const findAxiosInstanceExport = (chunkId: string, axiosVarName: string, chunks: 
     }
 
     const chunkCode = chunk.code;
-    const ast = parser.parse(chunkCode, {
-        sourceType: "unambiguous",
-        plugins: ["jsx", "typescript"],
-        errorRecovery: true,
-    });
+    let ast;
+    try {
+        ast = parser.parse(chunkCode, {
+            sourceType: "unambiguous",
+            plugins: ["jsx", "typescript"],
+            errorRecovery: true,
+        });
+    } catch {
+        return null;
+    }
 
     let foundExportName: string | null = null;
 
@@ -180,11 +185,16 @@ const processImportingChunk = (
     }
 
     const chunkCode = importingChunk.code;
-    const ast = parser.parse(chunkCode, {
-        sourceType: "unambiguous",
-        plugins: ["jsx", "typescript"],
-        errorRecovery: true,
-    });
+    let ast;
+    try {
+        ast = parser.parse(chunkCode, {
+            sourceType: "unambiguous",
+            plugins: ["jsx", "typescript"],
+            errorRecovery: true,
+        });
+    } catch {
+        return;
+    }
 
     // Get the third argument (import function)
     const thirdArg = getThirdArg(ast);

--- a/src/map/next_js/resolveAxiosHelpers/traceBody.ts
+++ b/src/map/next_js/resolveAxiosHelpers/traceBody.ts
@@ -34,8 +34,28 @@ const parseChunkAst = (chunkId: string, code: string): any | null => {
  * we follow `e` to its declaration to find the real shape (e.g. another property of a state
  * value or a string literal).
  */
+// Reconstruct a dotted-path string for `a.b.c` / `a["b"]` / `this.x` chains so
+// downstream consumers see `"e.ssn"` instead of the raw `"[MemberExpression]"`
+// AST-tag fallback.
+const memberExpressionToString = (node: any): string => {
+    if (!node) return "?";
+    if (node.type === "Identifier") return node.name;
+    if (node.type === "ThisExpression") return "this";
+    if (node.type === "MemberExpression") {
+        const obj = memberExpressionToString(node.object);
+        if (node.computed) {
+            if (node.property.type === "StringLiteral") return `${obj}["${node.property.value}"]`;
+            if (node.property.type === "NumericLiteral") return `${obj}[${node.property.value}]`;
+            return `${obj}[?]`;
+        }
+        if (node.property.type === "Identifier") return `${obj}.${node.property.name}`;
+        return `${obj}.?`;
+    }
+    return "?";
+};
+
 const resolvePropertyValueNode = (node: Node, scopePath: NodePath, depth: number = 0): string => {
-    if (depth > 6) return `"[max depth]"`;
+    if (depth > 6) return `"<unknown>"`;
     if (!node) return `""`;
 
     if (node.type === "Identifier") {
@@ -43,7 +63,7 @@ const resolvePropertyValueNode = (node: Node, scopePath: NodePath, depth: number
         if (binding && binding.path.isVariableDeclarator() && binding.path.node.init) {
             return resolvePropertyValueNode(binding.path.node.init, binding.path, depth + 1);
         }
-        return `"[var ${node.name}]"`;
+        return `"<unknown>"`;
     }
 
     if (node.type === "ObjectExpression") {
@@ -71,7 +91,31 @@ const resolvePropertyValueNode = (node: Node, scopePath: NodePath, depth: number
     if (node.type === "BooleanLiteral") return String(node.value);
     if (node.type === "NullLiteral") return "null";
 
-    return `"[${node.type}]"`;
+    if (node.type === "MemberExpression") {
+        return JSON.stringify(memberExpressionToString(node));
+    }
+
+    // `new Date(...)` is the only NewExpression that shows up in practice (date
+    // pickers materializing `new Date(value)` before the POST). Treat it as a
+    // date placeholder; everything else degrades to "<unknown>".
+    if (node.type === "NewExpression") {
+        const callee: any = (node as any).callee;
+        if (callee && callee.type === "Identifier" && callee.name === "Date") return `"<date>"`;
+        return `"<unknown>"`;
+    }
+
+    if (node.type === "TemplateLiteral") return `"<string>"`;
+    if (node.type === "ArrayExpression") return `["<array>"]`;
+    if (node.type === "CallExpression") return `"<unknown>"`;
+    if (node.type === "ConditionalExpression") {
+        return resolvePropertyValueNode((node as any).consequent, scopePath, depth + 1);
+    }
+    if (node.type === "LogicalExpression") {
+        return resolvePropertyValueNode((node as any).left, scopePath, depth + 1);
+    }
+    if (node.type === "UnaryExpression" && (node as any).operator === "void") return `"<unknown>"`;
+
+    return `"<unknown>"`;
 };
 
 /**
@@ -949,6 +993,21 @@ export const maybeTraceBodyForIdentifier = (
  * Helper: rebuild the original astNodeToJsonString result, but for an Identifier-only
  * body, attempt to improve via taint trace.
  */
+/**
+ * Detects literal-undefined body arguments. Minified bundles emit `undefined` as
+ * the `void 0` shorthand (UnaryExpression with operator `void` over any operand),
+ * which axios treats as "no body". The bare identifier `undefined` is the same
+ * thing in any non-shadowed scope. Either form should map to an empty body so
+ * downstream consumers (openapi/postman) omit the request body entirely instead
+ * of rendering the literal string `"void 0"`.
+ */
+const isUndefinedBodyNode = (node: Node): boolean => {
+    if (!node) return false;
+    if (node.type === "UnaryExpression" && (node as any).operator === "void") return true;
+    if (node.type === "Identifier" && (node as any).name === "undefined") return true;
+    return false;
+};
+
 export const resolveBodyArg = (
     bodyArgNode: Node,
     parentCallPath: NodePath,
@@ -957,6 +1016,7 @@ export const resolveBodyArg = (
     chunks: Chunks | undefined,
     chunkId?: string
 ): string => {
+    if (isUndefinedBodyNode(bodyArgNode)) return "";
     if (bodyArgNode && bodyArgNode.type === "Identifier") {
         const traced = maybeTraceBodyForIdentifier(bodyArgNode, parentCallPath, ast, chunkCode, chunks, chunkId);
         if (traced) return traced;

--- a/src/map/next_js/resolveAxiosHelpers/traceBody.ts
+++ b/src/map/next_js/resolveAxiosHelpers/traceBody.ts
@@ -98,176 +98,507 @@ const objectExpressionToBody = (node: any, scopePath: NodePath): string => {
     return `{${props.join(", ")}}`;
 };
 
-/**
- * Discovers a zod-style schema in the chunk (e.g. `let w = x.z.object({...})`) and
- * converts it to a JSON-like body shape.
- *
- * Preference order:
- *   1. The schema referenced via an `objectSchema:` or `resolver:` JSX prop in the
- *      chunk (these point to the schema actually wired to the active form).
- *   2. The first standalone `z.object({...})` definition in the chunk.
- */
-const findZodSchemaInChunk = (ast: Node): string | null => {
-    let preferredSchemaVar: string | null = null;
+type SchemaRef =
+    | { kind: "local"; name: string }
+    | { kind: "cross"; importVar: string; exportName: string };
 
+/**
+ * Walks any zod-style schema initializer to extract the keys that will end up in
+ * the parsed value, even when the schema is composed of chained builder calls
+ * (extend / merge / pick / omit / partial / required / passthrough / strict / etc.).
+ *
+ * Supports cross-chunk references when `chunks` + `chunkId` + `thirdArgName` are
+ * supplied: `let x = thirdArg(NNN); x.SCHEMA.extend(...)`.
+ */
+const buildSchemaFromInitNode = (
+    initNode: any,
+    ast: Node,
+    chunks: Chunks | undefined,
+    chunkId: string | undefined,
+    thirdArgName: string | null,
+    visited: Set<string> = new Set(),
+    depth: number = 0,
+): { fields: Map<string, any>; pickKeys?: Set<string>; omitKeys?: Set<string> } | null => {
+    if (depth > 8) return null;
+    if (!initNode) return null;
+
+    // Schema reference: an Identifier pointing to another schema variable in this chunk.
+    if (initNode.type === "Identifier") {
+        return resolveSchemaVarToFields(initNode.name, ast, chunks, chunkId, thirdArgName, visited, depth + 1);
+    }
+
+    // Cross-chunk reference: `x.SCHEMA` where `x = thirdArg(NNN)`.
+    if (
+        initNode.type === "MemberExpression" &&
+        initNode.property.type === "Identifier" &&
+        initNode.object.type === "Identifier"
+    ) {
+        const result = resolveCrossChunkSchemaRef(
+            initNode.object.name,
+            initNode.property.name,
+            ast,
+            chunks,
+            chunkId,
+            thirdArgName,
+            visited,
+            depth + 1,
+        );
+        if (result) return result;
+    }
+
+    if (initNode.type === "CallExpression" && initNode.callee.type === "MemberExpression") {
+        const methodName =
+            initNode.callee.property.type === "Identifier" ? initNode.callee.property.name : null;
+        const base = initNode.callee.object;
+        const arg0 = initNode.arguments[0];
+
+        // <X>.object({ ... }) — terminal: the keys are the object literal's properties.
+        if (methodName === "object" && arg0 && arg0.type === "ObjectExpression") {
+            const fields = new Map<string, any>();
+            for (const prop of arg0.properties) {
+                if (prop.type !== "ObjectProperty") continue;
+                let key = "";
+                if ((prop.key as any).type === "Identifier") key = (prop.key as any).name;
+                else if ((prop.key as any).type === "StringLiteral") key = (prop.key as any).value;
+                else continue;
+                fields.set(key, prop.value);
+            }
+            return { fields };
+        }
+
+        // <base>.extend({ ... }) or <base>.merge(<schema>) — accumulate the base's
+        // fields then add the extension's.
+        if (methodName === "extend" || methodName === "merge") {
+            const baseResult =
+                buildSchemaFromInitNode(base, ast, chunks, chunkId, thirdArgName, visited, depth + 1) ?? {
+                    fields: new Map(),
+                };
+
+            if (arg0 && arg0.type === "ObjectExpression") {
+                for (const prop of arg0.properties) {
+                    if (prop.type !== "ObjectProperty") continue;
+                    let key = "";
+                    if ((prop.key as any).type === "Identifier") key = (prop.key as any).name;
+                    else if ((prop.key as any).type === "StringLiteral") key = (prop.key as any).value;
+                    else continue;
+                    baseResult.fields.set(key, prop.value);
+                }
+            } else if (arg0) {
+                const extResult = buildSchemaFromInitNode(
+                    arg0,
+                    ast,
+                    chunks,
+                    chunkId,
+                    thirdArgName,
+                    visited,
+                    depth + 1,
+                );
+                if (extResult) {
+                    for (const [k, v] of extResult.fields) baseResult.fields.set(k, v);
+                }
+            }
+            return baseResult;
+        }
+
+        // <base>.pick({ keyA: true, keyB: true }) / .omit(...) — narrow the field set.
+        // The pick/omit spec may be an inline ObjectExpression *or* an Identifier
+        // pointing to a `let spec = { keyA: !0, ... }` declaration earlier in the chunk.
+        if (methodName === "pick" || methodName === "omit") {
+            let specObj: any = null;
+            if (arg0 && arg0.type === "ObjectExpression") {
+                specObj = arg0;
+            } else if (arg0 && arg0.type === "Identifier") {
+                traverse(ast as any, {
+                    VariableDeclarator(p) {
+                        if (specObj) return;
+                        if (
+                            p.node.id.type === "Identifier" &&
+                            p.node.id.name === arg0.name &&
+                            p.node.init &&
+                            p.node.init.type === "ObjectExpression"
+                        ) {
+                            specObj = p.node.init;
+                            p.stop();
+                        }
+                    },
+                });
+            }
+            if (!specObj) {
+                return buildSchemaFromInitNode(base, ast, chunks, chunkId, thirdArgName, visited, depth + 1);
+            }
+            const keys = new Set<string>();
+            for (const prop of specObj.properties) {
+                if (prop.type !== "ObjectProperty") continue;
+                let key = "";
+                if ((prop.key as any).type === "Identifier") key = (prop.key as any).name;
+                else if ((prop.key as any).type === "StringLiteral") key = (prop.key as any).value;
+                else continue;
+                keys.add(key);
+            }
+            const baseResult = buildSchemaFromInitNode(
+                base,
+                ast,
+                chunks,
+                chunkId,
+                thirdArgName,
+                visited,
+                depth + 1,
+            );
+            if (!baseResult) return { fields: new Map(), [methodName === "pick" ? "pickKeys" : "omitKeys"]: keys };
+            if (methodName === "pick") {
+                const filtered = new Map<string, any>();
+                for (const [k, v] of baseResult.fields) {
+                    if (keys.has(k)) filtered.set(k, v);
+                }
+                return { fields: filtered };
+            } else {
+                const filtered = new Map<string, any>();
+                for (const [k, v] of baseResult.fields) {
+                    if (!keys.has(k)) filtered.set(k, v);
+                }
+                return { fields: filtered };
+            }
+        }
+
+        // Pass-through wrappers — schema stays the same.
+        if (
+            methodName === "partial" ||
+            methodName === "required" ||
+            methodName === "passthrough" ||
+            methodName === "strict" ||
+            methodName === "strip" ||
+            methodName === "describe" ||
+            methodName === "refine" ||
+            methodName === "superRefine" ||
+            methodName === "transform" ||
+            methodName === "default" ||
+            methodName === "optional" ||
+            methodName === "nullable" ||
+            methodName === "nullish" ||
+            methodName === "readonly" ||
+            methodName === "brand" ||
+            methodName === "catch" ||
+            methodName === "innerType" ||
+            methodName === "unwrap" ||
+            methodName === "removeDefault" ||
+            methodName === "removeCatch" ||
+            methodName === "promise" ||
+            methodName === "array"
+        ) {
+            return buildSchemaFromInitNode(base, ast, chunks, chunkId, thirdArgName, visited, depth + 1);
+        }
+    }
+
+    return null;
+};
+
+/**
+ * Resolves a local schema variable name to its keys, recursively chasing through
+ * builder chains and aliases.
+ */
+const resolveSchemaVarToFields = (
+    varName: string,
+    ast: Node,
+    chunks: Chunks | undefined,
+    chunkId: string | undefined,
+    thirdArgName: string | null,
+    visited: Set<string>,
+    depth: number,
+): { fields: Map<string, any> } | null => {
+    const cycleKey = `${chunkId ?? "_"}:${varName}`;
+    if (visited.has(cycleKey)) return null;
+    visited.add(cycleKey);
+
+    let initNode: any = null;
     traverse(ast as any, {
-        ObjectProperty(p) {
-            if (preferredSchemaVar) return;
-            const key = p.node.key as any;
-            const keyName = key.type === "Identifier" ? key.name : key.type === "StringLiteral" ? key.value : null;
-            if (keyName === "objectSchema") {
-                if (p.node.value.type === "Identifier") {
-                    preferredSchemaVar = p.node.value.name;
-                }
-            } else if (keyName === "resolver") {
-                const v: any = p.node.value;
-                if (v.type === "CallExpression" && v.arguments.length > 0 && v.arguments[0].type === "Identifier") {
-                    preferredSchemaVar = v.arguments[0].name;
-                }
+        VariableDeclarator(p) {
+            if (initNode) return;
+            if (p.node.id.type === "Identifier" && p.node.id.name === varName && p.node.init) {
+                initNode = p.node.init;
+                p.stop();
+            }
+        },
+    });
+    if (!initNode) return null;
+
+    const built = buildSchemaFromInitNode(initNode, ast, chunks, chunkId, thirdArgName, visited, depth);
+    return built ? { fields: built.fields } : null;
+};
+
+/**
+ * Resolves `<importVar>.<exportName>` where `<importVar> = <thirdArg>(<chunkId>)`,
+ * locating the corresponding schema in the imported chunk.
+ */
+const resolveCrossChunkSchemaRef = (
+    importVar: string,
+    exportName: string,
+    ast: Node,
+    chunks: Chunks | undefined,
+    _chunkId: string | undefined,
+    thirdArgName: string | null,
+    visited: Set<string>,
+    depth: number,
+): { fields: Map<string, any> } | null => {
+    if (!chunks || !thirdArgName) return null;
+
+    // Identify which chunk `importVar` points to in the current chunk.
+    let targetChunkId: string | null = null;
+    traverse(ast as any, {
+        VariableDeclarator(p) {
+            if (targetChunkId) return;
+            if (
+                p.node.id.type === "Identifier" &&
+                p.node.id.name === importVar &&
+                p.node.init &&
+                p.node.init.type === "CallExpression" &&
+                p.node.init.callee.type === "Identifier" &&
+                p.node.init.callee.name === thirdArgName &&
+                p.node.init.arguments.length === 1 &&
+                p.node.init.arguments[0].type === "NumericLiteral"
+            ) {
+                targetChunkId = String((p.node.init.arguments[0] as any).value);
+                p.stop();
             }
         },
     });
 
-    const resolveSchemaVar = (varName: string, depth: number = 0): any => {
-        if (depth > 6) return null;
-        let initNode: any = null;
-        traverse(ast as any, {
-            VariableDeclarator(p) {
-                if (initNode) return;
-                if (p.node.id.type === "Identifier" && p.node.id.name === varName && p.node.init) {
-                    initNode = p.node.init;
-                    p.stop();
-                }
-            },
-        });
-        if (!initNode) return null;
+    if (!targetChunkId || !chunks[targetChunkId]) return null;
 
-        if (
-            initNode.type === "CallExpression" &&
-            initNode.callee.type === "MemberExpression" &&
-            initNode.callee.property.type === "Identifier" &&
-            initNode.callee.property.name === "object" &&
-            initNode.arguments.length === 1 &&
-            initNode.arguments[0].type === "ObjectExpression"
-        ) {
-            return initNode.arguments[0];
-        }
+    const targetChunk = chunks[targetChunkId];
+    const targetAst = parseChunkAst(targetChunkId, targetChunk.code);
+    if (!targetAst) return null;
 
-        if (
-            initNode.type === "CallExpression" &&
-            initNode.callee.type === "MemberExpression" &&
-            initNode.callee.property.type === "Identifier" &&
-            (initNode.callee.property.name === "extend" || initNode.callee.property.name === "merge")
-        ) {
-            const baseObj = initNode.callee.object;
-            if (baseObj.type === "Identifier") {
-                return resolveSchemaVar(baseObj.name, depth + 1);
+    // Find which local variable backs the requested export.
+    let exportVarName: string | null = null;
+    traverse(targetAst, {
+        CallExpression(p) {
+            if (exportVarName) return;
+            const callee = p.node.callee;
+            if (
+                callee.type !== "MemberExpression" ||
+                callee.property.type !== "Identifier" ||
+                callee.property.name !== "d" ||
+                p.node.arguments.length !== 2 ||
+                p.node.arguments[1].type !== "ObjectExpression"
+            ) {
+                return;
             }
-        }
-
-        if (initNode.type === "Identifier") {
-            return resolveSchemaVar(initNode.name, depth + 1);
-        }
-
-        return null;
-    };
-
-    let schemaNode: any = null;
-
-    if (preferredSchemaVar) {
-        schemaNode = resolveSchemaVar(preferredSchemaVar);
-    }
-
-    if (!schemaNode) {
-        traverse(ast as any, {
-            CallExpression(p) {
-                if (schemaNode) return;
-                const callee = p.node.callee;
+            for (const prop of (p.node.arguments[1] as any).properties) {
                 if (
-                    callee.type === "MemberExpression" &&
-                    callee.property.type === "Identifier" &&
-                    callee.property.name === "object" &&
-                    p.node.arguments.length === 1 &&
-                    p.node.arguments[0].type === "ObjectExpression"
+                    prop.type !== "ObjectProperty" ||
+                    prop.key.type !== "Identifier" ||
+                    prop.key.name !== exportName
                 ) {
-                    schemaNode = p.node.arguments[0];
-                    p.stop();
+                    continue;
                 }
-            },
-        });
+                const value = prop.value;
+                if (value.type !== "FunctionExpression" && value.type !== "ArrowFunctionExpression") continue;
+                let returnNode: any = null;
+                if (value.type === "ArrowFunctionExpression" && value.body.type !== "BlockStatement") {
+                    returnNode = value.body;
+                } else if (value.body.type === "BlockStatement") {
+                    const ret = value.body.body.find((s: any) => s.type === "ReturnStatement");
+                    if (ret) returnNode = (ret as any).argument;
+                }
+                if (returnNode && returnNode.type === "Identifier") {
+                    exportVarName = returnNode.name;
+                    return;
+                }
+            }
+        },
+    });
+    if (!exportVarName) return null;
+
+    const targetThirdArg = findThirdArgInAst(targetAst);
+    return resolveSchemaVarToFields(exportVarName, targetAst, chunks, targetChunkId, targetThirdArg, visited, depth);
+};
+
+const zodTypeToPlaceholder = (valueNode: any): string => {
+    if (!valueNode) return `"<unknown>"`;
+    let cur = valueNode;
+    while (
+        cur &&
+        cur.type === "CallExpression" &&
+        cur.callee.type === "MemberExpression" &&
+        cur.callee.property.type === "Identifier" &&
+        ["optional", "nullable", "nullish", "min", "max", "length", "email", "url", "uuid", "regex", "trim", "default", "describe", "refine", "transform", "superRefine"].includes(
+            cur.callee.property.name,
+        )
+    ) {
+        cur = cur.callee.object;
     }
+
+    if (
+        cur &&
+        cur.type === "CallExpression" &&
+        cur.callee.type === "MemberExpression" &&
+        cur.callee.property.type === "Identifier"
+    ) {
+        const name = cur.callee.property.name;
+        switch (name) {
+            case "string":
+                return `"<string>"`;
+            case "number":
+                return `"<number>"`;
+            case "boolean":
+                return `"<boolean>"`;
+            case "bigint":
+                return `"<bigint>"`;
+            case "date":
+                return `"<date>"`;
+            case "array":
+                return `["<array>"]`;
+            case "object":
+                if (cur.arguments.length === 1 && cur.arguments[0].type === "ObjectExpression") {
+                    return fieldsObjectToString(cur.arguments[0]);
+                }
+                return `"<object>"`;
+            case "enum":
+                return `"<enum>"`;
+            case "literal":
+                if (cur.arguments.length === 1 && cur.arguments[0].type === "StringLiteral") {
+                    return JSON.stringify(cur.arguments[0].value);
+                }
+                return `"<literal>"`;
+            case "coerce":
+                return `"<coerce>"`;
+            default:
+                return `"<${name}>"`;
+        }
+    }
+
+    return `"<unknown>"`;
+};
+
+const fieldsObjectToString = (objNode: any): string => {
+    const parts = objNode.properties
+        .map((prop: any) => {
+            if (prop.type !== "ObjectProperty") return null;
+            let key = "";
+            if (prop.key.type === "Identifier") key = prop.key.name;
+            else if (prop.key.type === "StringLiteral") key = prop.key.value;
+            else return null;
+            return `"${key}": ${zodTypeToPlaceholder(prop.value)}`;
+        })
+        .filter(Boolean);
+    return `{${parts.join(", ")}}`;
+};
+
+const fieldsMapToString = (fields: Map<string, any>): string => {
+    const parts: string[] = [];
+    for (const [k, v] of fields) {
+        parts.push(`"${k}": ${zodTypeToPlaceholder(v)}`);
+    }
+    return `{${parts.join(", ")}}`;
+};
+
+/**
+ * Discovers zod-style schemas in the chunk (e.g. `let w = x.z.object({...})`,
+ * `objectSchema: o.VG`) and converts them to a JSON-like body shape.
+ *
+ * Preference order:
+ *   1. Schemas referenced via `objectSchema:` or `resolver:` JSX props. Supports
+ *      both local Identifiers and cross-chunk MemberExpressions (`o.VG`).
+ *      Multiple matches are merged so multi-step forms whose final POST body is
+ *      the union of all step schemas come out closer to reality.
+ *   2. The first standalone `z.object({...})` definition in the chunk.
+ */
+const findZodSchemaInChunk = (
+    ast: Node,
+    chunks?: Chunks,
+    chunkId?: string,
+    thirdArgName?: string | null,
+): string | null => {
+    const schemaRefs: SchemaRef[] = [];
+
+    traverse(ast as any, {
+        ObjectProperty(p) {
+            const key = p.node.key as any;
+            const keyName = key.type === "Identifier" ? key.name : key.type === "StringLiteral" ? key.value : null;
+            const value: any = p.node.value;
+            const captureFromValue = (v: any) => {
+                if (!v) return;
+                if (v.type === "Identifier") {
+                    schemaRefs.push({ kind: "local", name: v.name });
+                } else if (
+                    v.type === "MemberExpression" &&
+                    v.object.type === "Identifier" &&
+                    v.property.type === "Identifier"
+                ) {
+                    schemaRefs.push({ kind: "cross", importVar: v.object.name, exportName: v.property.name });
+                }
+            };
+            if (keyName === "objectSchema") {
+                captureFromValue(value);
+            } else if (keyName === "resolver" && value.type === "CallExpression" && value.arguments.length > 0) {
+                captureFromValue(value.arguments[0]);
+            }
+        },
+    });
+
+    const resolvedFieldMaps: Map<string, any>[] = [];
+    const seen = new Set<string>();
+    for (const ref of schemaRefs) {
+        const key = ref.kind === "local" ? `L:${ref.name}` : `X:${ref.importVar}.${ref.exportName}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        // Each top-level schema ref starts with a fresh visited set — otherwise
+        // resolving the first schema would block the second from following
+        // shared base schemas (e.g. multi-step forms where every step extends
+        // the same `p`).
+        const refVisited = new Set<string>();
+        let resolved: { fields: Map<string, any> } | null = null;
+        if (ref.kind === "local") {
+            resolved = resolveSchemaVarToFields(ref.name, ast, chunks, chunkId, thirdArgName ?? null, refVisited, 0);
+        } else {
+            resolved = resolveCrossChunkSchemaRef(
+                ref.importVar,
+                ref.exportName,
+                ast,
+                chunks,
+                chunkId,
+                thirdArgName ?? null,
+                refVisited,
+                0,
+            );
+        }
+        if (resolved && resolved.fields.size > 0) {
+            resolvedFieldMaps.push(resolved.fields);
+        }
+    }
+
+    if (resolvedFieldMaps.length > 0) {
+        // Merge fields from all referenced schemas. For multi-step forms this gives
+        // the union — the final POST body is generally the accumulated form state.
+        const merged = new Map<string, any>();
+        for (const fields of resolvedFieldMaps) {
+            for (const [k, v] of fields) merged.set(k, v);
+        }
+        return fieldsMapToString(merged);
+    }
+
+    // Fallback: the first standalone `<X>.object({...})` in the chunk.
+    let schemaNode: any = null;
+    traverse(ast as any, {
+        CallExpression(p) {
+            if (schemaNode) return;
+            const callee = p.node.callee;
+            if (
+                callee.type === "MemberExpression" &&
+                callee.property.type === "Identifier" &&
+                callee.property.name === "object" &&
+                p.node.arguments.length === 1 &&
+                p.node.arguments[0].type === "ObjectExpression"
+            ) {
+                schemaNode = p.node.arguments[0];
+                p.stop();
+            }
+        },
+    });
 
     if (!schemaNode) return null;
-
-    const zodTypeToPlaceholder = (valueNode: any): string => {
-        let cur = valueNode;
-        while (
-            cur &&
-            cur.type === "CallExpression" &&
-            cur.callee.type === "MemberExpression" &&
-            cur.callee.property.type === "Identifier" &&
-            ["optional", "nullable", "nullish", "min", "max", "length", "email", "url", "uuid", "regex", "trim", "default", "describe", "refine", "transform"].includes(
-                cur.callee.property.name,
-            )
-        ) {
-            cur = cur.callee.object;
-        }
-
-        if (
-            cur &&
-            cur.type === "CallExpression" &&
-            cur.callee.type === "MemberExpression" &&
-            cur.callee.property.type === "Identifier"
-        ) {
-            const name = cur.callee.property.name;
-            switch (name) {
-                case "string":
-                    return `"<string>"`;
-                case "number":
-                    return `"<number>"`;
-                case "boolean":
-                    return `"<boolean>"`;
-                case "bigint":
-                    return `"<bigint>"`;
-                case "date":
-                    return `"<date>"`;
-                case "array":
-                    return `["<array>"]`;
-                case "object":
-                    if (cur.arguments.length === 1 && cur.arguments[0].type === "ObjectExpression") {
-                        return buildSchemaBody(cur.arguments[0]);
-                    }
-                    return `"<object>"`;
-                case "enum":
-                    return `"<enum>"`;
-                case "literal":
-                    if (cur.arguments.length === 1 && cur.arguments[0].type === "StringLiteral") {
-                        return JSON.stringify(cur.arguments[0].value);
-                    }
-                    return `"<literal>"`;
-                default:
-                    return `"<${name}>"`;
-            }
-        }
-
-        return `"<unknown>"`;
-    };
-
-    const buildSchemaBody = (objNode: any): string => {
-        const parts = objNode.properties
-            .map((prop: any) => {
-                if (prop.type !== "ObjectProperty") return null;
-                let key = "";
-                if (prop.key.type === "Identifier") key = prop.key.name;
-                else if (prop.key.type === "StringLiteral") key = prop.key.value;
-                else return null;
-                return `"${key}": ${zodTypeToPlaceholder(prop.value)}`;
-            })
-            .filter(Boolean);
-        return `{${parts.join(", ")}}`;
-    };
-
-    return buildSchemaBody(schemaNode);
+    return fieldsObjectToString(schemaNode);
 };
 
 /**
@@ -474,7 +805,31 @@ export const traceIdentifierBody = (
 
     const binding = path.scope.getBinding(paramName);
     if (!binding) return null;
-    if (binding.kind !== "param") return null;
+
+    // Non-parameter bindings (let / const / var) can still have a useful initializer
+    // — most commonly `let r = { reportType: n.type, ...e }` immediately before an
+    // axios call. Render the initializer's ObjectExpression directly when we have one.
+    if (binding.kind !== "param") {
+        if (binding.path.isVariableDeclarator() && binding.path.node.init) {
+            const init: any = binding.path.node.init;
+            if (init.type === "ObjectExpression") {
+                return objectExpressionToBody(init, binding.path as NodePath);
+            }
+            if (init.type === "Identifier") {
+                return traceIdentifierBody(
+                    init.name,
+                    binding.path as NodePath,
+                    ast,
+                    chunkCode,
+                    chunks,
+                    visited,
+                    depth + 1,
+                    chunkId,
+                );
+            }
+        }
+        return null;
+    }
 
     const funcPath = binding.path.find((p) => p.isFunction()) as NodePath | null;
     if (!funcPath) return null;
@@ -497,8 +852,10 @@ export const traceIdentifierBody = (
         }
     }
 
+    const localThirdArg = findThirdArgInAst(ast);
+
     if (!funcName) {
-        return findZodSchemaInChunk(ast);
+        return findZodSchemaInChunk(ast, chunks, chunkId, localThirdArg);
     }
 
     const cycleKey = `${chunkId ?? "_"}:${funcName}:${paramIndex}`;
@@ -564,11 +921,14 @@ export const traceIdentifierBody = (
         if (crossChunk) return crossChunk;
     }
 
-    if (directCallCount === 0) {
-        return findZodSchemaInChunk(ast);
-    }
-
-    return null;
+    // Schema fallback. Used when:
+    //   - the function is never called directly (only passed as a callback to a
+    //     form/library), or
+    //   - it *is* called locally but with state/non-traceable identifiers (so the
+    //     local callsite gave us nothing).
+    // The schema search prefers `objectSchema:` / `resolver:` JSX props, which
+    // are usually the right wiring even when the handler's data flow is opaque.
+    return findZodSchemaInChunk(ast, chunks, chunkId, localThirdArg);
 };
 
 /**

--- a/src/map/next_js/resolveAxiosHelpers/traceBody.ts
+++ b/src/map/next_js/resolveAxiosHelpers/traceBody.ts
@@ -98,9 +98,7 @@ const objectExpressionToBody = (node: any, scopePath: NodePath): string => {
     return `{${props.join(", ")}}`;
 };
 
-type SchemaRef =
-    | { kind: "local"; name: string }
-    | { kind: "cross"; importVar: string; exportName: string };
+type SchemaRef = { kind: "local"; name: string } | { kind: "cross"; importVar: string; exportName: string };
 
 /**
  * Walks any zod-style schema initializer to extract the keys that will end up in
@@ -117,7 +115,7 @@ const buildSchemaFromInitNode = (
     chunkId: string | undefined,
     thirdArgName: string | null,
     visited: Set<string> = new Set(),
-    depth: number = 0,
+    depth: number = 0
 ): { fields: Map<string, any>; pickKeys?: Set<string>; omitKeys?: Set<string> } | null => {
     if (depth > 8) return null;
     if (!initNode) return null;
@@ -141,14 +139,13 @@ const buildSchemaFromInitNode = (
             chunkId,
             thirdArgName,
             visited,
-            depth + 1,
+            depth + 1
         );
         if (result) return result;
     }
 
     if (initNode.type === "CallExpression" && initNode.callee.type === "MemberExpression") {
-        const methodName =
-            initNode.callee.property.type === "Identifier" ? initNode.callee.property.name : null;
+        const methodName = initNode.callee.property.type === "Identifier" ? initNode.callee.property.name : null;
         const base = initNode.callee.object;
         const arg0 = initNode.arguments[0];
 
@@ -169,10 +166,17 @@ const buildSchemaFromInitNode = (
         // <base>.extend({ ... }) or <base>.merge(<schema>) — accumulate the base's
         // fields then add the extension's.
         if (methodName === "extend" || methodName === "merge") {
-            const baseResult =
-                buildSchemaFromInitNode(base, ast, chunks, chunkId, thirdArgName, visited, depth + 1) ?? {
-                    fields: new Map(),
-                };
+            const baseResult = buildSchemaFromInitNode(
+                base,
+                ast,
+                chunks,
+                chunkId,
+                thirdArgName,
+                visited,
+                depth + 1
+            ) ?? {
+                fields: new Map(),
+            };
 
             if (arg0 && arg0.type === "ObjectExpression") {
                 for (const prop of arg0.properties) {
@@ -184,15 +188,7 @@ const buildSchemaFromInitNode = (
                     baseResult.fields.set(key, prop.value);
                 }
             } else if (arg0) {
-                const extResult = buildSchemaFromInitNode(
-                    arg0,
-                    ast,
-                    chunks,
-                    chunkId,
-                    thirdArgName,
-                    visited,
-                    depth + 1,
-                );
+                const extResult = buildSchemaFromInitNode(arg0, ast, chunks, chunkId, thirdArgName, visited, depth + 1);
                 if (extResult) {
                     for (const [k, v] of extResult.fields) baseResult.fields.set(k, v);
                 }
@@ -235,15 +231,7 @@ const buildSchemaFromInitNode = (
                 else continue;
                 keys.add(key);
             }
-            const baseResult = buildSchemaFromInitNode(
-                base,
-                ast,
-                chunks,
-                chunkId,
-                thirdArgName,
-                visited,
-                depth + 1,
-            );
+            const baseResult = buildSchemaFromInitNode(base, ast, chunks, chunkId, thirdArgName, visited, depth + 1);
             if (!baseResult) return { fields: new Map(), [methodName === "pick" ? "pickKeys" : "omitKeys"]: keys };
             if (methodName === "pick") {
                 const filtered = new Map<string, any>();
@@ -303,7 +291,7 @@ const resolveSchemaVarToFields = (
     chunkId: string | undefined,
     thirdArgName: string | null,
     visited: Set<string>,
-    depth: number,
+    depth: number
 ): { fields: Map<string, any> } | null => {
     const cycleKey = `${chunkId ?? "_"}:${varName}`;
     if (visited.has(cycleKey)) return null;
@@ -337,7 +325,7 @@ const resolveCrossChunkSchemaRef = (
     _chunkId: string | undefined,
     thirdArgName: string | null,
     visited: Set<string>,
-    depth: number,
+    depth: number
 ): { fields: Map<string, any> } | null => {
     if (!chunks || !thirdArgName) return null;
 
@@ -384,11 +372,7 @@ const resolveCrossChunkSchemaRef = (
                 return;
             }
             for (const prop of (p.node.arguments[1] as any).properties) {
-                if (
-                    prop.type !== "ObjectProperty" ||
-                    prop.key.type !== "Identifier" ||
-                    prop.key.name !== exportName
-                ) {
+                if (prop.type !== "ObjectProperty" || prop.key.type !== "Identifier" || prop.key.name !== exportName) {
                     continue;
                 }
                 const value = prop.value;
@@ -421,9 +405,24 @@ const zodTypeToPlaceholder = (valueNode: any): string => {
         cur.type === "CallExpression" &&
         cur.callee.type === "MemberExpression" &&
         cur.callee.property.type === "Identifier" &&
-        ["optional", "nullable", "nullish", "min", "max", "length", "email", "url", "uuid", "regex", "trim", "default", "describe", "refine", "transform", "superRefine"].includes(
-            cur.callee.property.name,
-        )
+        [
+            "optional",
+            "nullable",
+            "nullish",
+            "min",
+            "max",
+            "length",
+            "email",
+            "url",
+            "uuid",
+            "regex",
+            "trim",
+            "default",
+            "describe",
+            "refine",
+            "transform",
+            "superRefine",
+        ].includes(cur.callee.property.name)
     ) {
         cur = cur.callee.object;
     }
@@ -507,7 +506,7 @@ const findZodSchemaInChunk = (
     ast: Node,
     chunks?: Chunks,
     chunkId?: string,
-    thirdArgName?: string | null,
+    thirdArgName?: string | null
 ): string | null => {
     const schemaRefs: SchemaRef[] = [];
 
@@ -560,7 +559,7 @@ const findZodSchemaInChunk = (
                 chunkId,
                 thirdArgName ?? null,
                 refVisited,
-                0,
+                0
             );
         }
         if (resolved && resolved.fields.size > 0) {
@@ -681,7 +680,7 @@ const crossChunkTrace = (
     currentAst: Node,
     chunks: Chunks,
     visited: Set<string>,
-    depth: number,
+    depth: number
 ): string | null => {
     const exportName = findExportNameForFunc(currentAst, funcName);
     if (!exportName) return null;
@@ -758,7 +757,7 @@ const crossChunkTrace = (
                         chunks,
                         visited,
                         depth + 1,
-                        otherChunkId,
+                        otherChunkId
                     );
                     if (traced) {
                         resolved = traced;
@@ -799,7 +798,7 @@ export const traceIdentifierBody = (
     chunks: Chunks | undefined,
     visited: Set<string> = new Set(),
     depth: number = 0,
-    chunkId?: string,
+    chunkId?: string
 ): string | null => {
     if (depth > 6) return null;
 
@@ -824,7 +823,7 @@ export const traceIdentifierBody = (
                     chunks,
                     visited,
                     depth + 1,
-                    chunkId,
+                    chunkId
                 );
             }
         }
@@ -835,9 +834,7 @@ export const traceIdentifierBody = (
     if (!funcPath) return null;
 
     const funcNode: any = funcPath.node;
-    const paramIndex = funcNode.params.findIndex(
-        (p: any) => p.type === "Identifier" && p.name === paramName,
-    );
+    const paramIndex = funcNode.params.findIndex((p: any) => p.type === "Identifier" && p.name === paramName);
     if (paramIndex === -1) return null;
 
     let funcName: string | null = null;
@@ -900,7 +897,7 @@ export const traceIdentifierBody = (
                         chunks,
                         visited,
                         depth + 1,
-                        chunkId,
+                        chunkId
                     );
                     if (traced) {
                         resolved = traced;
@@ -941,7 +938,7 @@ export const maybeTraceBodyForIdentifier = (
     ast: Node,
     chunkCode: string,
     chunks: Chunks | undefined,
-    chunkId?: string,
+    chunkId?: string
 ): string | null => {
     if (!bodyArgNode || bodyArgNode.type !== "Identifier") return null;
     const idName = (bodyArgNode as any).name as string;
@@ -958,7 +955,7 @@ export const resolveBodyArg = (
     ast: Node,
     chunkCode: string,
     chunks: Chunks | undefined,
-    chunkId?: string,
+    chunkId?: string
 ): string => {
     if (bodyArgNode && bodyArgNode.type === "Identifier") {
         const traced = maybeTraceBodyForIdentifier(bodyArgNode, parentCallPath, ast, chunkCode, chunks, chunkId);

--- a/src/map/next_js/resolveAxiosHelpers/traceBody.ts
+++ b/src/map/next_js/resolveAxiosHelpers/traceBody.ts
@@ -1,0 +1,608 @@
+import { NodePath } from "@babel/traverse";
+import _traverse from "@babel/traverse";
+import parser from "@babel/parser";
+import { Node } from "@babel/types";
+import { Chunks } from "../../../utility/interfaces.js";
+import { astNodeToJsonString } from "./astNodeToJsonString.js";
+
+const traverse = _traverse.default;
+
+// AST parse cache keyed by chunk id, so that cross-chunk tracing doesn't reparse
+// the same chunk file dozens of times across recursive calls.
+const astCache: Map<string, any> = new Map();
+const parseChunkAst = (chunkId: string, code: string): any | null => {
+    const cached = astCache.get(chunkId);
+    if (cached !== undefined) return cached;
+    try {
+        const ast = parser.parse(code, {
+            sourceType: "unambiguous",
+            plugins: ["jsx", "typescript"],
+            errorRecovery: true,
+        });
+        astCache.set(chunkId, ast);
+        return ast;
+    } catch {
+        astCache.set(chunkId, null);
+        return null;
+    }
+};
+
+/**
+ * Resolves an Identifier value by walking variable initializers in scope.
+ *
+ * Used when an object property is assigned an identifier like `{username: e, password: t}` —
+ * we follow `e` to its declaration to find the real shape (e.g. another property of a state
+ * value or a string literal).
+ */
+const resolvePropertyValueNode = (node: Node, scopePath: NodePath, depth: number = 0): string => {
+    if (depth > 6) return `"[max depth]"`;
+    if (!node) return `""`;
+
+    if (node.type === "Identifier") {
+        const binding = scopePath.scope.getBinding(node.name);
+        if (binding && binding.path.isVariableDeclarator() && binding.path.node.init) {
+            return resolvePropertyValueNode(binding.path.node.init, binding.path, depth + 1);
+        }
+        return `"[var ${node.name}]"`;
+    }
+
+    if (node.type === "ObjectExpression") {
+        const props = node.properties
+            .map((prop: any) => {
+                if (prop.type === "ObjectProperty") {
+                    let key = "";
+                    if (prop.key.type === "Identifier") key = prop.key.name;
+                    else if (prop.key.type === "StringLiteral") key = prop.key.value;
+                    else key = "[unresolved key]";
+                    const value = resolvePropertyValueNode(prop.value, scopePath, depth + 1);
+                    return `"${key}": ${value}`;
+                }
+                if (prop.type === "SpreadElement") {
+                    return `"...": ${resolvePropertyValueNode(prop.argument, scopePath, depth + 1)}`;
+                }
+                return null;
+            })
+            .filter(Boolean);
+        return `{${props.join(", ")}}`;
+    }
+
+    if (node.type === "StringLiteral") return JSON.stringify(node.value);
+    if (node.type === "NumericLiteral") return String(node.value);
+    if (node.type === "BooleanLiteral") return String(node.value);
+    if (node.type === "NullLiteral") return "null";
+
+    return `"[${node.type}]"`;
+};
+
+/**
+ * Builds a JSON-like body string from an ObjectExpression argument, resolving identifier
+ * property values via Babel scope where possible.
+ */
+const objectExpressionToBody = (node: any, scopePath: NodePath): string => {
+    const props = node.properties
+        .map((prop: any) => {
+            if (prop.type === "ObjectProperty") {
+                let key = "";
+                if (prop.key.type === "Identifier") key = prop.key.name;
+                else if (prop.key.type === "StringLiteral") key = prop.key.value;
+                else key = "[unresolved key]";
+                const value = resolvePropertyValueNode(prop.value, scopePath, 0);
+                return `"${key}": ${value}`;
+            }
+            if (prop.type === "SpreadElement") {
+                return `"...": ${resolvePropertyValueNode(prop.argument, scopePath, 0)}`;
+            }
+            return null;
+        })
+        .filter(Boolean);
+    return `{${props.join(", ")}}`;
+};
+
+/**
+ * Discovers a zod-style schema in the chunk (e.g. `let w = x.z.object({...})`) and
+ * converts it to a JSON-like body shape.
+ *
+ * Preference order:
+ *   1. The schema referenced via an `objectSchema:` or `resolver:` JSX prop in the
+ *      chunk (these point to the schema actually wired to the active form).
+ *   2. The first standalone `z.object({...})` definition in the chunk.
+ */
+const findZodSchemaInChunk = (ast: Node): string | null => {
+    let preferredSchemaVar: string | null = null;
+
+    traverse(ast as any, {
+        ObjectProperty(p) {
+            if (preferredSchemaVar) return;
+            const key = p.node.key as any;
+            const keyName = key.type === "Identifier" ? key.name : key.type === "StringLiteral" ? key.value : null;
+            if (keyName === "objectSchema") {
+                if (p.node.value.type === "Identifier") {
+                    preferredSchemaVar = p.node.value.name;
+                }
+            } else if (keyName === "resolver") {
+                const v: any = p.node.value;
+                if (v.type === "CallExpression" && v.arguments.length > 0 && v.arguments[0].type === "Identifier") {
+                    preferredSchemaVar = v.arguments[0].name;
+                }
+            }
+        },
+    });
+
+    const resolveSchemaVar = (varName: string, depth: number = 0): any => {
+        if (depth > 6) return null;
+        let initNode: any = null;
+        traverse(ast as any, {
+            VariableDeclarator(p) {
+                if (initNode) return;
+                if (p.node.id.type === "Identifier" && p.node.id.name === varName && p.node.init) {
+                    initNode = p.node.init;
+                    p.stop();
+                }
+            },
+        });
+        if (!initNode) return null;
+
+        if (
+            initNode.type === "CallExpression" &&
+            initNode.callee.type === "MemberExpression" &&
+            initNode.callee.property.type === "Identifier" &&
+            initNode.callee.property.name === "object" &&
+            initNode.arguments.length === 1 &&
+            initNode.arguments[0].type === "ObjectExpression"
+        ) {
+            return initNode.arguments[0];
+        }
+
+        if (
+            initNode.type === "CallExpression" &&
+            initNode.callee.type === "MemberExpression" &&
+            initNode.callee.property.type === "Identifier" &&
+            (initNode.callee.property.name === "extend" || initNode.callee.property.name === "merge")
+        ) {
+            const baseObj = initNode.callee.object;
+            if (baseObj.type === "Identifier") {
+                return resolveSchemaVar(baseObj.name, depth + 1);
+            }
+        }
+
+        if (initNode.type === "Identifier") {
+            return resolveSchemaVar(initNode.name, depth + 1);
+        }
+
+        return null;
+    };
+
+    let schemaNode: any = null;
+
+    if (preferredSchemaVar) {
+        schemaNode = resolveSchemaVar(preferredSchemaVar);
+    }
+
+    if (!schemaNode) {
+        traverse(ast as any, {
+            CallExpression(p) {
+                if (schemaNode) return;
+                const callee = p.node.callee;
+                if (
+                    callee.type === "MemberExpression" &&
+                    callee.property.type === "Identifier" &&
+                    callee.property.name === "object" &&
+                    p.node.arguments.length === 1 &&
+                    p.node.arguments[0].type === "ObjectExpression"
+                ) {
+                    schemaNode = p.node.arguments[0];
+                    p.stop();
+                }
+            },
+        });
+    }
+
+    if (!schemaNode) return null;
+
+    const zodTypeToPlaceholder = (valueNode: any): string => {
+        let cur = valueNode;
+        while (
+            cur &&
+            cur.type === "CallExpression" &&
+            cur.callee.type === "MemberExpression" &&
+            cur.callee.property.type === "Identifier" &&
+            ["optional", "nullable", "nullish", "min", "max", "length", "email", "url", "uuid", "regex", "trim", "default", "describe", "refine", "transform"].includes(
+                cur.callee.property.name,
+            )
+        ) {
+            cur = cur.callee.object;
+        }
+
+        if (
+            cur &&
+            cur.type === "CallExpression" &&
+            cur.callee.type === "MemberExpression" &&
+            cur.callee.property.type === "Identifier"
+        ) {
+            const name = cur.callee.property.name;
+            switch (name) {
+                case "string":
+                    return `"<string>"`;
+                case "number":
+                    return `"<number>"`;
+                case "boolean":
+                    return `"<boolean>"`;
+                case "bigint":
+                    return `"<bigint>"`;
+                case "date":
+                    return `"<date>"`;
+                case "array":
+                    return `["<array>"]`;
+                case "object":
+                    if (cur.arguments.length === 1 && cur.arguments[0].type === "ObjectExpression") {
+                        return buildSchemaBody(cur.arguments[0]);
+                    }
+                    return `"<object>"`;
+                case "enum":
+                    return `"<enum>"`;
+                case "literal":
+                    if (cur.arguments.length === 1 && cur.arguments[0].type === "StringLiteral") {
+                        return JSON.stringify(cur.arguments[0].value);
+                    }
+                    return `"<literal>"`;
+                default:
+                    return `"<${name}>"`;
+            }
+        }
+
+        return `"<unknown>"`;
+    };
+
+    const buildSchemaBody = (objNode: any): string => {
+        const parts = objNode.properties
+            .map((prop: any) => {
+                if (prop.type !== "ObjectProperty") return null;
+                let key = "";
+                if (prop.key.type === "Identifier") key = prop.key.name;
+                else if (prop.key.type === "StringLiteral") key = prop.key.value;
+                else return null;
+                return `"${key}": ${zodTypeToPlaceholder(prop.value)}`;
+            })
+            .filter(Boolean);
+        return `{${parts.join(", ")}}`;
+    };
+
+    return buildSchemaBody(schemaNode);
+};
+
+/**
+ * Finds the webpack-export name a local function is exposed under.
+ *
+ * Webpack emits exports as:
+ *   <thirdArg>.d(<exportObj>, { EXPNAME: function() { return funcName; } })
+ *
+ * Given `funcName`, returns the matching `EXPNAME` (or null if not exported).
+ */
+const findExportNameForFunc = (ast: Node, funcName: string): string | null => {
+    let exportName: string | null = null;
+    traverse(ast as any, {
+        CallExpression(p) {
+            if (exportName) return;
+            const callee = p.node.callee;
+            if (callee.type !== "MemberExpression") return;
+            if (callee.property.type !== "Identifier" || callee.property.name !== "d") return;
+            if (p.node.arguments.length !== 2) return;
+            if (p.node.arguments[1].type !== "ObjectExpression") return;
+
+            for (const prop of (p.node.arguments[1] as any).properties) {
+                if (prop.type !== "ObjectProperty" || prop.key.type !== "Identifier") continue;
+                const value = prop.value;
+                if (value.type !== "FunctionExpression" && value.type !== "ArrowFunctionExpression") continue;
+
+                let returnNode: any = null;
+                if (value.type === "ArrowFunctionExpression" && value.body.type !== "BlockStatement") {
+                    returnNode = value.body;
+                } else if (value.body.type === "BlockStatement") {
+                    const ret = value.body.body.find((s: any) => s.type === "ReturnStatement");
+                    if (ret) returnNode = (ret as any).argument;
+                }
+
+                if (returnNode && returnNode.type === "Identifier" && returnNode.name === funcName) {
+                    exportName = prop.key.name;
+                    return;
+                }
+            }
+        },
+    });
+    return exportName;
+};
+
+/**
+ * Finds the third parameter (webpack-require) name of a module function in an AST.
+ *
+ * Webpack module wrappers look like `function (e, t, n) { ... }` or
+ * `MODULE_ID: function (e, t, n) { ... }`. The third param is the require function
+ * used to import other chunks: `var X = n(<chunkId>)`.
+ */
+const findThirdArgInAst = (ast: Node): string | null => {
+    let thirdArg: string | null = null;
+    traverse(ast as any, {
+        Function(p) {
+            if (thirdArg) return;
+            const fn: any = p.node;
+            if (fn.params && fn.params.length === 3 && fn.params[2].type === "Identifier") {
+                thirdArg = fn.params[2].name;
+                p.stop();
+            }
+        },
+    });
+    return thirdArg;
+};
+
+/**
+ * Cross-chunk callsite trace.
+ *
+ * When a wrapper function (e.g. `let i = (t, e) => axios.post("/url", t, e)`) has
+ * no local callsites — typical for "service module" chunks whose only purpose is
+ * to export wrappers — search every chunk that imports the current chunk, look
+ * for invocations of the corresponding export (`x.cr(args)` or `(0, x.cr)(args)`),
+ * and recurse into the body argument's identifier in that scope.
+ */
+const crossChunkTrace = (
+    funcName: string,
+    paramIndex: number,
+    currentChunkId: string,
+    currentAst: Node,
+    chunks: Chunks,
+    visited: Set<string>,
+    depth: number,
+): string | null => {
+    const exportName = findExportNameForFunc(currentAst, funcName);
+    if (!exportName) return null;
+
+    for (const [otherChunkId, otherChunk] of Object.entries(chunks)) {
+        if (otherChunkId === currentChunkId) continue;
+        if (!otherChunk.imports || !otherChunk.imports.includes(currentChunkId)) continue;
+
+        const otherAst = parseChunkAst(otherChunkId, otherChunk.code);
+        if (!otherAst) continue;
+
+        const otherThirdArg = findThirdArgInAst(otherAst);
+        if (!otherThirdArg) continue;
+
+        // Find every variable that is `<otherThirdArg>(<currentChunkId>)`.
+        const importVarNames: Set<string> = new Set();
+        traverse(otherAst, {
+            VariableDeclarator(p) {
+                if (
+                    p.node.id.type === "Identifier" &&
+                    p.node.init &&
+                    p.node.init.type === "CallExpression" &&
+                    p.node.init.callee.type === "Identifier" &&
+                    p.node.init.callee.name === otherThirdArg &&
+                    p.node.init.arguments.length === 1 &&
+                    p.node.init.arguments[0].type === "NumericLiteral" &&
+                    String((p.node.init.arguments[0] as any).value) === currentChunkId
+                ) {
+                    importVarNames.add(p.node.id.name);
+                }
+            },
+        });
+
+        if (importVarNames.size === 0) continue;
+
+        let resolved: string | null = null;
+
+        traverse(otherAst, {
+            CallExpression(callPath) {
+                if (resolved) return;
+
+                // Unwrap (0, X.exp)(...) → callee is SequenceExpression whose last element
+                // is the member expression we care about.
+                let callee: any = callPath.node.callee;
+                if (callee.type === "SequenceExpression") {
+                    callee = callee.expressions[callee.expressions.length - 1];
+                }
+
+                if (
+                    callee.type !== "MemberExpression" ||
+                    callee.object.type !== "Identifier" ||
+                    !importVarNames.has(callee.object.name) ||
+                    callee.property.type !== "Identifier" ||
+                    callee.property.name !== exportName
+                ) {
+                    return;
+                }
+
+                const argNode = callPath.node.arguments[paramIndex];
+                if (!argNode) return;
+
+                if (argNode.type === "ObjectExpression") {
+                    resolved = objectExpressionToBody(argNode, callPath);
+                    callPath.stop();
+                    return;
+                }
+
+                if (argNode.type === "Identifier") {
+                    const traced = traceIdentifierBody(
+                        argNode.name,
+                        callPath,
+                        otherAst,
+                        otherChunk.code,
+                        chunks,
+                        visited,
+                        depth + 1,
+                        otherChunkId,
+                    );
+                    if (traced) {
+                        resolved = traced;
+                        callPath.stop();
+                    }
+                }
+            },
+        });
+
+        if (resolved) return resolved;
+    }
+
+    return null;
+};
+
+/**
+ * Traces a function-parameter identifier back through call sites to find its
+ * actual body shape.
+ *
+ * Algorithm:
+ *   1. Look up the binding for `paramName` in `path.scope`.
+ *   2. If the binding is a function parameter, walk to the enclosing function,
+ *      determine the parameter index, and find the function's bound name (if any).
+ *   3. Search the current chunk's AST for direct call sites of that function. For
+ *      each call site, inspect the argument at the same index:
+ *        - If it's an ObjectExpression, convert it to a JSON-like body and return.
+ *        - If it's an Identifier, recurse on it.
+ *   4. If no local call site resolves the shape:
+ *      a. Try cross-chunk tracing: find the chunk's export name for this function
+ *         and recurse into every chunk that imports the export.
+ *      b. As a last resort, fall back to discovering a zod schema in the same chunk.
+ */
+export const traceIdentifierBody = (
+    paramName: string,
+    path: NodePath,
+    ast: Node,
+    chunkCode: string,
+    chunks: Chunks | undefined,
+    visited: Set<string> = new Set(),
+    depth: number = 0,
+    chunkId?: string,
+): string | null => {
+    if (depth > 6) return null;
+
+    const binding = path.scope.getBinding(paramName);
+    if (!binding) return null;
+    if (binding.kind !== "param") return null;
+
+    const funcPath = binding.path.find((p) => p.isFunction()) as NodePath | null;
+    if (!funcPath) return null;
+
+    const funcNode: any = funcPath.node;
+    const paramIndex = funcNode.params.findIndex(
+        (p: any) => p.type === "Identifier" && p.name === paramName,
+    );
+    if (paramIndex === -1) return null;
+
+    let funcName: string | null = null;
+    if (funcPath.isFunctionDeclaration() && funcNode.id?.type === "Identifier") {
+        funcName = funcNode.id.name;
+    } else if (funcPath.parentPath) {
+        const parent: any = funcPath.parentPath.node;
+        if (parent.type === "VariableDeclarator" && parent.id?.type === "Identifier") {
+            funcName = parent.id.name;
+        } else if (parent.type === "AssignmentExpression" && parent.left?.type === "Identifier") {
+            funcName = parent.left.name;
+        }
+    }
+
+    if (!funcName) {
+        return findZodSchemaInChunk(ast);
+    }
+
+    const cycleKey = `${chunkId ?? "_"}:${funcName}:${paramIndex}`;
+    if (visited.has(cycleKey)) return null;
+    visited.add(cycleKey);
+
+    const targetFuncNode: Node = funcNode;
+
+    let resolved: string | null = null;
+    let directCallCount = 0;
+
+    traverse(ast as any, {
+        CallExpression(callPath) {
+            if (resolved) return;
+            const callee = callPath.node.callee;
+            if (callee.type === "Identifier" && callee.name === funcName) {
+                const callBinding = callPath.scope.getBinding(funcName);
+                if (!callBinding) return;
+                const callTargetFunc =
+                    callBinding.path.isVariableDeclarator() && (callBinding.path.node as any).init
+                        ? (callBinding.path.node as any).init
+                        : callBinding.path.node;
+                if (callTargetFunc !== targetFuncNode) {
+                    return;
+                }
+                directCallCount++;
+                const argNode = callPath.node.arguments[paramIndex];
+                if (!argNode) return;
+
+                if (argNode.type === "ObjectExpression") {
+                    resolved = objectExpressionToBody(argNode, callPath);
+                    callPath.stop();
+                    return;
+                }
+
+                if (argNode.type === "Identifier") {
+                    const traced = traceIdentifierBody(
+                        argNode.name,
+                        callPath,
+                        ast,
+                        chunkCode,
+                        chunks,
+                        visited,
+                        depth + 1,
+                        chunkId,
+                    );
+                    if (traced) {
+                        resolved = traced;
+                        callPath.stop();
+                    }
+                }
+            }
+        },
+    });
+
+    if (resolved) return resolved;
+
+    // No local resolution. Try cross-chunk callsite trace before falling back to
+    // schema discovery — cross-chunk usually carries real call-site evidence,
+    // while zod schemas in unrelated chunks are easy to misidentify.
+    if (chunkId && chunks) {
+        const crossChunk = crossChunkTrace(funcName, paramIndex, chunkId, ast, chunks, visited, depth);
+        if (crossChunk) return crossChunk;
+    }
+
+    if (directCallCount === 0) {
+        return findZodSchemaInChunk(ast);
+    }
+
+    return null;
+};
+
+/**
+ * Convenience entry that converts the result back into something acceptable as a
+ * `callBody` string. Returns null if no improvement is possible.
+ */
+export const maybeTraceBodyForIdentifier = (
+    bodyArgNode: Node,
+    parentCallPath: NodePath,
+    ast: Node,
+    chunkCode: string,
+    chunks: Chunks | undefined,
+    chunkId?: string,
+): string | null => {
+    if (!bodyArgNode || bodyArgNode.type !== "Identifier") return null;
+    const idName = (bodyArgNode as any).name as string;
+    return traceIdentifierBody(idName, parentCallPath, ast, chunkCode, chunks, new Set(), 0, chunkId);
+};
+
+/**
+ * Helper: rebuild the original astNodeToJsonString result, but for an Identifier-only
+ * body, attempt to improve via taint trace.
+ */
+export const resolveBodyArg = (
+    bodyArgNode: Node,
+    parentCallPath: NodePath,
+    ast: Node,
+    chunkCode: string,
+    chunks: Chunks | undefined,
+    chunkId?: string,
+): string => {
+    if (bodyArgNode && bodyArgNode.type === "Identifier") {
+        const traced = maybeTraceBodyForIdentifier(bodyArgNode, parentCallPath, ast, chunkCode, chunks, chunkId);
+        if (traced) return traced;
+    }
+    return astNodeToJsonString(bodyArgNode, chunkCode);
+};

--- a/src/map/next_js/resolveFetch.ts
+++ b/src/map/next_js/resolveFetch.ts
@@ -239,10 +239,7 @@ const traceFetchFunctionCalls = (
  * single module's code. Used to resolve URL placeholders when the fetch
  * wrapper is a non-exported (module-internal) function.
  */
-const traceInternalFunctionCalls = (
-    functionName: string,
-    moduleCode: string
-): any[] => {
+const traceInternalFunctionCalls = (functionName: string, moduleCode: string): any[] => {
     try {
         const ast = parser.parse(moduleCode, {
             sourceType: "module",
@@ -372,7 +369,15 @@ const resolveFetch = async (chunks: Chunks, directory: string) => {
                         // extract the whole code from the main file just in case the resolution fails
                         const argText = fileContent.slice(args[0].start, args[0].end).replace(/\n\s*/g, "");
 
-                        let url = resolveNodeValue(args[0], path.scope, argText, "fetch", fileContent, chunks, thirdArgName);
+                        let url = resolveNodeValue(
+                            args[0],
+                            path.scope,
+                            argText,
+                            "fetch",
+                            fileContent,
+                            chunks,
+                            thirdArgName
+                        );
 
                         // Substitute any [var X] or [MemberExpression -> X] placeholders with actual values from the chunk.
                         // Use chunk.code (module-scoped) rather than the entire fileContent to prevent
@@ -398,13 +403,27 @@ const resolveFetch = async (chunks: Chunks, directory: string) => {
                                 const internalCallArgs = traceInternalFunctionCalls(wrapperName, chunk.code);
                                 if (internalCallArgs.length > 0) {
                                     // Use the first resolved arg as a representative URL component
-                                    const firstArgResolved = resolveNodeValue(internalCallArgs[0], path.scope, "", "fetch", fileContent, chunks, thirdArgName);
-                                    if (firstArgResolved && typeof firstArgResolved === "string" && !firstArgResolved.startsWith("[")) {
+                                    const firstArgResolved = resolveNodeValue(
+                                        internalCallArgs[0],
+                                        path.scope,
+                                        "",
+                                        "fetch",
+                                        fileContent,
+                                        chunks,
+                                        thirdArgName
+                                    );
+                                    if (
+                                        firstArgResolved &&
+                                        typeof firstArgResolved === "string" &&
+                                        !firstArgResolved.startsWith("[")
+                                    ) {
                                         // Replace [var X] with the resolved caller argument
                                         const varMatch = url.match(/\[var ([^\]]+)\]/);
                                         if (varMatch) {
                                             url = url.replace(varMatch[0], firstArgResolved);
-                                            console.log(chalk.cyan(`    [i] Resolved URL from internal caller: ${url}`));
+                                            console.log(
+                                                chalk.cyan(`    [i] Resolved URL from internal caller: ${url}`)
+                                            );
                                         }
                                     }
                                 }
@@ -547,14 +566,24 @@ const resolveFetch = async (chunks: Chunks, directory: string) => {
                                             directory
                                         );
                                         if (actualCallArg) {
-                                            const callerUrl = resolveNodeValue(actualCallArg, path.scope, "", "fetch", fileContent, chunks, thirdArgName);
+                                            const callerUrl = resolveNodeValue(
+                                                actualCallArg,
+                                                path.scope,
+                                                "",
+                                                "fetch",
+                                                fileContent,
+                                                chunks,
+                                                thirdArgName
+                                            );
                                             if (
                                                 callerUrl &&
                                                 typeof callerUrl === "string" &&
                                                 !callerUrl.startsWith("[unresolved") &&
                                                 !callerUrl.startsWith("[error")
                                             ) {
-                                                console.log(chalk.cyan(`    [i] Resolved URL from caller: ${callerUrl}`));
+                                                console.log(
+                                                    chalk.cyan(`    [i] Resolved URL from caller: ${callerUrl}`)
+                                                );
                                                 resolvedUrl = callerUrl;
                                             }
                                         }

--- a/src/map/next_js/resolveFetch.ts
+++ b/src/map/next_js/resolveFetch.ts
@@ -234,11 +234,64 @@ const traceFetchFunctionCalls = (
  * @param {Chunks} chunks - A dictionary of chunk names to chunk objects.
  * @param {string} directory - The directory of the chunk file.
  */
+/**
+ * Finds all call-site first-arguments for a given function name within a
+ * single module's code. Used to resolve URL placeholders when the fetch
+ * wrapper is a non-exported (module-internal) function.
+ */
+const traceInternalFunctionCalls = (
+    functionName: string,
+    moduleCode: string
+): any[] => {
+    try {
+        const ast = parser.parse(moduleCode, {
+            sourceType: "module",
+            plugins: ["jsx", "typescript"],
+            errorRecovery: true,
+        });
+        const firstArgs: any[] = [];
+        traverse(ast, {
+            CallExpression(path) {
+                const callee = path.node.callee;
+                if (callee.type === "Identifier" && callee.name === functionName && path.node.arguments.length > 0) {
+                    firstArgs.push(path.node.arguments[0]);
+                }
+            },
+        });
+        return firstArgs;
+    } catch {
+        return [];
+    }
+};
+
+/**
+ * Returns true when the chunk's code looks like a Next.js framework-internal
+ * module (RSC router, Server Actions reducer, etc.) that should not be
+ * reported as user-defined API endpoints.
+ */
+const isNextJsFrameworkChunk = (code: string): boolean => {
+    // RSC navigation / router internals
+    if (code.includes("NEXT_RSC_UNION_QUERY") || code.includes("setCacheBustingSearchParam")) {
+        return true;
+    }
+    // Server Actions reducer exported by the Next.js runtime
+    if (code.includes('"serverActionReducer"') || code.includes("serverActionReducer:")) {
+        return true;
+    }
+    return false;
+};
+
 const resolveFetch = async (chunks: Chunks, directory: string) => {
     console.log(chalk.cyan("[i] Resolving fetch instances"));
 
     for (const chunk of Object.values(chunks)) {
         if (!chunk.containsFetch || !chunk.file) {
+            continue;
+        }
+
+        // Skip Next.js framework-internal chunks to avoid noise
+        if (isNextJsFrameworkChunk(chunk.code || "")) {
+            console.log(chalk.gray(`    [i] Skipping Next.js framework chunk ${chunk.id}`));
             continue;
         }
 
@@ -319,16 +372,42 @@ const resolveFetch = async (chunks: Chunks, directory: string) => {
                         // extract the whole code from the main file just in case the resolution fails
                         const argText = fileContent.slice(args[0].start, args[0].end).replace(/\n\s*/g, "");
 
-                        let url = resolveNodeValue(args[0], path.scope, argText, "fetch");
+                        let url = resolveNodeValue(args[0], path.scope, argText, "fetch", fileContent, chunks, thirdArgName);
 
-                        // Substitute any [var X] or [MemberExpression -> X] placeholders with actual values from the chunk
+                        // Substitute any [var X] or [MemberExpression -> X] placeholders with actual values from the chunk.
+                        // Use chunk.code (module-scoped) rather than the entire fileContent to prevent
+                        // cross-module variable name collisions from polluting the resolved value.
                         if (typeof url === "string" && (url.includes("[var ") || url.includes("[MemberExpression"))) {
-                            const substitutedUrl = substituteVariablesInString(url, fileContent, chunks, thirdArgName);
+                            const substitutedUrl = substituteVariablesInString(url, chunk.code, chunks, thirdArgName);
                             if (substitutedUrl !== url) {
                                 console.log(
                                     chalk.cyan(`    [i] Resolved variables in URL: ${url} -> ${substitutedUrl}`)
                                 );
                                 url = substitutedUrl;
+                            }
+                        }
+
+                        // If the URL still has unresolved [var X] placeholders, try to
+                        // resolve them by tracing internal (non-exported) callers within
+                        // the same module. This handles patterns like:
+                        //   function J(e, t) { fetch("".concat(t.basePath, "/").concat(e)) }
+                        //   J("session", Y)  →  resolved e = "session"
+                        if (typeof url === "string" && url.includes("[var ")) {
+                            const wrapperName = getFunctionNameForFetchCall(path);
+                            if (wrapperName) {
+                                const internalCallArgs = traceInternalFunctionCalls(wrapperName, chunk.code);
+                                if (internalCallArgs.length > 0) {
+                                    // Use the first resolved arg as a representative URL component
+                                    const firstArgResolved = resolveNodeValue(internalCallArgs[0], path.scope, "", "fetch", fileContent, chunks, thirdArgName);
+                                    if (firstArgResolved && typeof firstArgResolved === "string" && !firstArgResolved.startsWith("[")) {
+                                        // Replace [var X] with the resolved caller argument
+                                        const varMatch = url.match(/\[var ([^\]]+)\]/);
+                                        if (varMatch) {
+                                            url = url.replace(varMatch[0], firstArgResolved);
+                                            console.log(chalk.cyan(`    [i] Resolved URL from internal caller: ${url}`));
+                                        }
+                                    }
+                                }
                             }
                         }
 
@@ -440,6 +519,56 @@ const resolveFetch = async (chunks: Chunks, directory: string) => {
                                 path: callUrl || "",
                                 headers: callHeaders || {},
                                 body: callBody || "",
+                                chunkId: chunk.id,
+                                functionFile: filePath,
+                                functionFileLine: functionFileLine,
+                            });
+                        } else {
+                            // Single-argument fetch(url) — implicit GET request.
+                            // Try to resolve the URL from callers when the direct resolution
+                            // left an unresolved function-parameter placeholder.
+                            let resolvedUrl = callUrl || "";
+
+                            if (resolvedUrl.startsWith("[unresolved:") || resolvedUrl === "") {
+                                const functionName = getFunctionNameForFetchCall(path);
+                                if (functionName && chunk.exports && chunk.exports.length > 0) {
+                                    const exportName = findExportForFunction(fileContent, functionName, chunk.exports);
+                                    if (exportName) {
+                                        console.log(
+                                            chalk.cyan(
+                                                `    [i] Fetch is wrapped in function '${functionName}', checking for exports...`
+                                            )
+                                        );
+                                        const actualCallArg = traceFetchFunctionCalls(
+                                            chunk.id,
+                                            exportName,
+                                            functionName,
+                                            chunks,
+                                            directory
+                                        );
+                                        if (actualCallArg) {
+                                            const callerUrl = resolveNodeValue(actualCallArg, path.scope, "", "fetch", fileContent, chunks, thirdArgName);
+                                            if (
+                                                callerUrl &&
+                                                typeof callerUrl === "string" &&
+                                                !callerUrl.startsWith("[unresolved") &&
+                                                !callerUrl.startsWith("[error")
+                                            ) {
+                                                console.log(chalk.cyan(`    [i] Resolved URL from caller: ${callerUrl}`));
+                                                resolvedUrl = callerUrl;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            console.log(chalk.green(`    Method: GET`));
+                            globals.addOpenapiOutput({
+                                url: resolvedUrl,
+                                method: "GET",
+                                path: resolvedUrl,
+                                headers: {},
+                                body: "",
                                 chunkId: chunk.id,
                                 functionFile: filePath,
                                 functionFileLine: functionFileLine,

--- a/src/map/next_js/resolveNewRequest.ts
+++ b/src/map/next_js/resolveNewRequest.ts
@@ -137,8 +137,14 @@ const isWrapperClassBody = (body: any): boolean => {
                     right.type === "ObjectExpression"
                 ) {
                     const keys = right.properties
-                        .filter((p: any) => p.type === "ObjectProperty" && p.key.type === "Identifier")
-                        .map((p: any) => p.key.name);
+                        .filter((p: any) => p.type === "ObjectProperty")
+                        .map((p: any) =>
+                            p.key.type === "Identifier"
+                                ? p.key.name
+                                : p.key.type === "StringLiteral"
+                                  ? p.key.value
+                                  : null
+                        );
                     if (keys.includes("url") && keys.includes("method")) {
                         found = true;
                         return;
@@ -176,10 +182,18 @@ const findNewExpressionsWithUrl = (ast: any): any[] => {
             const first = args[0];
             if (first.type !== "ObjectExpression") return;
 
-            // Must have a `url` property (heuristic for HTTP config)
-            const hasUrl = first.properties.some(
-                (p: any) => p.type === "ObjectProperty" && p.key.type === "Identifier" && p.key.name === "url"
-            );
+            // Must have a `url` property (heuristic for HTTP config).
+            // Accept both identifier (`url: ...`) and string-literal (`"url": ...`) keys.
+            const hasUrl = first.properties.some((p: any) => {
+                if (p.type !== "ObjectProperty") return false;
+                const keyName =
+                    p.key.type === "Identifier"
+                        ? p.key.name
+                        : p.key.type === "StringLiteral"
+                          ? p.key.value
+                          : null;
+                return keyName === "url";
+            });
             if (!hasUrl) return;
 
             results.push(path);
@@ -260,11 +274,17 @@ const resolveCalleeToWrapperChunk = (
 const extractObjectField = (objExpr: any, fieldName: string): { rawNode: any; stringValue: string | null } | null => {
     if (!objExpr || objExpr.type !== "ObjectExpression") return null;
     for (const prop of objExpr.properties) {
-        if (prop.type === "ObjectProperty" && prop.key.type === "Identifier" && prop.key.name === fieldName) {
-            let val: string | null = null;
-            if (prop.value.type === "StringLiteral") val = prop.value.value;
-            return { rawNode: prop.value, stringValue: val };
-        }
+        if (prop.type !== "ObjectProperty") continue;
+        const keyName =
+            prop.key.type === "Identifier"
+                ? prop.key.name
+                : prop.key.type === "StringLiteral"
+                  ? prop.key.value
+                  : null;
+        if (keyName !== fieldName) continue;
+        let val: string | null = null;
+        if (prop.value.type === "StringLiteral") val = prop.value.value;
+        return { rawNode: prop.value, stringValue: val };
     }
     return null;
 };

--- a/src/map/next_js/resolveNewRequest.ts
+++ b/src/map/next_js/resolveNewRequest.ts
@@ -1,0 +1,800 @@
+import chalk from "chalk";
+import fs from "fs";
+import path from "path";
+import parser from "@babel/parser";
+import _traverse from "@babel/traverse";
+import { Chunks } from "../../utility/interfaces.js";
+import { resolveNodeValue, substituteVariablesInString } from "./utils.js";
+import { astNodeToJsonString } from "./resolveAxiosHelpers/astNodeToJsonString.js";
+import { getThirdArg } from "./resolveAxios.js";
+import * as globals from "../../utility/globals.js";
+
+const traverse = _traverse.default;
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"];
+
+/**
+ * Detect chunks that define an HTTP-request wrapper class. Heuristic:
+ * the chunk contains a `class` whose constructor assigns
+ *   this.config = { url: ..., method: ..., ... }
+ * Returns map of chunkId -> Set of exported binding names that point to such a class.
+ */
+const findWrapperClasses = (chunks: Chunks): Map<string, Set<string>> => {
+    const wrappers = new Map<string, Set<string>>();
+
+    for (const chunk of Object.values(chunks)) {
+        if (!chunk.code) continue;
+        let ast;
+        try {
+            ast = parser.parse(chunk.code, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+        } catch {
+            continue;
+        }
+
+        const wrapperClassNames = new Set<string>();
+
+        traverse(ast, {
+            ClassDeclaration(path) {
+                const className = path.node.id?.name;
+                if (!className) return;
+                if (isWrapperClassBody(path.node.body)) {
+                    wrapperClassNames.add(className);
+                }
+            },
+            ClassExpression(path) {
+                // Class expressions assigned to a variable: let E = class { ... }
+                const parent = path.parent;
+                if (parent.type === "VariableDeclarator" && parent.id.type === "Identifier") {
+                    if (isWrapperClassBody(path.node.body)) {
+                        wrapperClassNames.add(parent.id.name);
+                    }
+                } else if (parent.type === "AssignmentExpression" && parent.left.type === "Identifier") {
+                    if (isWrapperClassBody(path.node.body)) {
+                        wrapperClassNames.add(parent.left.name);
+                    }
+                }
+            },
+        });
+
+        if (wrapperClassNames.size === 0) continue;
+
+        // Now find which exports point to these classes:
+        //   o.d(t, { A: () => E, ... })
+        const exportedBindings = new Set<string>();
+
+        traverse(ast, {
+            CallExpression(path) {
+                const callee = path.node.callee;
+                if (
+                    callee.type === "MemberExpression" &&
+                    callee.property.type === "Identifier" &&
+                    callee.property.name === "d" &&
+                    path.node.arguments.length >= 2 &&
+                    path.node.arguments[1].type === "ObjectExpression"
+                ) {
+                    for (const prop of path.node.arguments[1].properties) {
+                        if (
+                            prop.type !== "ObjectProperty" ||
+                            prop.key.type !== "Identifier"
+                        )
+                            continue;
+                        const exportName = prop.key.name;
+                        const value = prop.value;
+                        // Pattern: A: () => E
+                        if (
+                            value.type === "ArrowFunctionExpression" &&
+                            value.body.type === "Identifier" &&
+                            wrapperClassNames.has(value.body.name)
+                        ) {
+                            exportedBindings.add(exportName);
+                        }
+                    }
+                }
+            },
+        });
+
+        if (exportedBindings.size > 0) {
+            wrappers.set(chunk.id, exportedBindings);
+        }
+    }
+
+    return wrappers;
+};
+
+/**
+ * Returns true if a class body looks like an HTTP wrapper:
+ * its constructor assigns `this.config = { url: ..., method: ..., ... }`.
+ */
+const isWrapperClassBody = (body: any): boolean => {
+    if (!body || body.type !== "ClassBody") return false;
+
+    for (const member of body.body) {
+        if (
+            member.type !== "ClassMethod" ||
+            member.kind !== "constructor" ||
+            !member.body ||
+            member.body.type !== "BlockStatement"
+        ) {
+            continue;
+        }
+
+        // Walk all statements/expressions in the constructor and look for
+        //   this.config = { url: ..., method: ... }
+        let found = false;
+        const walkForConfigAssignment = (stmt: any) => {
+            if (found) return;
+            if (!stmt || typeof stmt !== "object") return;
+            if (stmt.type === "AssignmentExpression") {
+                const left = stmt.left;
+                const right = stmt.right;
+                if (
+                    left &&
+                    left.type === "MemberExpression" &&
+                    left.object.type === "ThisExpression" &&
+                    left.property.type === "Identifier" &&
+                    left.property.name === "config" &&
+                    right &&
+                    right.type === "ObjectExpression"
+                ) {
+                    const keys = right.properties
+                        .filter((p: any) => p.type === "ObjectProperty" && p.key.type === "Identifier")
+                        .map((p: any) => p.key.name);
+                    if (keys.includes("url") && keys.includes("method")) {
+                        found = true;
+                        return;
+                    }
+                }
+            }
+            // Recurse into children
+            for (const key of Object.keys(stmt)) {
+                if (key === "loc" || key === "start" || key === "end") continue;
+                const child = stmt[key];
+                if (Array.isArray(child)) {
+                    for (const c of child) walkForConfigAssignment(c);
+                } else if (child && typeof child === "object" && child.type) {
+                    walkForConfigAssignment(child);
+                }
+            }
+        };
+        for (const stmt of member.body.body) walkForConfigAssignment(stmt);
+        if (found) return true;
+    }
+    return false;
+};
+
+/**
+ * Within a chunk, find all `new X(...)` calls. For each, the caller of
+ * `findWrapperInstantiations` will decide whether the constructor is a wrapper
+ * class. We return the new-expression node plus the matched `X` text.
+ */
+const findNewExpressionsWithUrl = (ast: any): any[] => {
+    const results: any[] = [];
+    traverse(ast, {
+        NewExpression(path) {
+            const args = path.node.arguments;
+            if (args.length === 0) return;
+            const first = args[0];
+            if (first.type !== "ObjectExpression") return;
+
+            // Must have a `url` property (heuristic for HTTP config)
+            const hasUrl = first.properties.some(
+                (p: any) =>
+                    p.type === "ObjectProperty" &&
+                    p.key.type === "Identifier" &&
+                    p.key.name === "url"
+            );
+            if (!hasUrl) return;
+
+            results.push(path);
+        },
+    });
+    return results;
+};
+
+/**
+ * Resolve which chunk + exported binding a `new X.Y(...)` callee refers to.
+ * If the callee is `X.Y`, find `X = require(N)` in the current chunk to get N,
+ * then verify N is a wrapper chunk and Y is one of its exported wrapper bindings.
+ * Returns the targetChunkId if so, else null.
+ */
+const resolveCalleeToWrapperChunk = (
+    calleeNode: any,
+    ast: any,
+    thirdArgName: string,
+    wrappers: Map<string, Set<string>>
+): { chunkId: string; exportName: string } | null => {
+    if (!thirdArgName) return null;
+    if (calleeNode.type !== "MemberExpression") return null;
+    if (calleeNode.object.type !== "Identifier") return null;
+    if (calleeNode.property.type !== "Identifier") return null;
+
+    const objName = calleeNode.object.name;
+    const exportName = calleeNode.property.name;
+
+    let targetChunkId: string | null = null;
+    traverse(ast, {
+        VariableDeclarator(p) {
+            if (targetChunkId) return;
+            const id = p.node.id;
+            const init = p.node.init;
+            if (id.type !== "Identifier" || id.name !== objName || !init) return;
+            if (
+                init.type === "CallExpression" &&
+                init.callee.type === "Identifier" &&
+                init.callee.name === thirdArgName &&
+                init.arguments.length > 0
+            ) {
+                const arg = init.arguments[0];
+                if (arg.type === "NumericLiteral") targetChunkId = String(arg.value);
+                else if (arg.type === "StringLiteral") targetChunkId = arg.value;
+                p.stop();
+            }
+        },
+        AssignmentExpression(p) {
+            if (targetChunkId) return;
+            const left = p.node.left;
+            const right = p.node.right;
+            if (left.type !== "Identifier" || left.name !== objName) return;
+            if (
+                right.type === "CallExpression" &&
+                right.callee.type === "Identifier" &&
+                right.callee.name === thirdArgName &&
+                right.arguments.length > 0
+            ) {
+                const arg = right.arguments[0];
+                if (arg.type === "NumericLiteral") targetChunkId = String(arg.value);
+                else if (arg.type === "StringLiteral") targetChunkId = arg.value;
+                p.stop();
+            }
+        },
+    });
+
+    if (!targetChunkId) return null;
+    const exports = wrappers.get(targetChunkId);
+    if (!exports || !exports.has(exportName)) return null;
+
+    return { chunkId: targetChunkId, exportName };
+};
+
+/**
+ * Extract a known string field (e.g., "method") from the first ObjectExpression
+ * argument of a `new` call. Returns the raw value (uppercased for methods) or null.
+ */
+const extractObjectField = (
+    objExpr: any,
+    fieldName: string
+): { rawNode: any; stringValue: string | null } | null => {
+    if (!objExpr || objExpr.type !== "ObjectExpression") return null;
+    for (const prop of objExpr.properties) {
+        if (
+            prop.type === "ObjectProperty" &&
+            prop.key.type === "Identifier" &&
+            prop.key.name === fieldName
+        ) {
+            let val: string | null = null;
+            if (prop.value.type === "StringLiteral") val = prop.value.value;
+            return { rawNode: prop.value, stringValue: val };
+        }
+    }
+    return null;
+};
+
+/**
+ * Walks upward from a `new X(...)` path to find the enclosing function
+ * declaration/expression. Returns its identifier name if it's named (or
+ * assigned to a named variable), else null.
+ */
+const enclosingFunctionName = (path: any): string | null => {
+    let cur = path;
+    while (cur) {
+        if (cur.isFunctionDeclaration?.()) {
+            return cur.node.id?.name || null;
+        }
+        if (cur.isVariableDeclarator?.()) {
+            const init = cur.node.init;
+            if (init && (init.type === "ArrowFunctionExpression" || init.type === "FunctionExpression")) {
+                return cur.node.id.type === "Identifier" ? cur.node.id.name : null;
+            }
+        }
+        if (cur.isArrowFunctionExpression?.() || cur.isFunctionExpression?.()) {
+            const parent = cur.parent;
+            if (parent && parent.type === "VariableDeclarator" && parent.id?.type === "Identifier") {
+                return parent.id.name;
+            }
+        }
+        cur = cur.parentPath;
+    }
+    return null;
+};
+
+/**
+ * Within a chunk's AST, find calls to `factoryName(...)` followed by `.do(<arg>)`
+ * (possibly through an intermediate variable). Returns the first such arg AST
+ * node found, or null. Handles:
+ *   factoryName().do(body)
+ *   let x = factoryName(); x.do(body)
+ */
+const findFactoryDoCallArg = (factoryName: string, ast: any): any | null => {
+    let result: any = null;
+    // Variables that hold the instance from factoryName()
+    const instanceVars = new Set<string>();
+
+    traverse(ast, {
+        // let x = factoryName()
+        VariableDeclarator(p) {
+            const init = p.node.init;
+            if (!init) return;
+            if (
+                init.type === "CallExpression" &&
+                init.callee.type === "Identifier" &&
+                init.callee.name === factoryName &&
+                p.node.id.type === "Identifier"
+            ) {
+                instanceVars.add(p.node.id.name);
+            }
+        },
+    });
+
+    const DO_METHODS_LOCAL = new Set(["do", "doRawResponse"]);
+    traverse(ast, {
+        CallExpression(p) {
+            if (result) return;
+            const callee = p.node.callee;
+            // Pattern: <X>.do(<arg>) or <X>.doRawResponse(<arg>)
+            if (
+                callee.type === "MemberExpression" &&
+                callee.property.type === "Identifier" &&
+                DO_METHODS_LOCAL.has(callee.property.name) &&
+                p.node.arguments.length > 0
+            ) {
+                // Case A: factoryName().do(arg)
+                if (
+                    callee.object.type === "CallExpression" &&
+                    callee.object.callee.type === "Identifier" &&
+                    callee.object.callee.name === factoryName
+                ) {
+                    result = p.node.arguments[0];
+                    p.stop();
+                    return;
+                }
+                // Case B: instance.do(arg) where instance came from factoryName()
+                if (
+                    callee.object.type === "Identifier" &&
+                    instanceVars.has(callee.object.name)
+                ) {
+                    result = p.node.arguments[0];
+                    p.stop();
+                    return;
+                }
+            }
+        },
+    });
+
+    return result;
+};
+
+/**
+ * For a given factory-export name on a wrapper-instantiation chunk, trace
+ * across all chunks that import this chunk, looking for `factory().do(arg)`
+ * call patterns. Returns the first `.do()` arg node found.
+ */
+const traceDoCallAcrossChunks = (
+    sourceChunkId: string,
+    factoryExportName: string,
+    chunks: Chunks
+): { argNode: any; chunkCode: string } | null => {
+    for (const callerChunk of Object.values(chunks)) {
+        if (!callerChunk.imports?.includes(sourceChunkId)) continue;
+        if (!callerChunk.code) continue;
+
+        let callerAst;
+        try {
+            callerAst = parser.parse(callerChunk.code, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+        } catch {
+            continue;
+        }
+
+        const thirdArgName = getThirdArg(callerAst);
+        if (!thirdArgName) continue;
+
+        // Find which local var binds to require(sourceChunkId)
+        let localBinding: string | null = null;
+        traverse(callerAst, {
+            VariableDeclarator(p) {
+                if (localBinding) return;
+                const init = p.node.init;
+                if (
+                    init &&
+                    init.type === "CallExpression" &&
+                    init.callee.type === "Identifier" &&
+                    init.callee.name === thirdArgName &&
+                    init.arguments.length > 0 &&
+                    p.node.id.type === "Identifier"
+                ) {
+                    const arg = init.arguments[0];
+                    const argVal = arg.type === "NumericLiteral" ? String(arg.value)
+                                 : arg.type === "StringLiteral" ? arg.value : null;
+                    if (argVal === sourceChunkId) {
+                        localBinding = p.node.id.name;
+                    }
+                }
+            },
+        });
+        if (!localBinding) continue;
+
+        // Identify a CallExpression that invokes `localBinding.factoryExportName(...)`,
+        // including the `(0, b.factoryName)(...)` SequenceExpression form.
+        const isFactoryCall = (n: any): boolean => {
+            if (!n || n.type !== "CallExpression") return false;
+            const c = n.callee;
+            // localBinding.factoryExportName(...)
+            if (
+                c.type === "MemberExpression" &&
+                c.object.type === "Identifier" &&
+                c.object.name === localBinding &&
+                c.property.type === "Identifier" &&
+                c.property.name === factoryExportName
+            ) return true;
+            // (0, localBinding.factoryExportName)(...)
+            if (c.type === "SequenceExpression" && c.expressions.length === 2) {
+                const last = c.expressions[1];
+                if (
+                    last.type === "MemberExpression" &&
+                    last.object.type === "Identifier" &&
+                    last.object.name === localBinding &&
+                    last.property.type === "Identifier" &&
+                    last.property.name === factoryExportName
+                ) return true;
+            }
+            return false;
+        };
+
+        // Step A: collect instance variable names. Patterns considered:
+        //   let x = factory()
+        //   let x = useRef(factory())  / useMemo(() => factory())
+        //   let x = anyCall(factory())  // assume `.current.do` access for these
+        // Returns: Map<varName, {viaCurrent: boolean}>
+        const instanceVars = new Map<string, { viaCurrent: boolean }>();
+
+        const findFactoryInExpression = (expr: any): { found: boolean; depth: number } => {
+            if (!expr || typeof expr !== "object") return { found: false, depth: 0 };
+            if (isFactoryCall(expr)) return { found: true, depth: 0 };
+            if (expr.type === "CallExpression" && expr.arguments) {
+                for (const a of expr.arguments) {
+                    const r = findFactoryInExpression(a);
+                    if (r.found) return { found: true, depth: r.depth + 1 };
+                }
+            }
+            if (expr.type === "ArrowFunctionExpression" || expr.type === "FunctionExpression") {
+                if (expr.body) {
+                    const r = findFactoryInExpression(expr.body);
+                    if (r.found) return { found: true, depth: r.depth + 1 };
+                }
+            }
+            if (expr.type === "BlockStatement" && expr.body) {
+                for (const s of expr.body) {
+                    if (s.type === "ReturnStatement" && s.argument) {
+                        const r = findFactoryInExpression(s.argument);
+                        if (r.found) return { found: true, depth: r.depth + 1 };
+                    }
+                }
+            }
+            return { found: false, depth: 0 };
+        };
+
+        traverse(callerAst, {
+            VariableDeclarator(p) {
+                const init = p.node.init;
+                if (!init || p.node.id.type !== "Identifier") return;
+                const r = findFactoryInExpression(init);
+                if (r.found) {
+                    // depth>0 means it's wrapped (e.g., useRef) → access via .current
+                    instanceVars.set(p.node.id.name, { viaCurrent: r.depth > 0 });
+                }
+            },
+        });
+
+        // Step B: find `.do(arg)` / `.doRawResponse(arg)` calls referencing an
+        // instance var or factory directly.
+        let argNode: any = null;
+        const DO_METHODS = new Set(["do", "doRawResponse"]);
+        traverse(callerAst, {
+            CallExpression(p) {
+                if (argNode) return;
+                const callee = p.node.callee;
+                if (
+                    callee.type !== "MemberExpression" ||
+                    callee.property.type !== "Identifier" ||
+                    !DO_METHODS.has(callee.property.name) ||
+                    p.node.arguments.length === 0
+                ) return;
+
+                const recv = callee.object;
+
+                // Pattern 1: factory().do(arg)
+                if (isFactoryCall(recv)) {
+                    argNode = p.node.arguments[0];
+                    p.stop();
+                    return;
+                }
+
+                // Pattern 2: instance.do(arg)
+                if (recv.type === "Identifier") {
+                    const info = instanceVars.get(recv.name);
+                    if (info && !info.viaCurrent) {
+                        argNode = p.node.arguments[0];
+                        p.stop();
+                        return;
+                    }
+                }
+
+                // Pattern 3: instance.current.do(arg)
+                if (
+                    recv.type === "MemberExpression" &&
+                    recv.object.type === "Identifier" &&
+                    recv.property.type === "Identifier" &&
+                    recv.property.name === "current"
+                ) {
+                    const info = instanceVars.get(recv.object.name);
+                    if (info) {
+                        argNode = p.node.arguments[0];
+                        p.stop();
+                        return;
+                    }
+                }
+            },
+        });
+
+        if (argNode) {
+            return { argNode, chunkCode: callerChunk.code };
+        }
+    }
+    return null;
+};
+
+/**
+ * Resolves wrapper-class HTTP requests: detects `new X.Y({url, method, ...}, ...)`
+ * patterns where X.Y is an exported HTTP-request wrapper class from another
+ * webpack chunk, then resolves the URL, method, and body schema.
+ */
+const resolveNewRequest = async (chunks: Chunks, directory: string) => {
+    console.log(chalk.cyan("[i] Resolving wrapper-class HTTP requests (new X({url, method, ...}))"));
+
+    const wrappers = findWrapperClasses(chunks);
+    if (wrappers.size === 0) {
+        console.log(chalk.yellow("    [!] No HTTP-wrapper classes detected"));
+        return;
+    }
+
+    for (const [chunkId, exports] of wrappers.entries()) {
+        console.log(
+            chalk.green(
+                `    [✓] Wrapper class chunk ${chunkId} exports: ${Array.from(exports).join(", ")}`
+            )
+        );
+    }
+
+    // Also collect, per wrapper chunk, the set of "factory" export bindings
+    // i.e. functions in OTHER chunks that return `new <wrapper>(...)` instances.
+    // Built lazily as we scan chunks below.
+
+    for (const chunk of Object.values(chunks)) {
+        if (!chunk.code || !chunk.file) continue;
+
+        let ast;
+        try {
+            ast = parser.parse(chunk.code, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+        } catch {
+            continue;
+        }
+
+        const thirdArgName = getThirdArg(ast);
+        if (!thirdArgName) continue;
+
+        const newExprPaths = findNewExpressionsWithUrl(ast);
+        if (newExprPaths.length === 0) continue;
+
+        const filePath = path.join(directory, chunk.file);
+        let fileContent: string;
+        try {
+            fileContent = fs.readFileSync(filePath, "utf-8");
+        } catch {
+            fileContent = chunk.code;
+        }
+
+        // Per-chunk: build a map of local factory-function names -> the export
+        // name (in the wrapper-instance chunk) under which they're exported.
+        const factoryExports = new Map<string, string>();
+        traverse(ast, {
+            CallExpression(p) {
+                const callee = p.node.callee;
+                if (
+                    callee.type === "MemberExpression" &&
+                    callee.property.type === "Identifier" &&
+                    callee.property.name === "d" &&
+                    p.node.arguments.length >= 2 &&
+                    p.node.arguments[1].type === "ObjectExpression"
+                ) {
+                    for (const prop of p.node.arguments[1].properties) {
+                        if (
+                            prop.type === "ObjectProperty" &&
+                            prop.key.type === "Identifier" &&
+                            prop.value.type === "ArrowFunctionExpression" &&
+                            prop.value.body.type === "Identifier"
+                        ) {
+                            factoryExports.set(prop.value.body.name, prop.key.name);
+                        }
+                    }
+                }
+            },
+        });
+
+        for (const newPath of newExprPaths) {
+            const calleeNode = newPath.node.callee;
+            const target = resolveCalleeToWrapperChunk(calleeNode, ast, thirdArgName, wrappers);
+            if (!target) continue;
+
+            const args = newPath.node.arguments;
+            const configObj = args[0];
+            const optionsObj = args.length > 1 ? args[1] : null;
+
+            // Resolve URL
+            const urlField = extractObjectField(configObj, "url");
+            if (!urlField) continue;
+            const urlSrc = chunk.code.slice(urlField.rawNode.start, urlField.rawNode.end);
+            let url = urlField.stringValue;
+            if (url === null) {
+                url = resolveNodeValue(
+                    urlField.rawNode,
+                    newPath.scope,
+                    urlSrc,
+                    "new",
+                    chunk.code,
+                    chunks,
+                    thirdArgName
+                );
+                if (typeof url === "string" && (url.includes("[var ") || url.includes("[MemberExpression"))) {
+                    const substituted = substituteVariablesInString(url, chunk.code, chunks, thirdArgName);
+                    if (substituted) url = substituted;
+                }
+            }
+
+            // Resolve method
+            const methodField = extractObjectField(configObj, "method");
+            let method = "GET";
+            if (methodField) {
+                if (methodField.stringValue) {
+                    method = methodField.stringValue.toUpperCase();
+                } else {
+                    const resolved = resolveNodeValue(
+                        methodField.rawNode,
+                        newPath.scope,
+                        "",
+                        "new",
+                        chunk.code,
+                        chunks,
+                        thirdArgName
+                    );
+                    if (typeof resolved === "string" && HTTP_METHODS.includes(resolved.toUpperCase())) {
+                        method = resolved.toUpperCase();
+                    }
+                }
+            }
+
+            // Determine dataType (body vs query). The wrapper class defaults to "query"
+            // if not specified, so absence ≡ "query".
+            let dataType: "body" | "query" = "query";
+            if (optionsObj && optionsObj.type === "ObjectExpression") {
+                const dt = extractObjectField(optionsObj, "dataType");
+                if (dt?.stringValue === "body") dataType = "body";
+            }
+
+            // Find enclosing factory function name, then try to trace .do(<arg>)
+            // calls from chunks that import this chunk.
+            let bodyJson: string = "";
+            const factoryName = enclosingFunctionName(newPath);
+            if (factoryName) {
+                const exportName = factoryExports.get(factoryName);
+                if (exportName) {
+                    // Also try local in-chunk call: factoryName().do(arg)
+                    let argInfo: { argNode: any; chunkCode: string } | null = null;
+                    const localArg = findFactoryDoCallArg(factoryName, ast);
+                    if (localArg) {
+                        argInfo = { argNode: localArg, chunkCode: chunk.code };
+                    } else {
+                        argInfo = traceDoCallAcrossChunks(chunk.id, exportName, chunks);
+                    }
+                    if (argInfo) {
+                        bodyJson = astNodeToJsonString(argInfo.argNode, argInfo.chunkCode);
+                    }
+                }
+            }
+
+            const lineNo = findLineInFile(fileContent, chunk.code, newPath.node);
+
+            console.log(
+                chalk.blue(
+                    `[+] Found wrapped HTTP request in chunk ${chunk.id} ("${filePath}":${lineNo})`
+                )
+            );
+            // For dataType="query", attach the resolved arg keys as a query string
+            // to the URL so the OpenAPI generator surfaces them as `in: query` params.
+            let finalUrl = typeof url === "string" ? url : String(url ?? "");
+            if (dataType === "query" && bodyJson) {
+                const qs = jsonStringToQueryString(bodyJson);
+                if (qs) finalUrl = finalUrl + (finalUrl.includes("?") ? "&" : "?") + qs;
+            }
+
+            console.log(chalk.green(`    URL: ${finalUrl}`));
+            console.log(chalk.green(`    Method: ${method}`));
+            console.log(chalk.gray(`    dataType: ${dataType}`));
+            if (bodyJson) {
+                if (dataType === "query") {
+                    console.log(chalk.green(`    Query params: ${bodyJson}`));
+                } else {
+                    console.log(chalk.green(`    Body: ${bodyJson}`));
+                }
+            }
+
+            globals.addOpenapiOutput({
+                url: finalUrl,
+                method,
+                path: finalUrl,
+                headers: {},
+                body: dataType === "body" ? bodyJson : "",
+                chunkId: chunk.id,
+                functionFile: filePath,
+                functionFileLine: lineNo,
+            });
+        }
+    }
+};
+
+/**
+ * Convert a JSON-ish string produced by astNodeToJsonString
+ * (which renders identifiers as bare strings and member exprs as code text)
+ * into a `key1=val1&key2=val2` query string for OpenAPI consumption.
+ * Best-effort: any unparseable values are emitted as `{var}` placeholders.
+ */
+const jsonStringToQueryString = (s: string): string => {
+    try {
+        // astNodeToJsonString emits valid-ish JSON; try parsing first
+        const obj = JSON.parse(s);
+        if (typeof obj !== "object" || obj === null || Array.isArray(obj)) return "";
+        const parts: string[] = [];
+        for (const [k, v] of Object.entries(obj)) {
+            const valStr = typeof v === "string" ? v : JSON.stringify(v);
+            parts.push(`${encodeURIComponent(k)}={${encodeURIComponent(valStr)}}`);
+        }
+        return parts.join("&");
+    } catch {
+        return "";
+    }
+};
+
+const findLineInFile = (fileContent: string, chunkCode: string, node: any): number => {
+    try {
+        const snippet = chunkCode.slice(node.start, node.end).split("\n")[0].trim();
+        if (!snippet) return -1;
+        const probe = snippet.slice(0, Math.min(snippet.length, 40));
+        const lines = fileContent.split("\n");
+        for (let i = 0; i < lines.length; i++) {
+            if (lines[i].includes(probe)) return i + 1;
+        }
+    } catch {}
+    return -1;
+};
+
+export default resolveNewRequest;

--- a/src/map/next_js/resolveNewRequest.ts
+++ b/src/map/next_js/resolveNewRequest.ts
@@ -77,11 +77,7 @@ const findWrapperClasses = (chunks: Chunks): Map<string, Set<string>> => {
                     path.node.arguments[1].type === "ObjectExpression"
                 ) {
                     for (const prop of path.node.arguments[1].properties) {
-                        if (
-                            prop.type !== "ObjectProperty" ||
-                            prop.key.type !== "Identifier"
-                        )
-                            continue;
+                        if (prop.type !== "ObjectProperty" || prop.key.type !== "Identifier") continue;
                         const exportName = prop.key.name;
                         const value = prop.value;
                         // Pattern: A: () => E
@@ -182,10 +178,7 @@ const findNewExpressionsWithUrl = (ast: any): any[] => {
 
             // Must have a `url` property (heuristic for HTTP config)
             const hasUrl = first.properties.some(
-                (p: any) =>
-                    p.type === "ObjectProperty" &&
-                    p.key.type === "Identifier" &&
-                    p.key.name === "url"
+                (p: any) => p.type === "ObjectProperty" && p.key.type === "Identifier" && p.key.name === "url"
             );
             if (!hasUrl) return;
 
@@ -264,17 +257,10 @@ const resolveCalleeToWrapperChunk = (
  * Extract a known string field (e.g., "method") from the first ObjectExpression
  * argument of a `new` call. Returns the raw value (uppercased for methods) or null.
  */
-const extractObjectField = (
-    objExpr: any,
-    fieldName: string
-): { rawNode: any; stringValue: string | null } | null => {
+const extractObjectField = (objExpr: any, fieldName: string): { rawNode: any; stringValue: string | null } | null => {
     if (!objExpr || objExpr.type !== "ObjectExpression") return null;
     for (const prop of objExpr.properties) {
-        if (
-            prop.type === "ObjectProperty" &&
-            prop.key.type === "Identifier" &&
-            prop.key.name === fieldName
-        ) {
+        if (prop.type === "ObjectProperty" && prop.key.type === "Identifier" && prop.key.name === fieldName) {
             let val: string | null = null;
             if (prop.value.type === "StringLiteral") val = prop.value.value;
             return { rawNode: prop.value, stringValue: val };
@@ -362,10 +348,7 @@ const findFactoryDoCallArg = (factoryName: string, ast: any): any | null => {
                     return;
                 }
                 // Case B: instance.do(arg) where instance came from factoryName()
-                if (
-                    callee.object.type === "Identifier" &&
-                    instanceVars.has(callee.object.name)
-                ) {
+                if (callee.object.type === "Identifier" && instanceVars.has(callee.object.name)) {
                     result = p.node.arguments[0];
                     p.stop();
                     return;
@@ -420,8 +403,12 @@ const traceDoCallAcrossChunks = (
                     p.node.id.type === "Identifier"
                 ) {
                     const arg = init.arguments[0];
-                    const argVal = arg.type === "NumericLiteral" ? String(arg.value)
-                                 : arg.type === "StringLiteral" ? arg.value : null;
+                    const argVal =
+                        arg.type === "NumericLiteral"
+                            ? String(arg.value)
+                            : arg.type === "StringLiteral"
+                              ? arg.value
+                              : null;
                     if (argVal === sourceChunkId) {
                         localBinding = p.node.id.name;
                     }
@@ -442,7 +429,8 @@ const traceDoCallAcrossChunks = (
                 c.object.name === localBinding &&
                 c.property.type === "Identifier" &&
                 c.property.name === factoryExportName
-            ) return true;
+            )
+                return true;
             // (0, localBinding.factoryExportName)(...)
             if (c.type === "SequenceExpression" && c.expressions.length === 2) {
                 const last = c.expressions[1];
@@ -452,7 +440,8 @@ const traceDoCallAcrossChunks = (
                     last.object.name === localBinding &&
                     last.property.type === "Identifier" &&
                     last.property.name === factoryExportName
-                ) return true;
+                )
+                    return true;
             }
             return false;
         };
@@ -515,7 +504,8 @@ const traceDoCallAcrossChunks = (
                     callee.property.type !== "Identifier" ||
                     !DO_METHODS.has(callee.property.name) ||
                     p.node.arguments.length === 0
-                ) return;
+                )
+                    return;
 
                 const recv = callee.object;
 
@@ -575,11 +565,7 @@ const resolveNewRequest = async (chunks: Chunks, directory: string) => {
     }
 
     for (const [chunkId, exports] of wrappers.entries()) {
-        console.log(
-            chalk.green(
-                `    [✓] Wrapper class chunk ${chunkId} exports: ${Array.from(exports).join(", ")}`
-            )
-        );
+        console.log(chalk.green(`    [✓] Wrapper class chunk ${chunkId} exports: ${Array.from(exports).join(", ")}`));
     }
 
     // Also collect, per wrapper chunk, the set of "factory" export bindings
@@ -724,11 +710,7 @@ const resolveNewRequest = async (chunks: Chunks, directory: string) => {
 
             const lineNo = findLineInFile(fileContent, chunk.code, newPath.node);
 
-            console.log(
-                chalk.blue(
-                    `[+] Found wrapped HTTP request in chunk ${chunk.id} ("${filePath}":${lineNo})`
-                )
-            );
+            console.log(chalk.blue(`[+] Found wrapped HTTP request in chunk ${chunk.id} ("${filePath}":${lineNo})`));
             // For dataType="query", attach the resolved arg keys as a query string
             // to the URL so the OpenAPI generator surfaces them as `in: query` params.
             let finalUrl = typeof url === "string" ? url : String(url ?? "");

--- a/src/map/next_js/resolveNewRequest.ts
+++ b/src/map/next_js/resolveNewRequest.ts
@@ -187,11 +187,7 @@ const findNewExpressionsWithUrl = (ast: any): any[] => {
             const hasUrl = first.properties.some((p: any) => {
                 if (p.type !== "ObjectProperty") return false;
                 const keyName =
-                    p.key.type === "Identifier"
-                        ? p.key.name
-                        : p.key.type === "StringLiteral"
-                          ? p.key.value
-                          : null;
+                    p.key.type === "Identifier" ? p.key.name : p.key.type === "StringLiteral" ? p.key.value : null;
                 return keyName === "url";
             });
             if (!hasUrl) return;
@@ -276,11 +272,7 @@ const extractObjectField = (objExpr: any, fieldName: string): { rawNode: any; st
     for (const prop of objExpr.properties) {
         if (prop.type !== "ObjectProperty") continue;
         const keyName =
-            prop.key.type === "Identifier"
-                ? prop.key.name
-                : prop.key.type === "StringLiteral"
-                  ? prop.key.value
-                  : null;
+            prop.key.type === "Identifier" ? prop.key.name : prop.key.type === "StringLiteral" ? prop.key.value : null;
         if (keyName !== fieldName) continue;
         let val: string | null = null;
         if (prop.value.type === "StringLiteral") val = prop.value.value;

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -659,6 +659,18 @@ export const resolveWebpackChunkImport = (
         const convertAstToValue = (node: Node, remainingPath: string[] = []): any => {
             if (!node) return null;
 
+            // Unwrap Object.freeze({...}) and similar one-arg wrappers that return their first arg.
+            if (
+                node.type === "CallExpression" &&
+                (node as any).callee?.type === "MemberExpression" &&
+                (node as any).callee.property?.type === "Identifier" &&
+                ((node as any).callee.property.name === "freeze" ||
+                    (node as any).callee.property.name === "assign") &&
+                (node as any).arguments?.length > 0
+            ) {
+                return convertAstToValue((node as any).arguments[0], remainingPath);
+            }
+
             if (node.type === "ObjectExpression") {
                 const obj: { [key: string]: any } = {};
                 for (const prop of node.properties) {
@@ -987,7 +999,7 @@ export const resolveNodeValue = (
     initialNode: Node,
     scope: Scope,
     nodeCode: string,
-    callType: "fetch" | "axios",
+    callType: "fetch" | "axios" | "new",
     chunkCode?: string,
     chunks?: Chunks,
     thirdArgName?: string
@@ -1149,38 +1161,46 @@ export const resolveNodeValue = (
                     return obj;
                 }
                 case "MemberExpression": {
-                    // Handle webpack chunk imports first - try to resolve directly
-                    if (
-                        currentNode.object.type === "Identifier" &&
-                        currentNode.property.type === "Identifier" &&
-                        !currentNode.computed &&
-                        chunkCode &&
-                        chunks &&
-                        thirdArgName
-                    ) {
-                        const identifierName = currentNode.object.name;
-                        const propertyName = currentNode.property.name;
-
-                        // Try webpack chunk import resolution directly
-                        try {
-                            const webpackResult = resolveWebpackChunkImport(
-                                identifierName,
-                                chunkCode,
-                                chunks,
-                                thirdArgName,
-                                [propertyName]
-                            );
-
-                            if (
-                                webpackResult &&
-                                typeof webpackResult === "string" &&
-                                !webpackResult.startsWith("[unresolved") &&
-                                !webpackResult.startsWith("[error")
-                            ) {
-                                return webpackResult;
+                    // Handle deeply-nested webpack chunk imports by flattening the chain:
+                    //   s.h.NEXT_OKTA_VALIDATE_USER  ->  resolveWebpackChunkImport("s", ..., ["h", "NEXT_OKTA_VALIDATE_USER"])
+                    if (chunkCode && chunks && thirdArgName && !currentNode.computed) {
+                        const chain: string[] = [];
+                        let walker: any = currentNode;
+                        let rootIdent: string | null = null;
+                        while (walker) {
+                            if (walker.type === "MemberExpression" && !walker.computed && walker.property.type === "Identifier") {
+                                chain.unshift(walker.property.name);
+                                walker = walker.object;
+                            } else if (walker.type === "Identifier") {
+                                rootIdent = walker.name;
+                                break;
+                            } else {
+                                break;
                             }
-                        } catch (e) {
-                            // Fall through to normal resolution
+                        }
+                        if (rootIdent && chain.length > 0) {
+                            try {
+                                const webpackResult = resolveWebpackChunkImport(
+                                    rootIdent,
+                                    chunkCode,
+                                    chunks,
+                                    thirdArgName,
+                                    chain
+                                );
+                                if (
+                                    webpackResult !== null &&
+                                    webpackResult !== undefined &&
+                                    typeof webpackResult === "string" &&
+                                    !webpackResult.startsWith("[unresolved") &&
+                                    !webpackResult.startsWith("[error") &&
+                                    !webpackResult.startsWith("[unsupported") &&
+                                    !webpackResult.startsWith("[max_depth")
+                                ) {
+                                    return webpackResult;
+                                }
+                            } catch (e) {
+                                // fall through
+                            }
                         }
                     }
 

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -1063,7 +1063,22 @@ export const resolveNodeValue = (
                                         prop.value.callee.property.type === "Identifier" &&
                                         prop.value.callee.property.name === "stringify"
                                     ) {
-                                        obj[key] = "[call to object...]";
+                                        // Nested JSON.stringify(expr) — resolve expr so we show what's being serialized.
+                                        const innerArgs = prop.value.arguments;
+                                        if (innerArgs.length > 0) {
+                                            obj[key] =
+                                                resolveNodeValue(
+                                                    innerArgs[0] as Node,
+                                                    scope,
+                                                    "",
+                                                    callType,
+                                                    chunkCode,
+                                                    chunks,
+                                                    thirdArgName
+                                                ) ?? "[call to object...]";
+                                        } else {
+                                            obj[key] = "[call to object...]";
+                                        }
                                     } else {
                                         obj[key] = resolveNodeValue(
                                             prop.value,
@@ -1076,14 +1091,26 @@ export const resolveNodeValue = (
                                         ) ?? `[${prop.value.type}]`;
                                     }
                                 } else if (prop.type === "SpreadElement") {
-                                    const argName =
-                                        prop.argument.type === "Identifier"
-                                            ? prop.argument.name
-                                            : prop.argument.type;
-                                    obj["...spread"] = `[spread:${argName}]`;
+                                    // Skip unresolvable spread elements — they're code artifacts,
+                                    // not actual body fields.
                                 }
                             }
                             return obj;
+                        } else if (args.length > 0) {
+                            // Argument isn't a literal object — try resolving it (handles Identifier,
+                            // ConditionalExpression, etc.) so we can surface the actual body shape.
+                            const resolved = resolveNodeValue(
+                                args[0] as Node,
+                                scope,
+                                nodeCode,
+                                callType,
+                                chunkCode,
+                                chunks,
+                                thirdArgName
+                            );
+                            if (resolved !== null && resolved !== undefined && resolved !== "[call_stack_exceeded_use_better_machine]") {
+                                return resolved;
+                            }
                         }
                     }
                 }
@@ -1476,6 +1503,62 @@ export const resolveNodeValue = (
                         currentNode = currentNode.arguments[0];
                         continue;
                     }
+                    if (
+                        currentNode.callee.type === "Identifier" &&
+                        currentNode.callee.name === "URLSearchParams" &&
+                        currentNode.arguments.length > 0
+                    ) {
+                        const spArg = currentNode.arguments[0];
+                        if (spArg.type === "ObjectExpression") {
+                            const params: string[] = [];
+                            for (const prop of spArg.properties) {
+                                if (prop.type !== "ObjectProperty") continue;
+                                const key =
+                                    prop.key.type === "Identifier"
+                                        ? prop.key.name
+                                        : prop.key.type === "StringLiteral"
+                                          ? prop.key.value
+                                          : null;
+                                if (!key) continue;
+                                const val = resolveNodeValue(
+                                    prop.value,
+                                    scope,
+                                    nodeCode,
+                                    callType,
+                                    chunkCode,
+                                    chunks,
+                                    thirdArgName
+                                );
+                                if (val === "[call_stack_exceeded_use_better_machine]") return val;
+                                // Use the literal value when fully resolved; otherwise use {key} as placeholder.
+                                const valStr =
+                                    val !== null &&
+                                    val !== undefined &&
+                                    !String(val).startsWith("[")
+                                        ? encodeURIComponent(String(val))
+                                        : `{${key}}`;
+                                params.push(`${key}=${valStr}`);
+                            }
+                            if (params.length > 0) return params.join("&");
+                        }
+                        // Non-object arg — try to resolve it directly
+                        const spResolved = resolveNodeValue(
+                            spArg,
+                            scope,
+                            nodeCode,
+                            callType,
+                            chunkCode,
+                            chunks,
+                            thirdArgName
+                        );
+                        if (
+                            spResolved !== null &&
+                            spResolved !== undefined &&
+                            spResolved !== "[call_stack_exceeded_use_better_machine]"
+                        ) {
+                            return String(spResolved);
+                        }
+                    }
                     return `[unresolved new expression]`;
                 }
                 case "LogicalExpression": {
@@ -1539,19 +1622,72 @@ export const resolveNodeValue = (
                     if (right === "[call_stack_exceeded_use_better_machine]") {
                         return right;
                     }
-                    if (
-                        left !== null &&
-                        right !== null &&
-                        !String(left).startsWith("[") &&
-                        !String(right).startsWith("[")
-                    ) {
-                        // eslint-disable-next-line default-case
-                        switch (currentNode.operator) {
-                            case "+":
-                                return left + right;
+                    if (currentNode.operator === "+") {
+                        const leftOk = left !== null && left !== undefined;
+                        const rightOk = right !== null && right !== undefined;
+                        // Fully resolved — concatenate directly.
+                        if (
+                            leftOk &&
+                            rightOk &&
+                            !String(left).startsWith("[") &&
+                            !String(right).startsWith("[")
+                        ) {
+                            return left + right;
                         }
+                        // Partially resolved — concatenate what we have so the caller
+                        // at least sees the resolvable fragments alongside the placeholders.
+                        if (leftOk && rightOk) {
+                            return `${left}${right}`;
+                        }
+                        if (leftOk) return String(left);
+                        if (rightOk) return String(right);
                     }
                     return `[unresolved binary expression: ${currentNode.operator}]`;
+                }
+                case "ArrayExpression": {
+                    const elements: any[] = [];
+                    for (const element of currentNode.elements) {
+                        if (element === null) {
+                            elements.push(null);
+                            continue;
+                        }
+                        const resolved = resolveNodeValue(
+                            element,
+                            scope,
+                            nodeCode,
+                            callType,
+                            chunkCode,
+                            chunks,
+                            thirdArgName
+                        );
+                        if (resolved === "[call_stack_exceeded_use_better_machine]") return resolved;
+                        elements.push(resolved);
+                    }
+                    return elements;
+                }
+                case "UnaryExpression": {
+                    if (currentNode.operator === "void") return null;
+                    const operand = resolveNodeValue(
+                        (currentNode as any).argument,
+                        scope,
+                        nodeCode,
+                        callType,
+                        chunkCode,
+                        chunks,
+                        thirdArgName
+                    );
+                    if (operand === "[call_stack_exceeded_use_better_machine]") return operand;
+                    if (currentNode.operator === "!") {
+                        if (typeof operand === "boolean") return !operand;
+                        if (typeof operand === "number") return operand === 0;
+                        return "<boolean>";
+                    }
+                    if (currentNode.operator === "-") {
+                        if (typeof operand === "number") return -operand;
+                        return "<number>";
+                    }
+                    if (currentNode.operator === "typeof") return "<string>";
+                    return "<unknown>";
                 }
                 default:
                     return `[unsupported node type: ${currentNode.type}]`;

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -560,11 +560,16 @@ export const resolveWebpackChunkImport = (
         }
 
         // Parse the target chunk
-        const targetAst = parser.parse(targetChunk.code, {
-            sourceType: "unambiguous",
-            plugins: ["jsx", "typescript"],
-            errorRecovery: true,
-        });
+        let targetAst;
+        try {
+            targetAst = parser.parse(targetChunk.code, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+        } catch {
+            return `[webpack_import: chunk_${targetChunkId}]`;
+        }
 
         // Find the export for the first property in memberPath
         const firstProperty = memberPath[0];
@@ -1319,11 +1324,16 @@ export const resolveNodeValue = (
                     // first, match as regex
                     if (nodeCode.replace(/\n\s*/g, "").match(/^"[^"]*"(\.concat\(.+\))+$/)) {
                         // parse it separately with ast
-                        const ast = parser.parse(nodeCode, {
-                            sourceType: "unambiguous",
-                            plugins: ["jsx", "typescript"],
-                            errorRecovery: true,
-                        });
+                        let ast;
+                        try {
+                            ast = parser.parse(nodeCode, {
+                                sourceType: "unambiguous",
+                                plugins: ["jsx", "typescript"],
+                                errorRecovery: true,
+                            });
+                        } catch {
+                            break;
+                        }
 
                         // get all the concat calls first. Like .concat(...)
                         // I want to only get concat() and nothing else. Also, it doesn't matter how many times they are called

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -1080,15 +1080,16 @@ export const resolveNodeValue = (
                                             obj[key] = "[call to object...]";
                                         }
                                     } else {
-                                        obj[key] = resolveNodeValue(
-                                            prop.value,
-                                            scope,
-                                            "",
-                                            callType,
-                                            chunkCode,
-                                            chunks,
-                                            thirdArgName
-                                        ) ?? `[${prop.value.type}]`;
+                                        obj[key] =
+                                            resolveNodeValue(
+                                                prop.value,
+                                                scope,
+                                                "",
+                                                callType,
+                                                chunkCode,
+                                                chunks,
+                                                thirdArgName
+                                            ) ?? `[${prop.value.type}]`;
                                     }
                                 } else if (prop.type === "SpreadElement") {
                                     // Skip unresolvable spread elements — they're code artifacts,
@@ -1108,7 +1109,11 @@ export const resolveNodeValue = (
                                 chunks,
                                 thirdArgName
                             );
-                            if (resolved !== null && resolved !== undefined && resolved !== "[call_stack_exceeded_use_better_machine]") {
+                            if (
+                                resolved !== null &&
+                                resolved !== undefined &&
+                                resolved !== "[call_stack_exceeded_use_better_machine]"
+                            ) {
                                 return resolved;
                             }
                         }
@@ -1532,9 +1537,7 @@ export const resolveNodeValue = (
                                 if (val === "[call_stack_exceeded_use_better_machine]") return val;
                                 // Use the literal value when fully resolved; otherwise use {key} as placeholder.
                                 const valStr =
-                                    val !== null &&
-                                    val !== undefined &&
-                                    !String(val).startsWith("[")
+                                    val !== null && val !== undefined && !String(val).startsWith("[")
                                         ? encodeURIComponent(String(val))
                                         : `{${key}}`;
                                 params.push(`${key}=${valStr}`);
@@ -1626,12 +1629,7 @@ export const resolveNodeValue = (
                         const leftOk = left !== null && left !== undefined;
                         const rightOk = right !== null && right !== undefined;
                         // Fully resolved — concatenate directly.
-                        if (
-                            leftOk &&
-                            rightOk &&
-                            !String(left).startsWith("[") &&
-                            !String(right).startsWith("[")
-                        ) {
+                        if (leftOk && rightOk && !String(left).startsWith("[") && !String(right).startsWith("[")) {
                             return left + right;
                         }
                         // Partially resolved — concatenate what we have so the caller

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -664,15 +664,49 @@ export const resolveWebpackChunkImport = (
         const convertAstToValue = (node: Node, remainingPath: string[] = []): any => {
             if (!node) return null;
 
-            // Unwrap Object.freeze({...}) and similar one-arg wrappers that return their first arg.
+            // Unwrap Object.freeze({...}) — single-arg wrapper that returns its first arg.
             if (
                 node.type === "CallExpression" &&
                 (node as any).callee?.type === "MemberExpression" &&
                 (node as any).callee.property?.type === "Identifier" &&
-                ((node as any).callee.property.name === "freeze" || (node as any).callee.property.name === "assign") &&
+                (node as any).callee.property.name === "freeze" &&
                 (node as any).arguments?.length > 0
             ) {
                 return convertAstToValue((node as any).arguments[0], remainingPath);
+            }
+
+            // Unwrap Object.assign(target, ...sources) by merging each arg's properties
+            // so downstream remainingPath lookups can resolve keys contributed by sources.
+            if (
+                node.type === "CallExpression" &&
+                (node as any).callee?.type === "MemberExpression" &&
+                (node as any).callee.property?.type === "Identifier" &&
+                (node as any).callee.property.name === "assign" &&
+                (node as any).arguments?.length > 0
+            ) {
+                const merged: { [key: string]: any } = {};
+                for (const arg of (node as any).arguments) {
+                    const value = convertAstToValue(arg, []);
+                    if (value && typeof value === "object" && !Array.isArray(value)) {
+                        Object.assign(merged, value);
+                    }
+                }
+                if (remainingPath.length === 0) return merged;
+                const [next, ...rest] = remainingPath;
+                if (next in merged) {
+                    const v = merged[next];
+                    if (rest.length === 0) return v;
+                    if (v && typeof v === "object") {
+                        let cur: any = v;
+                        for (const k of rest) {
+                            if (cur && typeof cur === "object" && k in cur) cur = cur[k];
+                            else return null;
+                        }
+                        return cur;
+                    }
+                    return null;
+                }
+                return null;
             }
 
             if (node.type === "ObjectExpression") {

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -13,6 +13,30 @@ const traverse = _traverse.default;
  * @param depth - Current recursion depth to prevent infinite loops
  * @returns The resolved value or a placeholder if unresolved
  */
+/**
+ * Returns true if the given path is nested inside a loop statement.
+ * Used to skip loop-internal variable assignments that would shadow the
+ * top-level declaration we are interested in.
+ */
+const isInsideLoop = (p: any): boolean => {
+    let current = p.parentPath;
+    while (current) {
+        if (
+            current.isForStatement() ||
+            current.isForInStatement() ||
+            current.isForOfStatement() ||
+            current.isWhileStatement() ||
+            current.isDoWhileStatement()
+        ) {
+            return true;
+        }
+        // Don't cross function boundaries
+        if (current.isFunction()) break;
+        current = current.parentPath;
+    }
+    return false;
+};
+
 export const resolveVariableInChunk = (varName: string, chunkCode: string, depth: number = 0): any => {
     if (depth > 5) {
         return `[max recursion depth for ${varName}]`;
@@ -30,6 +54,10 @@ export const resolveVariableInChunk = (varName: string, chunkCode: string, depth
         traverse(ast, {
             // Find variable declarations: let/const/var varName = ...
             VariableDeclarator(path) {
+                // Skip declarations that are inside loops — they are loop counters or
+                // temporaries and would shadow the top-level variable we care about.
+                if (isInsideLoop(path)) return;
+
                 if (path.node.id.type === "Identifier" && path.node.id.name === varName && path.node.init) {
                     const init = path.node.init;
 
@@ -104,6 +132,9 @@ export const resolveVariableInChunk = (varName: string, chunkCode: string, depth
             },
             // Find assignments: varName = ...
             AssignmentExpression(path) {
+                // Skip assignments inside loops for the same reason as above
+                if (isInsideLoop(path)) return;
+
                 if (path.node.left.type === "Identifier" && path.node.left.name === varName) {
                     const right = path.node.right;
 
@@ -398,12 +429,21 @@ export const substituteVariablesInString = (
         const varName = match[1];
         const resolvedValue = resolveVariableInChunk(varName, chunkCode);
 
-        // Only substitute if we got a clean value (not an error/unresolved placeholder)
+        // Only substitute if we got a clean value (not an error/unresolved placeholder).
+        // Also reject values that contain placeholder-style brackets (they are not fully
+        // resolved), pure numbers (likely loop counters, not URL segments), very long
+        // strings (likely resolved to code, not a URL component), or strings containing
+        // ANSI escape sequences (leaked from logging utilities in the bundle).
         if (
             typeof resolvedValue === "string" &&
             !resolvedValue.startsWith("[unresolved:") &&
             !resolvedValue.startsWith("[error") &&
-            !resolvedValue.startsWith("[max recursion")
+            !resolvedValue.startsWith("[max recursion") &&
+            !resolvedValue.includes("[") &&
+            !/^\d+$/.test(resolvedValue) &&
+            !/^\d+:\d+$/.test(resolvedValue) &&
+            !resolvedValue.includes("\x1b") &&
+            resolvedValue.length <= 500
         ) {
             result = result.replace(`[var ${varName}]`, resolvedValue);
         }
@@ -1039,7 +1079,13 @@ export const resolveNodeValue = (
                 case "Identifier": {
                     const binding = scope.getBinding(currentNode.name);
                     if (binding && (binding.path.node as any).init) {
-                        currentNode = (binding.path.node as any).init;
+                        const initNode = (binding.path.node as any).init;
+                        // Update nodeCode to the actual source of the init so that concat
+                        // patterns (e.g. "".concat(x, "/path")) are re-parsed correctly
+                        if (chunkCode && typeof (initNode as any).start === "number" && typeof (initNode as any).end === "number") {
+                            nodeCode = chunkCode.slice((initNode as any).start, (initNode as any).end).replace(/\n\s*/g, "");
+                        }
+                        currentNode = initNode;
                         continue;
                     }
                     return `[unresolved: ${currentNode.name}]`;
@@ -1242,7 +1288,7 @@ export const resolveNodeValue = (
                     // .concat() with varying arguments end up here. They needs to be resolved as a string
 
                     // first, match as regex
-                    if (nodeCode.replace(/\n\s*/g, "").match(/^"[\d\w\/]*"(\.concat\(.+\))+$/)) {
+                    if (nodeCode.replace(/\n\s*/g, "").match(/^"[^"]*"(\.concat\(.+\))+$/)) {
                         // parse it separately with ast
                         const ast = parser.parse(nodeCode, {
                             sourceType: "unambiguous",
@@ -1320,6 +1366,10 @@ export const resolveNodeValue = (
                     }
 
                     return `[unresolved call to ${calleeName || "function"} -> ${nodeCode?.replace(/\n\s*/g, "")}]`;
+                }
+                case "AwaitExpression": {
+                    currentNode = (currentNode as any).argument;
+                    continue;
                 }
                 case "NewExpression": {
                     if (

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -1039,7 +1039,24 @@ export const resolveNodeValue = (
                                 if (prop.type === "ObjectProperty" && prop.key.type === "Identifier") {
                                     const key = prop.key.name;
                                     if (prop.value.type === "Identifier") {
-                                        obj[key] = prop.value.name;
+                                        // Try to resolve via scope; fall back to [param:name] for params
+                                        const valBinding = scope.getBinding(prop.value.name);
+                                        if (valBinding && (valBinding.path.node as any).init) {
+                                            const resolved = resolveNodeValue(
+                                                prop.value,
+                                                scope,
+                                                "",
+                                                callType,
+                                                chunkCode,
+                                                chunks,
+                                                thirdArgName
+                                            );
+                                            obj[key] = resolved;
+                                        } else if (valBinding && valBinding.kind === "param") {
+                                            obj[key] = `[param:${prop.value.name}]`;
+                                        } else {
+                                            obj[key] = prop.value.name;
+                                        }
                                     } else if (
                                         prop.value.type === "CallExpression" &&
                                         prop.value.callee.type === "MemberExpression" &&
@@ -1048,13 +1065,22 @@ export const resolveNodeValue = (
                                     ) {
                                         obj[key] = "[call to object...]";
                                     } else {
-                                        // For other types of values, you might want to add more handling
-                                        // For now, we'll just represent them as a string of their type.
-                                        obj[key] = `[${prop.value.type}]`;
+                                        obj[key] = resolveNodeValue(
+                                            prop.value,
+                                            scope,
+                                            "",
+                                            callType,
+                                            chunkCode,
+                                            chunks,
+                                            thirdArgName
+                                        ) ?? `[${prop.value.type}]`;
                                     }
                                 } else if (prop.type === "SpreadElement") {
-                                    // Handle spread elements if necessary, e.g., by adding a placeholder
-                                    obj["...spread"] = `[${prop.argument.type}]`;
+                                    const argName =
+                                        prop.argument.type === "Identifier"
+                                            ? prop.argument.name
+                                            : prop.argument.type;
+                                    obj["...spread"] = `[spread:${argName}]`;
                                 }
                             }
                             return obj;
@@ -1109,6 +1135,9 @@ export const resolveNodeValue = (
                         }
                         currentNode = initNode;
                         continue;
+                    }
+                    if (binding && binding.kind === "param") {
+                        return `[param:${currentNode.name}]`;
                     }
                     return `[unresolved: ${currentNode.name}]`;
                 }
@@ -1252,6 +1281,22 @@ export const resolveNodeValue = (
                         return object[propertyName];
                     }
 
+                    // Build a readable path like [member:e.Rut.toString] for unresolved member expressions
+                    const memberParts: string[] = [];
+                    let memberWalker: any = currentNode;
+                    while (
+                        memberWalker &&
+                        memberWalker.type === "MemberExpression" &&
+                        !memberWalker.computed &&
+                        memberWalker.property.type === "Identifier"
+                    ) {
+                        memberParts.unshift(memberWalker.property.name);
+                        memberWalker = memberWalker.object;
+                    }
+                    if (memberWalker && memberWalker.type === "Identifier" && memberParts.length > 0) {
+                        memberParts.unshift(memberWalker.name);
+                        return `[member:${memberParts.join(".")}]`;
+                    }
                     return `[unresolved member expression]`;
                 }
                 case "CallExpression": {
@@ -1404,7 +1449,19 @@ export const resolveNodeValue = (
                         }
                     }
 
-                    return `[unresolved call to ${calleeName || "function"} -> ${nodeCode?.replace(/\n\s*/g, "")}]`;
+                    // Build a readable callee label for the placeholder
+                    let calleeLabel = calleeName !== "[unknown]" ? calleeName : "";
+                    if (!calleeLabel && currentNode.callee.type === "MemberExpression") {
+                        const parts: string[] = [];
+                        let c: any = currentNode.callee;
+                        while (c.type === "MemberExpression" && !c.computed && c.property.type === "Identifier") {
+                            parts.unshift(c.property.name);
+                            c = c.object;
+                        }
+                        if (c.type === "Identifier") parts.unshift(c.name);
+                        calleeLabel = parts.join(".");
+                    }
+                    return `[call:${calleeLabel || "?"}()]`;
                 }
                 case "AwaitExpression": {
                     currentNode = (currentNode as any).argument;

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -664,8 +664,7 @@ export const resolveWebpackChunkImport = (
                 node.type === "CallExpression" &&
                 (node as any).callee?.type === "MemberExpression" &&
                 (node as any).callee.property?.type === "Identifier" &&
-                ((node as any).callee.property.name === "freeze" ||
-                    (node as any).callee.property.name === "assign") &&
+                ((node as any).callee.property.name === "freeze" || (node as any).callee.property.name === "assign") &&
                 (node as any).arguments?.length > 0
             ) {
                 return convertAstToValue((node as any).arguments[0], remainingPath);
@@ -1094,8 +1093,14 @@ export const resolveNodeValue = (
                         const initNode = (binding.path.node as any).init;
                         // Update nodeCode to the actual source of the init so that concat
                         // patterns (e.g. "".concat(x, "/path")) are re-parsed correctly
-                        if (chunkCode && typeof (initNode as any).start === "number" && typeof (initNode as any).end === "number") {
-                            nodeCode = chunkCode.slice((initNode as any).start, (initNode as any).end).replace(/\n\s*/g, "");
+                        if (
+                            chunkCode &&
+                            typeof (initNode as any).start === "number" &&
+                            typeof (initNode as any).end === "number"
+                        ) {
+                            nodeCode = chunkCode
+                                .slice((initNode as any).start, (initNode as any).end)
+                                .replace(/\n\s*/g, "");
                         }
                         currentNode = initNode;
                         continue;
@@ -1168,7 +1173,11 @@ export const resolveNodeValue = (
                         let walker: any = currentNode;
                         let rootIdent: string | null = null;
                         while (walker) {
-                            if (walker.type === "MemberExpression" && !walker.computed && walker.property.type === "Identifier") {
+                            if (
+                                walker.type === "MemberExpression" &&
+                                !walker.computed &&
+                                walker.property.type === "Identifier"
+                            ) {
                                 chain.unshift(walker.property.name);
                                 walker = walker.object;
                             } else if (walker.type === "Identifier") {

--- a/src/map/vue_js/vue_resolveFetch.ts
+++ b/src/map/vue_js/vue_resolveFetch.ts
@@ -96,13 +96,7 @@ const vue_resolveFetch = async (directory: string): Promise<void> => {
                     .slice((args[0] as any).start, (args[0] as any).end)
                     .replace(/\n\s*/g, "");
 
-                let url: any = resolveNodeValue(
-                    args[0],
-                    callPath.scope,
-                    urlArgCode,
-                    "fetch",
-                    fileContent
-                );
+                let url: any = resolveNodeValue(args[0], callPath.scope, urlArgCode, "fetch", fileContent);
 
                 if (typeof url === "string" && (url.includes("[var ") || url.includes("[MemberExpression"))) {
                     const substituted = substituteVariablesInString(url, fileContent);
@@ -119,13 +113,7 @@ const vue_resolveFetch = async (directory: string): Promise<void> => {
                 let body = "";
 
                 if (args.length > 1) {
-                    const options: any = resolveNodeValue(
-                        args[1],
-                        callPath.scope,
-                        "",
-                        "fetch",
-                        fileContent
-                    );
+                    const options: any = resolveNodeValue(args[1], callPath.scope, "", "fetch", fileContent);
 
                     if (typeof options === "object" && options !== null) {
                         method = options.method || "GET";
@@ -134,13 +122,9 @@ const vue_resolveFetch = async (directory: string): Promise<void> => {
                             const resolvedHeaders: Record<string, string> = {};
                             for (const [k, v] of Object.entries(options.headers)) {
                                 const rk =
-                                    typeof k === "string"
-                                        ? substituteVariablesInString(k, fileContent)
-                                        : String(k);
+                                    typeof k === "string" ? substituteVariablesInString(k, fileContent) : String(k);
                                 const rv =
-                                    typeof v === "string"
-                                        ? substituteVariablesInString(v, fileContent)
-                                        : String(v);
+                                    typeof v === "string" ? substituteVariablesInString(v, fileContent) : String(v);
                                 resolvedHeaders[rk] = rv;
                             }
                             headers = resolvedHeaders;
@@ -148,9 +132,7 @@ const vue_resolveFetch = async (directory: string): Promise<void> => {
 
                         if (options.body) {
                             body =
-                                typeof options.body === "object"
-                                    ? JSON.stringify(options.body)
-                                    : String(options.body);
+                                typeof options.body === "object" ? JSON.stringify(options.body) : String(options.body);
                         }
 
                         console.log(chalk.green(`    Method: ${method}`));

--- a/src/map/vue_js/vue_resolveFetch.ts
+++ b/src/map/vue_js/vue_resolveFetch.ts
@@ -1,0 +1,180 @@
+import chalk from "chalk";
+import parser from "@babel/parser";
+import _traverse from "@babel/traverse";
+import fs from "fs";
+import path from "path";
+import { resolveNodeValue, substituteVariablesInString } from "../next_js/utils.js";
+import * as globals from "../../utility/globals.js";
+
+const traverse = _traverse.default;
+
+/**
+ * Scans all JS files in the given directory for fetch() calls,
+ * resolves their URL / method / headers / body, and registers each
+ * call with the OpenAPI output collector.
+ *
+ * Designed for Vite-bundled Vue.JS applications where HTTP calls are
+ * made with the native fetch() API rather than via webpack chunks.
+ */
+const vue_resolveFetch = async (directory: string): Promise<void> => {
+    console.log(chalk.cyan("[i] Resolving Vue.JS fetch instances"));
+
+    let files: string[];
+    try {
+        files = fs.readdirSync(directory, { recursive: true, encoding: "utf8" }) as string[];
+    } catch {
+        console.log(chalk.red(`[!] Could not read directory: ${directory}`));
+        return;
+    }
+
+    files = files
+        .filter((f) => f.endsWith(".js") && !f.includes("___subsequent_requests"))
+        .filter((f) => !fs.lstatSync(path.join(directory, f)).isDirectory());
+
+    let totalFetchCalls = 0;
+
+    for (const file of files) {
+        const filePath = path.join(directory, file);
+        let fileContent: string;
+        try {
+            fileContent = fs.readFileSync(filePath, "utf-8");
+        } catch {
+            continue;
+        }
+
+        // Fast path: skip files with no fetch keyword at all
+        if (!fileContent.includes("fetch")) continue;
+
+        let fileAst: any;
+        try {
+            fileAst = parser.parse(fileContent, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            });
+        } catch {
+            continue;
+        }
+
+        // Collect fetch aliases (const x = fetch)
+        const fetchAliases = new Set<any>();
+        traverse(fileAst, {
+            VariableDeclarator(p) {
+                const { id, init } = p.node;
+                if (id.type !== "Identifier" || !init) return;
+                if (init.type === "Identifier" && init.name === "fetch") {
+                    const binding = p.scope.getBinding(id.name);
+                    if (binding) fetchAliases.add(binding);
+                }
+            },
+        });
+
+        // Resolve each fetch call
+        traverse(fileAst, {
+            CallExpression(callPath) {
+                const callee = callPath.node.callee;
+                let isFetchCall = false;
+
+                if (callee.type === "Identifier" && callee.name === "fetch") {
+                    isFetchCall = true;
+                } else if (callee.type === "Identifier") {
+                    const binding = callPath.scope.getBinding(callee.name);
+                    if (binding && fetchAliases.has(binding)) isFetchCall = true;
+                }
+
+                if (!isFetchCall) return;
+
+                const args = callPath.node.arguments;
+                if (args.length === 0) return;
+
+                const fileLine = callPath.node.loc?.start.line ?? 0;
+                console.log(chalk.blue(`[+] Found fetch call in "${filePath}":${fileLine}`));
+                totalFetchCalls++;
+
+                // Resolve URL (first argument)
+                const urlArgCode = fileContent
+                    .slice((args[0] as any).start, (args[0] as any).end)
+                    .replace(/\n\s*/g, "");
+
+                let url: any = resolveNodeValue(
+                    args[0],
+                    callPath.scope,
+                    urlArgCode,
+                    "fetch",
+                    fileContent
+                );
+
+                if (typeof url === "string" && (url.includes("[var ") || url.includes("[MemberExpression"))) {
+                    const substituted = substituteVariablesInString(url, fileContent);
+                    if (substituted !== url) {
+                        console.log(chalk.cyan(`    [i] Resolved variables in URL: ${url} -> ${substituted}`));
+                        url = substituted;
+                    }
+                }
+
+                console.log(chalk.green(`    URL: ${url}`));
+
+                let method = "GET";
+                let headers: Record<string, string> = {};
+                let body = "";
+
+                if (args.length > 1) {
+                    const options: any = resolveNodeValue(
+                        args[1],
+                        callPath.scope,
+                        "",
+                        "fetch",
+                        fileContent
+                    );
+
+                    if (typeof options === "object" && options !== null) {
+                        method = options.method || "GET";
+
+                        if (options.headers && typeof options.headers === "object") {
+                            const resolvedHeaders: Record<string, string> = {};
+                            for (const [k, v] of Object.entries(options.headers)) {
+                                const rk =
+                                    typeof k === "string"
+                                        ? substituteVariablesInString(k, fileContent)
+                                        : String(k);
+                                const rv =
+                                    typeof v === "string"
+                                        ? substituteVariablesInString(v, fileContent)
+                                        : String(v);
+                                resolvedHeaders[rk] = rv;
+                            }
+                            headers = resolvedHeaders;
+                        }
+
+                        if (options.body) {
+                            body =
+                                typeof options.body === "object"
+                                    ? JSON.stringify(options.body)
+                                    : String(options.body);
+                        }
+
+                        console.log(chalk.green(`    Method: ${method}`));
+                        if (Object.keys(headers).length > 0)
+                            console.log(chalk.green(`    Headers: ${JSON.stringify(headers)}`));
+                        if (body) console.log(chalk.green(`    Body: ${body}`));
+                    }
+                }
+
+                globals.addOpenapiOutput({
+                    url: String(url),
+                    method,
+                    path: String(url),
+                    headers,
+                    body,
+                    chunkId: file,
+                    functionFile: filePath,
+                    functionFileLine: fileLine,
+                });
+            },
+        });
+    }
+
+    console.log(chalk.green(`[✓] Found and resolved ${totalFetchCalls} fetch call(s) across Vue.JS files`));
+};
+
+export default vue_resolveFetch;

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -110,12 +110,17 @@ const processUrl = async (
     }
 
     if (globalsUtil.getTech() === "vue") {
-        // Vue.JS pipeline: lazyload (done) + map. Other stages aren't Vue-ready yet.
+        // Vue.JS pipeline: lazyload (done) + map + OpenAPI/Postman output.
         // Scan the whole download directory: Vue builds frequently spread chunks
         // across multiple asset hosts, and relative imports resolve within each tree.
         const mappedFileVue = isBatch ? `${workingDir}/mapped` : "mapped";
+        const openapiFile = isBatch ? `${workingDir}/mapped-openapi.json` : "mapped-openapi.json";
 
-        console.log(chalk.bgCyan("[2/2] Running map to find functions..."));
+        console.log(chalk.bgCyan("[2/3] Running map to find functions and API calls..."));
+        globalsUtil.setOpenapi(true);
+        if (isBatch) {
+            globalsUtil.setOpenapiOutputFile(openapiFile);
+        }
         await map(outputDir, mappedFileVue, ["json"], "vue", false, false);
         console.log(chalk.bgGreen("[+] Map complete."));
 

--- a/src/strings/index.ts
+++ b/src/strings/index.ts
@@ -211,7 +211,7 @@ const strings = async (
                     // like "./path/to/resource" or "../path/to/resource"
                     paths.push(string);
                 }
-                if (string.match(/^.+\.js$/)){
+                if (string.match(/^.+\.js$/)) {
                     // like "assets/app.abc.js"
                     paths.push(string);
                 }

--- a/src/strings/index.ts
+++ b/src/strings/index.ts
@@ -12,7 +12,7 @@ import openapi from "./openapi.js";
  * @param {object} node - The AST node to extract strings from
  * @returns {string[]} An array of extracted string literals
  */
-const extractStrings = (node: object): string[] => {
+export const extractStrings = (node: object): string[] => {
     const strings: Set<string> = new Set();
     const seen = new WeakSet();
 

--- a/src/strings/index.ts
+++ b/src/strings/index.ts
@@ -211,6 +211,10 @@ const strings = async (
                     // like "./path/to/resource" or "../path/to/resource"
                     paths.push(string);
                 }
+                if (string.match(/^.+\.js$/)){
+                    // like "assets/app.abc.js"
+                    paths.push(string);
+                }
             }
         }
 

--- a/src/utility/makeReq.ts
+++ b/src/utility/makeReq.ts
@@ -345,12 +345,15 @@ const makeRequest = async (
         // when buffer-backed bodies share underlying memory. Strip headers
         // that no longer match the decoded body (content-length / encoding).
         const createResponse = (data: { body: Buffer; status: number; headers: Headers; text?: string }): Response => {
-            const text = data.text ?? data.body.toString("utf-8");
+            // Copy bytes into a fresh Uint8Array so each Response owns its
+            // backing memory — text decoding would corrupt binary payloads.
+            const bodyCopy = new Uint8Array(data.body.byteLength);
+            bodyCopy.set(data.body);
             const headers = new Headers(data.headers);
             headers.delete("content-length");
             headers.delete("content-encoding");
             headers.delete("transfer-encoding");
-            return new Response(text, { status: data.status, headers });
+            return new Response(bodyCopy, { status: data.status, headers });
         };
 
         // When using default headers, try both with and without Referer/Origin

--- a/src/utility/makeReq.ts
+++ b/src/utility/makeReq.ts
@@ -72,6 +72,15 @@ const readCache = async (url: string, headers: {}): Promise<Response | null> => 
  * @returns Promise that resolves when caching is complete
  */
 const writeCache = async (url: string, headers: {}, response: Response): Promise<void> => {
+    try {
+        await writeCacheUnsafe(url, headers, response);
+    } catch (err) {
+        // Caching must never break a request. Log and move on.
+        console.log(chalk.yellow(`[!] Failed to write response cache for ${url}: ${err?.message || err}`));
+    }
+};
+
+const writeCacheUnsafe = async (url: string, headers: {}, response: Response): Promise<void> => {
     // clone the response
     const clonedResponse = response.clone();
 
@@ -87,7 +96,8 @@ const writeCache = async (url: string, headers: {}, response: Response): Promise
         cache[url] = {};
     }
 
-    const body = Buffer.from(await clonedResponse.arrayBuffer()).toString("base64");
+    const bodyBuffer = Buffer.from(await clonedResponse.arrayBuffer());
+    const body = bodyBuffer.toString("base64");
     const status = clonedResponse.status;
     const resp_headers = clonedResponse.headers;
     if (headers["RSC"]) {
@@ -107,7 +117,34 @@ const writeCache = async (url: string, headers: {}, response: Response): Promise
         };
         // console.log("normal", url);
     }
-    fs.writeFileSync(globals.getRespCacheFile(), JSON.stringify(cache));
+    let serialized: string;
+    try {
+        // so, the cache is the response body for the URL
+        serialized = JSON.stringify(cache);
+    } catch (err) {
+        if (err instanceof RangeError) {
+            // console.log(
+            //     chalk.yellow(
+            //         `[!] Response cache too large to serialize; dropping entry for ${url} and skipping cache write`
+            //     )
+            // );
+            // // Roll back the entry we just added so future writes don't keep retrying.
+            // if (headers["RSC"]) {
+            //     delete cache[url].rsc;
+            // } else {
+            //     delete cache[url].normal;
+            // }
+            // if (!cache[url].rsc && !cache[url].normal) {
+            //     delete cache[url];
+            // }
+            // return;
+
+            console.log(chalk.yellow(`[!] Cache too big... Emptying cache`));
+            serialized = JSON.stringify({}); // empty cache
+        }
+        // throw err;
+    }
+    fs.writeFileSync(globals.getRespCacheFile(), serialized);
     // console.log("wrote cache for ", url);
 };
 
@@ -284,19 +321,36 @@ const makeRequest = async (
         }
         return response;
     } else {
-        // Helper to read response once and store data for reuse
+        // Helper to read response once and store data for reuse.
+        // We copy the bytes into a Buffer that owns its own ArrayBuffer so the
+        // stored body cannot be invalidated by undici recycling its internal
+        // buffer after we consume the response.
         const consumeResponse = async (
             res: Response | null
-        ): Promise<{ body: ArrayBuffer; status: number; headers: Headers; ok: boolean; text: string } | null> => {
+        ): Promise<{ body: Buffer; status: number; headers: Headers; ok: boolean; text: string } | null> => {
             if (!res) return null;
-            const body = await res.arrayBuffer();
-            const text = new TextDecoder().decode(body);
-            return { body, status: res.status, headers: res.headers, ok: res.ok, text };
+            const ab = await res.arrayBuffer();
+            const body = Buffer.alloc(ab.byteLength);
+            body.set(new Uint8Array(ab));
+            const text = body.toString("utf-8");
+            // Snapshot headers as a plain object so we can rebuild a fresh
+            // Headers instance per Response instead of sharing state.
+            const headers = new Headers(res.headers);
+            return { body, status: res.status, headers, ok: res.ok, text };
         };
 
-        // Helper to create Response from stored data
-        const createResponse = (data: { body: ArrayBuffer; status: number; headers: Headers }): Response => {
-            return new Response(data.body, { status: data.status, headers: data.headers });
+        // Helper to create Response from stored data. Pass the body as an
+        // immutable string so each Response gets a fully independent backing
+        // store; undici has been known to flag Responses as already-consumed
+        // when buffer-backed bodies share underlying memory. Strip headers
+        // that no longer match the decoded body (content-length / encoding).
+        const createResponse = (data: { body: Buffer; status: number; headers: Headers; text?: string }): Response => {
+            const text = data.text ?? data.body.toString("utf-8");
+            const headers = new Headers(data.headers);
+            headers.delete("content-length");
+            headers.delete("content-encoding");
+            headers.delete("transfer-encoding");
+            return new Response(text, { status: data.status, headers });
         };
 
         // When using default headers, try both with and without Referer/Origin

--- a/src/utility/openapiGenerator.ts
+++ b/src/utility/openapiGenerator.ts
@@ -78,6 +78,32 @@ export interface OpenAPISpec {
  * @param value - The value to determine the OpenAPI type for
  * @returns The OpenAPI type string corresponding to the given value
  */
+// Zod-style placeholder strings emitted by traceBody (e.g. "<number>", "<date>",
+// "<array>") carry the field's real type even though they're stringified. Map
+// them back to an OpenAPI type so the spec doesn't collapse every body field
+// to `type: "string"`.
+const ZOD_PLACEHOLDER_TYPE_MAP: { [k: string]: string } = {
+    string: "string",
+    number: "number",
+    integer: "integer",
+    bigint: "integer",
+    boolean: "boolean",
+    date: "string",
+    array: "array",
+    object: "object",
+    enum: "string",
+    literal: "string",
+    unknown: "string",
+    coerce: "string",
+};
+
+export const getZodPlaceholderType = (value: any): string | null => {
+    if (typeof value !== "string") return null;
+    const match = /^<([a-zA-Z]+)>$/.exec(value);
+    if (!match) return null;
+    return ZOD_PLACEHOLDER_TYPE_MAP[match[1]] ?? null;
+};
+
 export const getOpenApiType = (value: any): string => {
     if (value === null) {
         return "string"; // OpenAPI 3.0 doesn't have a 'null' type, use nullable
@@ -85,6 +111,8 @@ export const getOpenApiType = (value: any): string => {
     if (Array.isArray(value)) {
         return "array";
     }
+    const placeholderType = getZodPlaceholderType(value);
+    if (placeholderType) return placeholderType;
     const jsType = typeof value;
     if (["string", "number", "boolean", "object"].includes(jsType)) {
         return jsType;

--- a/src/utility/openapiGenerator.ts
+++ b/src/utility/openapiGenerator.ts
@@ -155,7 +155,10 @@ export const generateOpenapiV3Spec = (items: OpenapiOutputItem[], chunks: Chunks
         const pathKey = replacePlaceholders(
             pathKeyBeforeQuery.startsWith("/") ? pathKeyBeforeQuery : `/${pathKeyBeforeQuery}`
         );
-        const method = typeof item.method === "string" ? item.method.toLowerCase() : "unknown";
+        const VALID_METHODS = new Set(["get", "post", "put", "patch", "delete", "head", "options", "trace"]);
+        const rawMethod = typeof item.method === "string" ? item.method.toLowerCase() : "";
+        const methodIsValid = VALID_METHODS.has(rawMethod);
+        const method = methodIsValid ? rawMethod : "get";
 
         if (!spec.paths[pathKey]) {
             spec.paths[pathKey] = {};
@@ -222,6 +225,10 @@ export const generateOpenapiV3Spec = (items: OpenapiOutputItem[], chunks: Chunks
             },
             tags: globalsUtil.getOpenapiChunkTag() ? [item.chunkId] : [],
         };
+
+        if (!methodIsValid) {
+            (operationObject as any).description = `Note: original HTTP method ${JSON.stringify(item.method)} could not be determined; defaulted to GET — verify before use.`;
+        }
 
         if (parameters.length > 0) {
             operationObject.parameters = parameters;

--- a/src/utility/openapiGenerator.ts
+++ b/src/utility/openapiGenerator.ts
@@ -121,7 +121,7 @@ export const generateOpenapiV3Spec = (items: OpenapiOutputItem[], chunks: Chunks
         const pathKey = replacePlaceholders(
             pathKeyBeforeQuery.startsWith("/") ? pathKeyBeforeQuery : `/${pathKeyBeforeQuery}`
         );
-        const method = item.method.toLowerCase();
+        const method = typeof item.method === "string" ? item.method.toLowerCase() : "unknown";
 
         if (!spec.paths[pathKey]) {
             spec.paths[pathKey] = {};

--- a/src/utility/openapiGenerator.ts
+++ b/src/utility/openapiGenerator.ts
@@ -145,7 +145,13 @@ export const generateOpenapiV3Spec = (items: OpenapiOutputItem[], chunks: Chunks
     };
 
     for (const item of items) {
-        const pathKeyBeforeQuery = typeof item.path === "string" ? item.path.split("?")[0] : "";
+        let rawItemPath = typeof item.path === "string" ? item.path : "";
+        try {
+            if (rawItemPath.startsWith("http://") || rawItemPath.startsWith("https://")) {
+                rawItemPath = new URL(rawItemPath).pathname;
+            }
+        } catch {}
+        const pathKeyBeforeQuery = rawItemPath.split("?")[0];
         const pathKey = replacePlaceholders(
             pathKeyBeforeQuery.startsWith("/") ? pathKeyBeforeQuery : `/${pathKeyBeforeQuery}`
         );

--- a/src/utility/openapiGenerator.ts
+++ b/src/utility/openapiGenerator.ts
@@ -227,7 +227,8 @@ export const generateOpenapiV3Spec = (items: OpenapiOutputItem[], chunks: Chunks
         };
 
         if (!methodIsValid) {
-            (operationObject as any).description = `Note: original HTTP method ${JSON.stringify(item.method)} could not be determined; defaulted to GET — verify before use.`;
+            (operationObject as any).description =
+                `Note: original HTTP method ${JSON.stringify(item.method)} could not be determined; defaulted to GET — verify before use.`;
         }
 
         if (parameters.length > 0) {

--- a/src/utility/postmanGenerator.ts
+++ b/src/utility/postmanGenerator.ts
@@ -116,7 +116,16 @@ export const generatePostmanCollection = (items: OpenapiOutputItem[]): PMCollect
     const seen = new Set<string>();
 
     for (const item of items) {
-        const rawPath = typeof item.path === "string" ? item.path : "";
+        let rawPath = typeof item.path === "string" ? item.path : "";
+        // If path is an absolute URL, extract just the pathname so we don't
+        // prepend {{baseUrl}} to an already-complete URL.
+        try {
+            if (rawPath.startsWith("http://") || rawPath.startsWith("https://")) {
+                rawPath = new URL(rawPath).pathname;
+            }
+        } catch {
+            // leave rawPath as-is if URL parsing fails
+        }
         const normalized = replacePlaceholders(rawPath.startsWith("/") ? rawPath : `/${rawPath}`);
         const method = typeof item.method === "string" ? item.method.toUpperCase() : "GET";
         const dedupeKey = `${method} ${normalized}`;
@@ -166,11 +175,22 @@ export const generatePostmanCollection = (items: OpenapiOutputItem[]): PMCollect
         };
 
         if (item.body && ["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
-            request.body = {
-                mode: "raw",
-                raw: buildBodyExample(item.body) ?? item.body,
-                options: { raw: { language: "json" } },
-            };
+            const bodyRaw = buildBodyExample(item.body) ?? item.body;
+            // Skip bodies that are empty objects — they only contain unresolvable spread artifacts.
+            let isEmptyObject = false;
+            try {
+                const parsed = JSON.parse(bodyRaw);
+                isEmptyObject = typeof parsed === "object" && parsed !== null && !Array.isArray(parsed) && Object.keys(parsed).length === 0;
+            } catch {}
+            if (!isEmptyObject) {
+                request.body = {
+                    mode: "raw",
+                    raw: bodyRaw,
+                    options: { raw: { language: "json" } },
+                };
+            } else {
+                request.body = { mode: "none" };
+            }
         } else {
             request.body = { mode: "none" };
         }

--- a/src/utility/postmanGenerator.ts
+++ b/src/utility/postmanGenerator.ts
@@ -121,7 +121,8 @@ export const generatePostmanCollection = (items: OpenapiOutputItem[]): PMCollect
         // prepend {{baseUrl}} to an already-complete URL.
         try {
             if (rawPath.startsWith("http://") || rawPath.startsWith("https://")) {
-                rawPath = new URL(rawPath).pathname;
+                const u = new URL(rawPath);
+                rawPath = u.pathname + (u.search || "");
             }
         } catch {
             // leave rawPath as-is if URL parsing fails

--- a/src/utility/postmanGenerator.ts
+++ b/src/utility/postmanGenerator.ts
@@ -1,0 +1,194 @@
+import { OpenapiOutputItem } from "./globals.js";
+import replacePlaceholders from "./replaceUrlPlaceholders.js";
+
+/**
+ * Postman Collection v2.1 — minimal subset of the schema we actually emit.
+ *
+ * Why this exists alongside the OpenAPI generator: OpenAPI tags are flat
+ * strings and Bruno / Insomnia / Postman render them as a single level of
+ * folders (often joining slashes with underscores). Postman Collection v2.1
+ * has a recursive `item` array — a folder is just an item that contains more
+ * items — so importers reproduce the URL path as a real directory tree.
+ */
+interface PMRequest {
+    method: string;
+    header: Array<{ key: string; value: string; type?: string }>;
+    url: {
+        raw: string;
+        host: string[];
+        path: string[];
+        query?: Array<{ key: string; value: string }>;
+        variable?: Array<{ key: string; value: string }>;
+    };
+    body?: {
+        mode: "raw" | "none";
+        raw?: string;
+        options?: { raw: { language: "json" } };
+    };
+}
+
+interface PMItem {
+    name: string;
+    request?: PMRequest;
+    item?: PMItem[];
+}
+
+interface PMCollection {
+    info: {
+        name: string;
+        description?: string;
+        schema: string;
+        _postman_id?: string;
+    };
+    item: PMItem[];
+    variable?: Array<{ key: string; value: string }>;
+}
+
+const buildBodyExample = (rawBody: string): string | undefined => {
+    if (!rawBody) return undefined;
+    // The body strings we produce in traceBody.ts are JSON-ish but use
+    // angle-bracketed placeholders for types (e.g. `"<string>"`). They are valid
+    // JSON, so just pretty-print whatever parses.
+    try {
+        return JSON.stringify(JSON.parse(rawBody), null, 2);
+    } catch {
+        return rawBody;
+    }
+};
+
+const splitPath = (rawPath: string): { segments: string[]; query: Array<{ key: string; value: string }> } => {
+    const [withoutQuery, queryString] = rawPath.split("?", 2);
+    const segments = withoutQuery.split("/").filter(Boolean);
+    const query: Array<{ key: string; value: string }> = [];
+    if (queryString) {
+        for (const part of queryString.split("&")) {
+            const [k, v = ""] = part.split("=", 2);
+            if (k) query.push({ key: decodeURIComponent(k), value: decodeURIComponent(v) });
+        }
+    }
+    return { segments, query };
+};
+
+/**
+ * Generates a Postman Collection v2.1 from the discovered endpoints, organising
+ * them into nested folders that mirror the URL path. The first matching folder
+ * is reused for sibling endpoints so importers don't end up with one folder per
+ * request.
+ *
+ * Path parameters (`{id}`) are not used as folder names — they belong to a
+ * specific endpoint, not the wider category — so when a segment is a path
+ * variable we attach the operation directly to its parent folder and let the
+ * request's full URL carry the variable.
+ */
+export const generatePostmanCollection = (items: OpenapiOutputItem[]): PMCollection => {
+    const collection: PMCollection = {
+        info: {
+            name: "API Collection",
+            description: "Endpoints discovered by js-recon, grouped by URL path.",
+            schema: "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        },
+        item: [],
+        variable: [{ key: "baseUrl", value: "https://example.com" }],
+    };
+
+    // Tracks (folder-path) → existing PMItem so the second endpoint under the same folder and reuses it
+    const folderIndex = new Map<string, PMItem>();
+    folderIndex.set("", { name: "", item: collection.item } as PMItem);
+
+    const ensureFolder = (folderSegments: string[]): PMItem => {
+        let runningKey = "";
+        let parent = folderIndex.get("") as PMItem;
+        for (const segment of folderSegments) {
+            runningKey = runningKey ? `${runningKey}/${segment}` : segment;
+            let folder = folderIndex.get(runningKey);
+            if (!folder) {
+                folder = { name: segment, item: [] };
+                (parent.item as PMItem[]).push(folder);
+                folderIndex.set(runningKey, folder);
+            }
+            parent = folder;
+        }
+        return parent;
+    };
+
+    // Deduplicate (path, method) — the OpenAPI generator already does this; we
+    // mirror the behaviour here so reimporting doesn't produce duplicates.
+    const seen = new Set<string>();
+
+    for (const item of items) {
+        const rawPath = typeof item.path === "string" ? item.path : "";
+        const normalized = replacePlaceholders(rawPath.startsWith("/") ? rawPath : `/${rawPath}`);
+        const method = typeof item.method === "string" ? item.method.toUpperCase() : "GET";
+        const dedupeKey = `${method} ${normalized}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+
+        const { segments, query } = splitPath(normalized);
+
+        // Folder segments = all path segments except path-parameter segments.
+        // A trailing `{id}` segment doesn't earn its own folder; we mount the
+        // request on the parent.
+        const folderSegments: string[] = [];
+        const pathVars: Array<{ key: string; value: string }> = [];
+        for (const seg of segments) {
+            const isVar = seg.startsWith("{") && seg.endsWith("}");
+            if (isVar) {
+                pathVars.push({ key: seg.slice(1, -1), value: "" });
+            } else {
+                folderSegments.push(seg);
+            }
+        }
+        // The leaf segment is the endpoint's own name; remove it from the
+        // folder hierarchy so the request lands directly in its parent folder.
+        const leaf = folderSegments.pop() ?? "";
+        const folder = ensureFolder(folderSegments);
+
+        const headers = Object.entries(item.headers || {}).map(([key, value]) => ({
+            key,
+            value: String(value),
+            type: "text",
+        }));
+
+        const requestName = `${method} /${segments.join("/")}`;
+
+        const pmUrlPath = segments.map((s) => (s.startsWith("{") && s.endsWith("}") ? `:${s.slice(1, -1)}` : s));
+
+        const request: PMRequest = {
+            method,
+            header: headers,
+            url: {
+                raw: `{{baseUrl}}/${pmUrlPath.join("/")}${query.length > 0 ? "?" + query.map((q) => `${q.key}=${q.value}`).join("&") : ""}`,
+                host: ["{{baseUrl}}"],
+                path: pmUrlPath,
+                ...(query.length > 0 ? { query } : {}),
+                ...(pathVars.length > 0 ? { variable: pathVars } : {}),
+            },
+        };
+
+        if (item.body && ["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+            request.body = {
+                mode: "raw",
+                raw: buildBodyExample(item.body) ?? item.body,
+                options: { raw: { language: "json" } },
+            };
+        } else {
+            request.body = { mode: "none" };
+        }
+
+        // Friendly request label — keep the leaf in the name to disambiguate
+        // siblings under the same parent (e.g. invoices vs invoices/latest).
+        const leafName = leaf || segments[segments.length - 1] || "/";
+        const itemEntry: PMItem = {
+            name: `${method} ${leafName}`,
+            request,
+        };
+
+        // If this URL has no folder segments at all (e.g. `/version`), put it
+        // at the top level so it isn't lost.
+        (folder.item as PMItem[]).push(itemEntry);
+        // Suppress unused requestName lint warning — kept for future use.
+        void requestName;
+    }
+
+    return collection;
+};

--- a/src/utility/postmanGenerator.ts
+++ b/src/utility/postmanGenerator.ts
@@ -180,7 +180,11 @@ export const generatePostmanCollection = (items: OpenapiOutputItem[]): PMCollect
             let isEmptyObject = false;
             try {
                 const parsed = JSON.parse(bodyRaw);
-                isEmptyObject = typeof parsed === "object" && parsed !== null && !Array.isArray(parsed) && Object.keys(parsed).length === 0;
+                isEmptyObject =
+                    typeof parsed === "object" &&
+                    parsed !== null &&
+                    !Array.isArray(parsed) &&
+                    Object.keys(parsed).length === 0;
             } catch {}
             if (!isEmptyObject) {
                 request.body = {


### PR DESCRIPTION
### Added

- Added taint analysis in the `analyze` engine for Next.js
- Download JS files as soon as they are discovered (`lazyload`)
- Recursively resolve HTTP requests in Next.js (`map`)
- Stream JS file downloads during Vue.js discovery — downloads start as soon as each discovery step finds files instead of waiting for the full pipeline (`lazyload`)
- Resolve `UnaryExpression` nodes (`!x`, `void 0`, `-x`, `typeof x`) so request bodies surface real boolean/null values instead of `[unsupported node type: UnaryExpression]` (`map`)
- Resolve `ArrayExpression` nodes recursively so array body fields render their element shape instead of `[unsupported node type: ArrayExpression]` (`map`)
- Resolve `JSON.stringify(variable)` calls by tracing the argument, replacing the opaque `[call:JSON.stringify()]` placeholder (`map`)
- Resolve `new URLSearchParams({...})` to a real query string, using `{key}` placeholders for values that can't be statically resolved (`map`)
- Partial-concatenation fallback for binary `+` expressions so resolvable fragments are preserved when one side is unresolved (`map`)

### Changed

- Nested `JSON.stringify(expr)` inside a body object now resolves `expr` instead of emitting `[call to object...]` (`map`)

### Fixed

- Invalidate request cache if the memory is full
- Progress bars no longer hide the terminal cursor permanently when they exit without a clean `stop()` — all bars now use `hideCursor: false` (`lazyload`)
- Removed the concurrent download progress bar in the Vue.js section that was causing display corruption — discovery `console.log` calls no longer collide with the bar's render line (`lazyload`)
- API spec / Postman collection URLs no longer get `{{baseUrl}}` prepended to already-absolute URLs — full URLs are now reduced to their pathname (`map`)
- Spread elements that can't be resolved are now skipped instead of being emitted as fake `"...spread": "[spread:e]"` body fields (`map`)
- Request bodies that reduce to an empty `{}` after resolution are now omitted from the Postman collection (`map`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Postman Collection v2.1 export alongside OpenAPI specifications
  * Enhanced Next.js and Vue.js API discovery with improved resource detection
  * Added progress indicators for downloads and processing operations
  * Introduced taint-flow filtering for ESQuery analysis rules

* **Bug Fixes**
  * Improved fault tolerance for malformed code parsing
  * Fixed empty body and spread element handling in request mapping
  * Enhanced URL and request body resolution across frameworks
  * Strengthened cache robustness and header merging logic

* **Chores**
  * Version bumped to 1.3.1-alpha.2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shriyanss/js-recon/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->