### PR TITLE
v1.3.1-alpha.3

### DIFF
--- a/.github/workflows/pr_checker.yml
+++ b/.github/workflows/pr_checker.yml
@@ -8,16 +8,17 @@ on:
 jobs:
   check-branch:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - name: Check source branch
-        if: github.head_ref != 'dev'
+      - name: Redirect PR to dev
+        if: github.head_ref != 'dev' || github.event.pull_request.head.repo.full_name != 'shriyanss/js-recon'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           BRANCH_NAME: ${{ github.head_ref }}
+          SOURCE_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          gh pr comment $PR_URL --body "This merge is not possible. Create a PR for $BRANCH_NAME -> dev"
-          gh pr close $PR_URL
+          gh pr edit $PR_NUMBER --base dev
+          gh pr comment $PR_NUMBER --body "This PR was targeting \`main\`, but only the \`dev\` branch of \`shriyanss/js-recon\` can merge directly into \`main\`. The target branch has been changed to \`dev\` (source: \`$SOURCE_REPO:$BRANCH_NAME\`)."

--- a/.github/workflows/pr_checker.yml
+++ b/.github/workflows/pr_checker.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Redirect PR to dev
         if: github.head_ref != 'dev' || github.event.pull_request.head.repo.full_name != 'shriyanss/js-recon'
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add version for rule templates
+- Add Vue js support for analyze module
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,13 @@
 ### Changed
 
 - Removed `mouse: true` from the interactive output pane so terminal-native text selection/copy works in the output area (`map -i`)
+- Vue.js fetch resolver now walks back to the enclosing wrapper function's caller(s) so `URLSearchParams(param.subprop)` expands to real `?k1={k1}&k2={k2}` query strings and spread-header / member-value placeholders get substituted from the caller's object literal — including transitive resolution when the caller passes its own param through (`map`)
+- Vue.js fetch resolver recognises destructured fetch wrappers (e.g. `const { wrapperKey: x } = factory({ ... })`) and resolves their callsites as fetch calls, with positional-first-arg filtering to avoid mis-identifying object-shaped wrappers that construct the URL from a property of their input (`map`)
+- Distinct callsites for the same `(path, method)` are preserved in both the OpenAPI spec (path key gets a `#N` suffix) and the Postman collection (request name gets a `#N` suffix) instead of being collapsed to a single entry (`map`)
 
 ### Fixed
+
+- Spread elements in request bodies and option objects are no longer silently dropped when the spread argument is unresolvable — the output surfaces a sentinel key (e.g. `"...arg": "<spread>"`, `"...call()": "<spread>"`) so downstream readers know more fields exist at runtime (`map`)
 
 ## 1.3.1-alpha.2 - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.3.1-alpha.3 - (unreleased)
+## 1.3.1-alpha.3 - 2026-05-20
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@
 
 - Add version for rule templates
 - Add Vue js support for analyze module
+- `esquery` interactive command + headless `-c/--command` runner for `map` and `run`, with `&&` chaining (`map`)
+- Line-editor behavior in interactive mode: cursor movement (left/right/home/end/ctrl-a/ctrl-e), word-wise motion/delete (ctrl-w, ctrl-left/right), kill-to-start/end (ctrl-u/ctrl-k), delete-at-cursor, mid-string insertion so paste lands at the cursor, and horizontal scroll for long inputs (`map -i`)
 
 ### Changed
+
+- Removed `mouse: true` from the interactive output pane so terminal-native text selection/copy works in the output area (`map -i`)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 1.3.1-alpha.3 - (unreleased)
+
+### Added
+
+- Add version for rule templates
+
+### Changed
+
+### Fixed
+
 ## 1.3.1-alpha.2 - 2026-05-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# js-recon
+
+Static analysis tool that maps API endpoints and detects client-side security issues by analyzing Next.js (webpack/turbopack) and Vue.js bundles. Written in TypeScript, compiled to `build/` before running.
+
+## Build & run
+
+```bash
+npm run cleanup   # rm -rf build/ + tsc (full rebuild)
+npm run start -- <subcommand> [options]
+```
+
+`cleanup` must be run before testing any TypeScript change when using the `run` command.
+
+## Subcommands
+
+| Command | Purpose |
+|---------|---------|
+| `lazyload` | Download JS chunks from a target URL |
+| `strings` | Extract strings/paths/secrets from JS files |
+| `map` | Parse webpack/turbopack bundles into a structured `mapped.json` |
+| `endpoints` | Extract client-side routes |
+| `analyze` | Run YAML rules against `mapped.json` / OpenAPI spec |
+| `report` | Generate HTML/SQLite report |
+| `run` | Run all of the above in sequence |
+| `api-gateway` | Manage AWS API Gateway for IP rotation |
+| `mcp` | Interactive AI-powered CLI |
+
+## Key source files
+
+- `src/index.ts` — CLI entry point; all subcommand definitions live here
+- `src/run/index.ts` — orchestrates the full pipeline (`run` subcommand)
+- `src/analyze/index.ts` — loads/validates rules, runs AST and request engines
+- `src/analyze/helpers/initRules.ts` — downloads/caches rules from GitHub to `~/.js-recon/rules`
+- `src/analyze/helpers/validate.ts` — validates rules and checks `js_recon_version` compatibility
+- `src/analyze/helpers/schemas.ts` — Zod schema for rule YAML files
+- `src/map/next_js/resolveFetch.ts` — resolves `fetch()` calls, detects Next.js framework chunks
+- `src/map/next_js/utils.ts` — `resolveNodeValue`, `resolveVariableInChunk`, `substituteVariablesInString`
+- `src/map/next_js/getWebpackConnections.ts` — extracts chunk code from webpack bundles
+- `src/globalConfig.ts` — current version string and tool-wide constants
+
+## Rules
+
+Rules are YAML files (`.yml`/`.yaml`) living in two places:
+- **Workspace:** `../js-recon-rules/` (relative to this repo)
+- **Installed cache:** `~/.js-recon/rules`
+
+`initRules` downloads rules from GitHub when missing or when the cached version doesn't match the GitHub latest. Rules may declare `js_recon_version: ">=X.Y.Z"`; incompatible rules are skipped with a warning. The version check strips prerelease suffixes (e.g. `1.3.1-alpha.3` → `[1,3,1]`).
+
+Rule categories: `ast/` (AST-based pattern matching) and `request/` (OpenAPI/request-level checks).
+
+## Testing a change
+
+**Testing is mandatory for every change.** Before reporting a task complete:
+
+1. Run `npm run cleanup` to rebuild TypeScript.
+2. Run the `run` subcommand against the target the user provides. Do not use `analyze` or other individual subcommands as a substitute — the `run` subcommand must be used to validate end-to-end behavior.
+3. If the user has not provided a target, ask for one before proceeding.
+
+Typical test invocation:
+
+```bash
+npm run cleanup && npm run start -- run -u <target-url> -y -k
+```
+
+## Security / confidentiality
+
+When a change is informed by behavior observed on a real target (URLs, endpoint names, response shapes, finding details, etc.):
+
+- **Do not include any target information in code comments, commit messages, docstrings, variable names, or any other artifact.**
+- This applies to hostnames, paths, parameter names, response content, or any other detail that could identify the target.
+- If context from the target is needed to describe a change, describe it in abstract terms only (e.g. "URL parameter passed to fetch" not "https://example.com/api/docs passes `file` param to fetch").

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,17 +13,17 @@ npm run start -- <subcommand> [options]
 
 ## Subcommands
 
-| Command | Purpose |
-|---------|---------|
-| `lazyload` | Download JS chunks from a target URL |
-| `strings` | Extract strings/paths/secrets from JS files |
-| `map` | Parse webpack/turbopack bundles into a structured `mapped.json` |
-| `endpoints` | Extract client-side routes |
-| `analyze` | Run YAML rules against `mapped.json` / OpenAPI spec |
-| `report` | Generate HTML/SQLite report |
-| `run` | Run all of the above in sequence (primary interface) |
-| `api-gateway` | Manage AWS API Gateway for IP rotation |
-| `mcp` | Interactive AI-powered CLI |
+| Command       | Purpose                                                         |
+| ------------- | --------------------------------------------------------------- |
+| `lazyload`    | Download JS chunks from a target URL                            |
+| `strings`     | Extract strings/paths/secrets from JS files                     |
+| `map`         | Parse webpack/turbopack bundles into a structured `mapped.json` |
+| `endpoints`   | Extract client-side routes                                      |
+| `analyze`     | Run YAML rules against `mapped.json` / OpenAPI spec             |
+| `report`      | Generate HTML/SQLite report                                     |
+| `run`         | Run all of the above in sequence (primary interface)            |
+| `api-gateway` | Manage AWS API Gateway for IP rotation                          |
+| `mcp`         | Interactive AI-powered CLI                                      |
 
 ## Key source files
 
@@ -73,6 +73,7 @@ npm run start -- <subcommand> [options]
 ### Batch mode
 
 When `-u` points to a file of URLs, each line is processed sequentially. For each URL:
+
 - A subdirectory `output/<host>/` is created
 - `clearJsUrls()` / `clearJsonUrls()` reset the URL sets so previous targets don't bleed over
 - All output paths are prefixed with `workingDir/`
@@ -84,6 +85,7 @@ When `-u` points to a file of URLs, each line is processed sequentially. For eac
 3. If it needs to reach a downstream module (like `analyze`), thread it through `cmd` — `processUrl` receives the full `cmd` object and passes it to submodule calls
 
 **Example — `-r/--rules` flag (added in this codebase):**
+
 - Declared in `src/index.ts`: `.option("-r, --rules <file/dir>", "Rules file or directory (passed to analyze module)")`
 - In `src/run/index.ts` the `analyze` calls use `cmd.rules || ""` — empty string tells `analyze` to use the default rules cache
 
@@ -98,12 +100,14 @@ The `map -i` blessed UI dispatches user input through `interactive_helpers/comma
 ## Rules
 
 Rules are YAML files (`.yml`/`.yaml`) in two places:
+
 - **Workspace:** `../js-recon-rules/` (relative to this repo)
 - **Installed cache:** `~/.js-recon/rules`
 
 `initRules` downloads rules from GitHub when missing or when the cached version doesn't match the latest release. Rules may declare `js_recon_version: ">=X.Y.Z"`; incompatible rules are skipped with a warning. The version check strips prerelease suffixes (e.g. `1.3.1-alpha.3` → `[1,3,1]`).
 
 Rule categories:
+
 - `ast/` — AST-based pattern matching against chunk code (uses `@babel/parser` + `esquery`)
 - `request/` — OpenAPI/request-level checks against the resolved endpoint list
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ npm run start -- <subcommand> [options]
 - `src/map/next_js/getWebpackConnections.ts` — extracts chunk code from webpack bundles
 - `src/map/next_js/interactive_helpers/esqueryGen.ts` — `esquery` interactive command: minifies a pasted snippet, matches it against each chunk's minified AST nodes, prints loose/strict selectors. Vue's command handler imports the same module — keep it framework-agnostic.
 - `src/map/next_js/interactive.ts` / `src/map/vue_js/interactive.ts` — export both the blessed-backed `interactive()` entry and a headless `runCommands(chunks, mapFile, commands)` that pipes `outputBox.log` to stdout for `-c/--command` execution.
+- `src/map/next_js/interactive_helpers/inputPatch.ts` — `enableCursorInput(inputBox)` patches a blessed textbox instance to support cursor movement, mid-string insertion, and paste-at-cursor. It overrides `_listener`/`setValue`/`_updateCursor`/`clearValue` on the instance. **Don't try to remove blessed's listener after the fact** — blessed re-binds `this._listener` on every focus, so overriding `_listener` on the instance is the only race-free approach. Shared by Next.js and Vue interactive entries.
 - `src/globalConfig.ts` — current version string and tool-wide constants
 - `src/utility/globals.ts` — mutable global state (tech detection result, AI config, OpenAPI flag, etc.)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ npm run start -- <subcommand> [options]
 - `src/map/next_js/resolveFetch.ts` — resolves `fetch()` calls, detects Next.js framework chunks
 - `src/map/next_js/utils.ts` — `resolveNodeValue`, `resolveVariableInChunk`, `substituteVariablesInString`
 - `src/map/next_js/getWebpackConnections.ts` — extracts chunk code from webpack bundles
+- `src/map/next_js/interactive_helpers/esqueryGen.ts` — `esquery` interactive command: minifies a pasted snippet, matches it against each chunk's minified AST nodes, prints loose/strict selectors. Vue's command handler imports the same module — keep it framework-agnostic.
+- `src/map/next_js/interactive.ts` / `src/map/vue_js/interactive.ts` — export both the blessed-backed `interactive()` entry and a headless `runCommands(chunks, mapFile, commands)` that pipes `outputBox.log` to stdout for `-c/--command` execution.
 - `src/globalConfig.ts` — current version string and tool-wide constants
 - `src/utility/globals.ts` — mutable global state (tech detection result, AI config, OpenAPI flag, etc.)
 
@@ -83,6 +85,14 @@ When `-u` points to a file of URLs, each line is processed sequentially. For eac
 **Example — `-r/--rules` flag (added in this codebase):**
 - Declared in `src/index.ts`: `.option("-r, --rules <file/dir>", "Rules file or directory (passed to analyze module)")`
 - In `src/run/index.ts` the `analyze` calls use `cmd.rules || ""` — empty string tells `analyze` to use the default rules cache
+
+## Interactive-mode commands
+
+The `map -i` blessed UI dispatches user input through `interactive_helpers/commandHandler.ts`. The same handler runs headlessly when commands are supplied via `-c/--command`:
+
+- The `-c` option's commander coerce function splits each value on `&&` (with optional whitespace) and concatenates into a single command array. So `-c "list fetch && esquery * fetch"` is two commands; passing `-c` twice has the same effect.
+- `map`'s entry point checks `commands.length > 0` first — if non-empty, it calls `nextRunCommands` / `vueRunCommands` and skips the blessed UI even when `-i` is also set.
+- New commands should be added to **both** `next_js/interactive_helpers/commandHandler.ts` and `vue_js/interactive_helpers/commandHandler.ts`, plus the corresponding `helpMenu.ts` entry. When the implementation is framework-agnostic (e.g. `esquery`), put it under `next_js/interactive_helpers/` and import it from the Vue handler — don't duplicate.
 
 ## Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Rules are YAML files (`.yml`/`.yaml`) in two places:
 - **Workspace:** `../js-recon-rules/` (relative to this repo)
 - **Installed cache:** `~/.js-recon/rules`
 
-`initRules` downloads rules from GitHub when missing or when the cached version doesn't match the latest release. Rules may declare `js_recon_version: ">=X.Y.Z"`; incompatible rules are skipped with a warning. The version check strips prerelease suffixes (e.g. `1.3.1-alpha.3` → `[1,3,1]`).
+`initRules` downloads rules from GitHub when missing or when the cached version doesn't match the latest release. `js_recon_version` (required) must be declared in every rule (e.g. `js_recon_version: ">=X.Y.Z"`); `initRules` uses it to validate compatibility and skips incompatible rules with a warning. The version check strips prerelease suffixes (e.g. `1.3.1-alpha.3` → `[1,3,1]`).
 
 Rule categories:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,14 +21,14 @@ npm run start -- <subcommand> [options]
 | `endpoints` | Extract client-side routes |
 | `analyze` | Run YAML rules against `mapped.json` / OpenAPI spec |
 | `report` | Generate HTML/SQLite report |
-| `run` | Run all of the above in sequence |
+| `run` | Run all of the above in sequence (primary interface) |
 | `api-gateway` | Manage AWS API Gateway for IP rotation |
 | `mcp` | Interactive AI-powered CLI |
 
 ## Key source files
 
-- `src/index.ts` — CLI entry point; all subcommand definitions live here
-- `src/run/index.ts` — orchestrates the full pipeline (`run` subcommand)
+- `src/index.ts` — CLI entry point; all subcommand definitions and option declarations live here
+- `src/run/index.ts` — orchestrates the full pipeline (`run` subcommand); two tech-specific flows (Next.js 8-step, Vue 4-step)
 - `src/analyze/index.ts` — loads/validates rules, runs AST and request engines
 - `src/analyze/helpers/initRules.ts` — downloads/caches rules from GitHub to `~/.js-recon/rules`
 - `src/analyze/helpers/validate.ts` — validates rules and checks `js_recon_version` compatibility
@@ -37,16 +37,66 @@ npm run start -- <subcommand> [options]
 - `src/map/next_js/utils.ts` — `resolveNodeValue`, `resolveVariableInChunk`, `substituteVariablesInString`
 - `src/map/next_js/getWebpackConnections.ts` — extracts chunk code from webpack bundles
 - `src/globalConfig.ts` — current version string and tool-wide constants
+- `src/utility/globals.ts` — mutable global state (tech detection result, AI config, OpenAPI flag, etc.)
+
+## `run` pipeline in detail
+
+`run` is the primary subcommand. It calls `processUrl` for each target, which dispatches to one of two pipelines based on the detected front-end framework (`globalsUtil.getTech()`).
+
+### Next.js pipeline (8 steps)
+
+1. **Lazyload** — downloads initial JS chunks via Puppeteer; detects framework; sets `globalsUtil.getTech()` to `"next"`
+2. **Strings** — scans downloaded JS for strings, extracts URL paths → `extracted_urls.json`
+3. **Lazyload (subsequent requests)** — re-crawls using the extracted paths to fetch dynamically loaded chunks; also fetches `buildId`
+4. **Strings (pass 2)** — re-runs strings on the expanded chunk set; generates `extracted_urls.txt` (permuted) and `extracted_urls-openapi.json`; optionally scans secrets (`--secrets`)
+5. **Lazyload re-pass (step 4.5)** — a second subsequent-requests crawl to pick up chunks for dynamic routes discovered in pass 2
+6. **Strings re-pass (step 4.6)** — strings pass over the re-pass chunks
+7. **Map** — parses webpack/turbopack bundles; resolves `fetch()` calls and axios usage; generates `mapped.json` and `mapped-openapi.json`; CDN-aware: if JS was served from a different host, `getCdnDir` finds the CDN output dir and passes that to map instead of `outputDir/host`
+8. **Endpoints** — extracts client-side route paths; uses `___subsequent_requests` directory presence to decide whether to pass a JS directory
+9. **Analyze** — loads YAML rules (from `-r/--rules` if provided, otherwise default rules cache); runs AST engine and request engine; writes `analyze.json`
+10. **Report** — populates SQLite DB (`js-recon.db`) and generates HTML report
+
+### Vue.js pipeline (4 steps)
+
+1. **Lazyload** — same as Next.js step 1; sets `globalsUtil.getTech()` to `"vue"`
+2. **Map** — scans the entire `outputDir` (Vue chunks spread across asset hosts)
+3. **Analyze** — same rule loading as Next.js; `-r/--rules` is forwarded here too
+4. **Report** — same as Next.js; if `endpoints.json` doesn't exist it is written as `[]` since Vue endpoints extraction isn't implemented yet
+
+### Tech detection flow
+
+`lazyLoad` sets the global tech string. If it remains `""` after lazyload, `run` exits (single URL) or skips (batch). Techs other than `"next"` and `"vue"` only get lazyload; the rest of the pipeline is skipped with a warning.
+
+### Batch mode
+
+When `-u` points to a file of URLs, each line is processed sequentially. For each URL:
+- A subdirectory `output/<host>/` is created
+- `clearJsUrls()` / `clearJsonUrls()` reset the URL sets so previous targets don't bleed over
+- All output paths are prefixed with `workingDir/`
+
+## Adding a new flag to `run`
+
+1. Declare the option in `src/index.ts` on the `run` command (`.option(...)`)
+2. If it configures a global, call the setter in the `action` handler before `await run(cmd)`
+3. If it needs to reach a downstream module (like `analyze`), thread it through `cmd` — `processUrl` receives the full `cmd` object and passes it to submodule calls
+
+**Example — `-r/--rules` flag (added in this codebase):**
+- Declared in `src/index.ts`: `.option("-r, --rules <file/dir>", "Rules file or directory (passed to analyze module)")`
+- In `src/run/index.ts` the `analyze` calls use `cmd.rules || ""` — empty string tells `analyze` to use the default rules cache
 
 ## Rules
 
-Rules are YAML files (`.yml`/`.yaml`) living in two places:
+Rules are YAML files (`.yml`/`.yaml`) in two places:
 - **Workspace:** `../js-recon-rules/` (relative to this repo)
 - **Installed cache:** `~/.js-recon/rules`
 
-`initRules` downloads rules from GitHub when missing or when the cached version doesn't match the GitHub latest. Rules may declare `js_recon_version: ">=X.Y.Z"`; incompatible rules are skipped with a warning. The version check strips prerelease suffixes (e.g. `1.3.1-alpha.3` → `[1,3,1]`).
+`initRules` downloads rules from GitHub when missing or when the cached version doesn't match the latest release. Rules may declare `js_recon_version: ">=X.Y.Z"`; incompatible rules are skipped with a warning. The version check strips prerelease suffixes (e.g. `1.3.1-alpha.3` → `[1,3,1]`).
 
-Rule categories: `ast/` (AST-based pattern matching) and `request/` (OpenAPI/request-level checks).
+Rule categories:
+- `ast/` — AST-based pattern matching against chunk code (uses `@babel/parser` + `esquery`)
+- `request/` — OpenAPI/request-level checks against the resolved endpoint list
+
+When `-r` points to a single file, only that rule is loaded. When it points to a directory, all `.yml`/`.yaml` files are loaded recursively.
 
 ## Testing a change
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shriyanss/js-recon",
-    "version": "1.3.1-alpha.2",
+    "version": "1.3.1-alpha.3",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/src/analyze/engine/index.ts
+++ b/src/analyze/engine/index.ts
@@ -22,7 +22,7 @@ export const engine = async (
     rule: Rule,
     mappedJsonData: Chunks | undefined,
     openapiData: OpenAPISpec | undefined,
-    tech: "next" | "all"
+    tech: "next" | "vue" | "all"
 ): Promise<EngineOutput[] | undefined> => {
     // first of all check what is rule type, and then check if the data for that is available or is undefined
 

--- a/src/analyze/engine/index.ts
+++ b/src/analyze/engine/index.ts
@@ -40,7 +40,7 @@ export const engine = async (
             }
         }
 
-        if (techValid || tech === "all") {
+        if (techValid || tech === "all" || rule.tech.includes("all")) {
             findings.push(...(await requestEngine(rule, openapiData)));
         }
     } else if (rule.type === "ast") {
@@ -55,7 +55,7 @@ export const engine = async (
             }
         }
 
-        if (techValid || tech === "all") {
+        if (techValid || tech === "all" || rule.tech.includes("all")) {
             findings.push(...(await astEngine(rule, mappedJsonData)));
         }
     }

--- a/src/analyze/helpers/outputHelper.ts
+++ b/src/analyze/helpers/outputHelper.ts
@@ -8,7 +8,7 @@ export interface EngineOutput {
     ruleType: string;
     ruleDescription: string;
     ruleAuthor: string;
-    ruleTech: ("next" | "all")[];
+    ruleTech: ("next" | "vue" | "all")[];
     severity: string;
     message: string;
     findingLocation: string;

--- a/src/analyze/helpers/schemas.ts
+++ b/src/analyze/helpers/schemas.ts
@@ -51,7 +51,7 @@ export const ruleSchema = z.object({
     author: z.string(),
     description: z.string(),
     js_recon_version: z.string(),
-    tech: z.array(z.enum(["next", "vue"])),
+    tech: z.array(z.enum(["next", "vue", "all"])),
     severity: z.enum(["info", "low", "medium", "high"]),
     type: z.enum(["request", "ast"]),
     steps: z.array(stepSchema),

--- a/src/analyze/helpers/schemas.ts
+++ b/src/analyze/helpers/schemas.ts
@@ -51,7 +51,7 @@ export const ruleSchema = z.object({
     author: z.string(),
     description: z.string(),
     js_recon_version: z.string(),
-    tech: z.array(z.literal("next")),
+    tech: z.array(z.enum(["next", "vue"])),
     severity: z.enum(["info", "low", "medium", "high"]),
     type: z.enum(["request", "ast"]),
     steps: z.array(stepSchema),

--- a/src/analyze/helpers/schemas.ts
+++ b/src/analyze/helpers/schemas.ts
@@ -50,7 +50,7 @@ export const ruleSchema = z.object({
     name: z.string(),
     author: z.string(),
     description: z.string(),
-    js_recon_version: z.string().optional(),
+    js_recon_version: z.string(),
     tech: z.array(z.literal("next")),
     severity: z.enum(["info", "low", "medium", "high"]),
     type: z.enum(["request", "ast"]),

--- a/src/analyze/helpers/schemas.ts
+++ b/src/analyze/helpers/schemas.ts
@@ -50,6 +50,7 @@ export const ruleSchema = z.object({
     name: z.string(),
     author: z.string(),
     description: z.string(),
+    js_recon_version: z.string().optional(),
     tech: z.array(z.literal("next")),
     severity: z.enum(["info", "low", "medium", "high"]),
     type: z.enum(["request", "ast"]),

--- a/src/analyze/helpers/validate.ts
+++ b/src/analyze/helpers/validate.ts
@@ -19,7 +19,7 @@ const compareVersions = (a: [number, number, number], b: [number, number, number
 
 const isVersionCompatible = (requirement: string, currentVersion: string): boolean => {
     const match = requirement.match(/^(>=|<=|>|<|==?)\s*(.+)/);
-    if (!match) return true;
+    if (!match) return false; // Invalid format
     const [, op, reqVer] = match;
     const current = parseVersion(currentVersion);
     const required = parseVersion(reqVer);

--- a/src/analyze/helpers/validate.ts
+++ b/src/analyze/helpers/validate.ts
@@ -2,31 +2,70 @@ import chalk from "chalk";
 import fs from "fs";
 import yaml from "yaml";
 import { ruleSchema } from "./schemas.js";
+import CONFIG from "../../globalConfig.js";
+
+const parseVersion = (version: string): [number, number, number] => {
+    const clean = version.split("-")[0];
+    const parts = clean.split(".").map(Number);
+    return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+};
+
+const compareVersions = (a: [number, number, number], b: [number, number, number]): number => {
+    for (let i = 0; i < 3; i++) {
+        if (a[i] !== b[i]) return a[i] - b[i];
+    }
+    return 0;
+};
+
+const isVersionCompatible = (requirement: string, currentVersion: string): boolean => {
+    const match = requirement.match(/^(>=|<=|>|<|==?)\s*(.+)/);
+    if (!match) return true;
+    const [, op, reqVer] = match;
+    const current = parseVersion(currentVersion);
+    const required = parseVersion(reqVer);
+    const cmp = compareVersions(current, required);
+    switch (op) {
+        case ">=": return cmp >= 0;
+        case "<=": return cmp <= 0;
+        case ">": return cmp > 0;
+        case "<": return cmp < 0;
+        case "=":
+        case "==": return cmp === 0;
+        default: return true;
+    }
+};
 
 /**
- * Validates a collection of YAML rule files against the defined schema.
+ * Validates a collection of YAML rule files against the defined schema and version requirements.
  *
- * Reads each rule file, parses the YAML content, and validates it against
- * the rule schema. Reports any validation errors found in the rules.
+ * Reads each rule file, parses the YAML content, validates it against the rule schema,
+ * and checks whether the rule's declared js_recon_version is satisfied by the current version.
+ * Rules that require a higher js-recon version are skipped with a warning.
  *
  * @param ruleFiles - Array of file paths to YAML rule files to validate
- * @returns Promise that resolves to true if all rules are valid, false otherwise
+ * @returns Promise that resolves to an object with allValid (schema validity) and compatibleRuleFiles (version-compatible files)
  */
-const validateRules = async (ruleFiles: string[]): Promise<boolean> => {
+const validateRules = async (ruleFiles: string[]): Promise<{ allValid: boolean; compatibleRuleFiles: string[] }> => {
     console.log(chalk.cyan("[i] Validating rules..."));
     let allValid = true;
+    const compatibleRuleFiles: string[] = [];
 
-    // iterate over the ruleFiles
     for (const ruleFile of ruleFiles) {
         try {
-            // open the rule file
             const ruleData = fs.readFileSync(ruleFile, "utf8");
-
-            // parse the rule data
             const rule = yaml.parse(ruleData);
-
-            // check if the rule is valid
             ruleSchema.parse(rule);
+
+            if (rule.js_recon_version && !isVersionCompatible(rule.js_recon_version, CONFIG.version)) {
+                console.log(
+                    chalk.yellow(
+                        `[!] Skipping ${ruleFile}: requires js-recon ${rule.js_recon_version} (current: ${CONFIG.version})`
+                    )
+                );
+                continue;
+            }
+
+            compatibleRuleFiles.push(ruleFile);
         } catch (error: any) {
             allValid = false;
             console.error(chalk.red(`[!] Invalid rule in ${ruleFile}:`));
@@ -38,7 +77,7 @@ const validateRules = async (ruleFiles: string[]): Promise<boolean> => {
         }
     }
 
-    return allValid;
+    return { allValid, compatibleRuleFiles };
 };
 
 export default validateRules;

--- a/src/analyze/helpers/validate.ts
+++ b/src/analyze/helpers/validate.ts
@@ -56,7 +56,7 @@ const validateRules = async (ruleFiles: string[]): Promise<{ allValid: boolean; 
             const rule = yaml.parse(ruleData);
             ruleSchema.parse(rule);
 
-            if (rule.js_recon_version && !isVersionCompatible(rule.js_recon_version, CONFIG.version)) {
+            if (!isVersionCompatible(rule.js_recon_version, CONFIG.version)) {
                 console.log(
                     chalk.yellow(
                         `[!] Skipping ${ruleFile}: requires js-recon ${rule.js_recon_version} (current: ${CONFIG.version})`

--- a/src/analyze/helpers/validate.ts
+++ b/src/analyze/helpers/validate.ts
@@ -25,13 +25,19 @@ const isVersionCompatible = (requirement: string, currentVersion: string): boole
     const required = parseVersion(reqVer);
     const cmp = compareVersions(current, required);
     switch (op) {
-        case ">=": return cmp >= 0;
-        case "<=": return cmp <= 0;
-        case ">": return cmp > 0;
-        case "<": return cmp < 0;
+        case ">=":
+            return cmp >= 0;
+        case "<=":
+            return cmp <= 0;
+        case ">":
+            return cmp > 0;
+        case "<":
+            return cmp < 0;
         case "=":
-        case "==": return cmp === 0;
-        default: return true;
+        case "==":
+            return cmp === 0;
+        default:
+            return true;
     }
 };
 

--- a/src/analyze/index.ts
+++ b/src/analyze/index.ts
@@ -12,6 +12,7 @@ import { EngineOutput, generateEngineOutput } from "./helpers/outputHelper.js";
 
 const availableTechs = {
     next: "Next.js",
+    vue: "Vue.js",
 };
 
 /**
@@ -55,7 +56,7 @@ const getRuleFilesRecursive = (dir: string): string[] => {
 const analyze = async (
     rulesPath: string,
     mappedJson: string,
-    tech: "next",
+    tech: "next" | "vue",
     list: boolean,
     openapi: string,
     validate: boolean,

--- a/src/analyze/index.ts
+++ b/src/analyze/index.ts
@@ -86,7 +86,7 @@ const analyze = async (
     }
 
     // now, validate all those files
-    const allValidated = await validateRules(ruleFiles);
+    const { allValid: allValidated, compatibleRuleFiles } = await validateRules(ruleFiles);
 
     if (!allValidated) {
         console.log(chalk.red("[!] Some rules are invalid"));
@@ -144,7 +144,7 @@ const analyze = async (
 
     // iterate over the ruleFiles
     let ruleFindings: EngineOutput[] = [];
-    for (const ruleFile of ruleFiles) {
+    for (const ruleFile of compatibleRuleFiles) {
         // load the rule
         const rule: Rule = yaml.parse(fs.readFileSync(ruleFile, "utf8"));
 

--- a/src/analyze/types/index.ts
+++ b/src/analyze/types/index.ts
@@ -3,7 +3,7 @@ export interface Rule {
     name: string;
     author: string;
     description: string;
-    js_recon_version?: string;
+    js_recon_version: string;
     tech: ("next" | "all")[];
     severity: "info" | "low" | "medium" | "high";
     type: "request" | "ast";

--- a/src/analyze/types/index.ts
+++ b/src/analyze/types/index.ts
@@ -3,6 +3,7 @@ export interface Rule {
     name: string;
     author: string;
     description: string;
+    js_recon_version?: string;
     tech: ("next" | "all")[];
     severity: "info" | "low" | "medium" | "high";
     type: "request" | "ast";

--- a/src/analyze/types/index.ts
+++ b/src/analyze/types/index.ts
@@ -4,7 +4,7 @@ export interface Rule {
     author: string;
     description: string;
     js_recon_version: string;
-    tech: ("next" | "all")[];
+    tech: ("next" | "vue" | "all")[];
     severity: "info" | "low" | "medium" | "high";
     type: "request" | "ast";
     steps: Step[];

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,6 @@
 const githubURL = "https://github.com/shriyanss/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
-const version = "1.3.1-alpha.2";
+const version = "1.3.1-alpha.3";
 const toolDesc = "JS Recon Tool";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,6 +264,7 @@ program
     .command("run")
     .description("Run all modules")
     .requiredOption("-u, --url <url/file>", "Target URL or a file containing a list of URLs (one per line)")
+    .option("-r, --rules <file/dir>", "Rules file or directory (passed to analyze module)")
     .option("-o, --output <directory>", "Output directory", "output")
     .option("--strict-scope", "Download JS files from only the input URL domain", false)
     .option("-s, --scope <scope>", "Download JS files from specific domains (comma-separated)", "*")

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,6 +183,12 @@ program
     .option("-o, --output <file>", "Output file name (without extension)", "mapped")
     .option("-f, --format <format>", "Output format for the results comma-separated (available: JSON)", "json")
     .option("-i, --interactive", "Interactive mode", false)
+    .option(
+        "-c, --command <command>",
+        "Run an interactive-mode command non-interactively. Can be passed multiple times, or chain several with `&&` inside a single value (e.g. -c 'list fetch && go to 1234'), to run several commands in sequence.",
+        (val: string, prev: string[]) => [...prev, ...val.split(/\s*&&\s*/).filter((c) => c.length > 0)],
+        [] as string[]
+    )
     .option("--ai <options>", "Use AI to analyze the code (comma-separated; available: description)")
     .option("--ai-threads <threads>", "Number of threads to use for AI", "5")
     .option("--ai-provider <provider>", "Service provider to use for AI (available: openai, ollama)", "openai")
@@ -212,7 +218,15 @@ program
                 }
             }
         }
-        await map(cmd.directory, cmd.output, cmd.format.split(","), cmd.tech, cmd.list, cmd.interactive);
+        await map(
+            cmd.directory,
+            cmd.output,
+            cmd.format.split(","),
+            cmd.tech,
+            cmd.list,
+            cmd.interactive,
+            cmd.command || []
+        );
     });
 
 program
@@ -265,6 +279,12 @@ program
     .description("Run all modules")
     .requiredOption("-u, --url <url/file>", "Target URL or a file containing a list of URLs (one per line)")
     .option("-r, --rules <file/dir>", "Rules file or directory (passed to analyze module)")
+    .option(
+        "-c, --command <command>",
+        "Run an interactive-mode command on the mapped chunks non-interactively (forwarded to the map step). Can be passed multiple times, or chain several with `&&` inside a single value (e.g. -c 'list fetch && go to 1234').",
+        (val: string, prev: string[]) => [...prev, ...val.split(/\s*&&\s*/).filter((c) => c.length > 0)],
+        [] as string[]
+    )
     .option("-o, --output <directory>", "Output directory", "output")
     .option("--strict-scope", "Download JS files from only the input URL domain", false)
     .option("-s, --scope <scope>", "Download JS files from specific domains (comma-separated)", "*")

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import analyze from "./analyze/index.js";
 import report from "./report/index.js";
 import configureSandbox from "./utility/configureSandbox.js";
 import mcp from "./mcp/index.js";
+import load from "./load/index.js";
 
 /**
  * Main CLI application entry point for js-recon tool.
@@ -52,6 +53,7 @@ program
     .option("--api-gateway-config <file>", "API Gateway config file", ".api_gateway_config.json")
     .option("--cache-file <file>", "File to store response cache", ".resp_cache.json")
     .option("--disable-cache", "Disable response caching", false)
+    .option("--cache-only", "Only use the response cache; never make network requests", false)
     .option("-y, --yes", "Auto-approve executing JS code from the target", false)
     .option("--timeout <timeout>", "Request timeout in ms", "30000")
     .option("-k, --insecure", "Disable SSL certificate verification", false)
@@ -67,6 +69,7 @@ program
         globalsUtil.setUseApiGateway(cmd.apiGateway);
         globalsUtil.setDisableCache(cmd.disableCache);
         globalsUtil.setRespCacheFile(cmd.cacheFile);
+        globalsUtil.setCacheOnly(cmd.cacheOnly);
         globalsUtil.setYes(cmd.yes);
         validateAndSetTimeout(cmd.timeout);
 
@@ -293,6 +296,7 @@ program
     .option("--api-gateway-config <file>", "API Gateway config file", ".api_gateway_config.json")
     .option("--cache-file <file>", "File to store response cache", ".resp_cache.json")
     .option("--disable-cache", "Disable response caching", false)
+    .option("--cache-only", "Only use the response cache; never make network requests", false)
     .option("-y, --yes", "Auto-approve executing JS code from the target", false)
     .option("--secrets", "Scan for secrets", false)
     .option("--ai <options>", "Use AI to analyze the code (comma-separated; available: description)")
@@ -319,6 +323,9 @@ program
         globalsUtil.setAiThreads(cmd.aiThreads);
         if (cmd.aiEndpoint) globalsUtil.setAiEndpoint(cmd.aiEndpoint);
         globalsUtil.setOpenapiChunkTag(cmd.mapOpenapiChunkTag);
+        globalsUtil.setDisableCache(cmd.disableCache);
+        globalsUtil.setRespCacheFile(cmd.cacheFile);
+        globalsUtil.setCacheOnly(cmd.cacheOnly);
 
         configureSandbox(cmd);
 
@@ -332,6 +339,17 @@ program
             }
         }
         await run(cmd);
+    });
+
+program
+    .command("load")
+    .description("Populate response cache from a Caido/Burp request history export")
+    .requiredOption("-c, --caido <file>", "Caido JSON export file")
+    .requiredOption("-u, --url <url>", "Target URL — only entries matching this host/port/scheme are loaded")
+    .option("--cache-file <file>", "Response cache file to write", ".resp_cache.json")
+    .action(async (cmd) => {
+        globalsUtil.setRespCacheFile(cmd.cacheFile);
+        await load(cmd.caido, cmd.url);
     });
 
 program

--- a/src/lazyLoad/downloadFilesUtil.ts
+++ b/src/lazyLoad/downloadFilesUtil.ts
@@ -33,7 +33,7 @@ const downloadFiles = async (urls: string[], output: string) => {
 
     const processOne = async (url: string) => {
         try {
-            if (!url.match(/(\.js|\.json|\.js\.map)/)) {
+            if (!url.match(/(\.js|\.json|\.js\.map|\.vue)/) || url.match(/lang\.(css|scss|sass|less|styl)/)) {
                 console.log(chalk.yellow(`[i] Ignored ${url}`));
                 return;
             }
@@ -72,10 +72,10 @@ const downloadFiles = async (urls: string[], output: string) => {
                 filename = url
                     .split("/")
                     .pop()
-                    ?.match(/[a-zA-Z0-9\.\-_]+\.js(on)?(\.map)?/)?.[0];
+                    ?.match(/[a-zA-Z0-9\.\-_]+\.(js(on)?(\.map)?|vue)/)?.[0];
             } catch {
                 for (const chunk of url.split("/")) {
-                    if (chunk.match(/\.js(on)?$/)) {
+                    if (chunk.match(/\.(js(on)?|vue)$/)) {
                         filename = chunk;
                         break;
                     }

--- a/src/lazyLoad/downloadQueue.ts
+++ b/src/lazyLoad/downloadQueue.ts
@@ -185,6 +185,10 @@ export class DownloadQueue {
                     const formatted =
                         file.length <= PRETTIER_SIZE_LIMIT ? await prettier.format(file, { parser: "json" }) : file;
                     fs.writeFileSync(filePath, formatted);
+                } else if (url.match(/\.vue$/)) {
+                    const formatted =
+                        file.length <= PRETTIER_SIZE_LIMIT ? await prettier.format(file, { parser: "vue" }) : file;
+                    fs.writeFileSync(filePath, formatted);
                 } else {
                     const formatted =
                         file.length <= PRETTIER_SIZE_LIMIT ? await prettier.format(file, { parser: "babel" }) : file;

--- a/src/lazyLoad/downloadQueue.ts
+++ b/src/lazyLoad/downloadQueue.ts
@@ -123,7 +123,7 @@ export class DownloadQueue {
 
     private async processOne(url: string): Promise<void> {
         try {
-            if (!url.match(/(\.js|\.json|\.js\.map)/)) {
+            if (!url.match(/(\.js|\.json|\.js\.map|\.vue)/) || url.match(/lang\.(css|scss|sass|less|styl)/)) {
                 console.log(chalk.yellow(`[i] Ignored ${url}`));
                 return;
             }
@@ -164,10 +164,10 @@ export class DownloadQueue {
                 filename = url
                     .split("/")
                     .pop()
-                    ?.match(/[a-zA-Z0-9\.\-_]+\.js(on)?(\.map)?/)?.[0];
+                    ?.match(/[a-zA-Z0-9\.\-_]+\.(js(on)?(\.map)?|vue)/)?.[0];
             } catch {
                 for (const chunk of url.split("/")) {
-                    if (chunk.match(/\.js(on)?$/)) {
+                    if (chunk.match(/\.(js(on)?|vue)$/)) {
                         filename = chunk;
                         break;
                     }

--- a/src/lazyLoad/next_js/next_GetJSScript.ts
+++ b/src/lazyLoad/next_js/next_GetJSScript.ts
@@ -4,6 +4,7 @@ import { URL } from "url";
 import * as cheerio from "cheerio";
 import makeRequest from "../../utility/makeReq.js";
 import { getJsUrls } from "../globals.js";
+import { getCacheOnly } from "../../utility/globals.js";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -24,16 +25,19 @@ const next_getJSScript = async (url: string): Promise<string[]> => {
     const toReturn: string[] = [];
     // get the page source — bounded retry so an unreachable host can't hang the crawler
     let res: Response | null = null;
-    for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
+    const maxAttempts = getCacheOnly() ? 1 : MAX_FETCH_ATTEMPTS;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         res = await makeRequest(url, {});
         if (res) break;
-        if (attempt < MAX_FETCH_ATTEMPTS) {
-            console.log(chalk.yellow(`[!] Request to ${url} failed, retrying (${attempt}/${MAX_FETCH_ATTEMPTS})...`));
+        if (attempt < maxAttempts) {
+            console.log(chalk.yellow(`[!] Request to ${url} failed, retrying (${attempt}/${maxAttempts})...`));
             await sleep(1000);
         }
     }
     if (!res) {
-        console.log(chalk.red(`[!] Giving up on ${url} after ${MAX_FETCH_ATTEMPTS} attempts`));
+        if (!getCacheOnly()) {
+            console.log(chalk.red(`[!] Giving up on ${url} after ${maxAttempts} attempts`));
+        }
         return toReturn;
     }
     const pageSource = await res.text();

--- a/src/lazyLoad/techDetect/index.ts
+++ b/src/lazyLoad/techDetect/index.ts
@@ -42,26 +42,28 @@ const frameworkDetect = async (url: string): Promise<{ name: string; evidence: s
         }
     }
 
-    // get the page source in the browser
-    const browser = await puppeteer.launch({
-        args: globalsUtil.getDisableSandbox() ? ["--no-sandbox", "--disable-setuid-sandbox"] : [],
-    });
-    const page = await browser.newPage();
-    page.setDefaultNavigationTimeout(30000);
+    // get the page source in the browser (skipped in cache-only mode — no network allowed)
     let pageSource = "";
-    try {
-        await page.goto(url, {
-            waitUntil: "domcontentloaded",
-            timeout: 30000,
+    if (!globalsUtil.getCacheOnly()) {
+        const browser = await puppeteer.launch({
+            args: globalsUtil.getDisableSandbox() ? ["--no-sandbox", "--disable-setuid-sandbox"] : [],
         });
-        // Give client-side frameworks a brief window to render
-        await page.waitForSelector("html", { timeout: 10000 }).catch(() => {});
-        await new Promise((resolve) => setTimeout(resolve, 2000));
-        pageSource = await page.content();
-    } catch (err) {
-        console.log(chalk.yellow("[!] Page navigation/content failed, falling back to fetch response if available"));
-    } finally {
-        await browser.close().catch(() => {});
+        const page = await browser.newPage();
+        page.setDefaultNavigationTimeout(30000);
+        try {
+            await page.goto(url, {
+                waitUntil: "domcontentloaded",
+                timeout: 30000,
+            });
+            // Give client-side frameworks a brief window to render
+            await page.waitForSelector("html", { timeout: 10000 }).catch(() => {});
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            pageSource = await page.content();
+        } catch (err) {
+            console.log(chalk.yellow("[!] Page navigation/content failed, falling back to fetch response if available"));
+        } finally {
+            await browser.close().catch(() => {});
+        }
     }
 
     // if (res === null || res === undefined) {

--- a/src/lazyLoad/techDetect/index.ts
+++ b/src/lazyLoad/techDetect/index.ts
@@ -60,7 +60,9 @@ const frameworkDetect = async (url: string): Promise<{ name: string; evidence: s
             await new Promise((resolve) => setTimeout(resolve, 2000));
             pageSource = await page.content();
         } catch (err) {
-            console.log(chalk.yellow("[!] Page navigation/content failed, falling back to fetch response if available"));
+            console.log(
+                chalk.yellow("[!] Page navigation/content failed, falling back to fetch response if available")
+            );
         } finally {
             await browser.close().catch(() => {});
         }

--- a/src/load/index.ts
+++ b/src/load/index.ts
@@ -22,10 +22,7 @@ interface CaidoEntry {
 
 const DEFAULT_PORTS: Record<string, number> = { "http:": 80, "https:": 443 };
 
-async function* streamCaidoEntries(
-    filePath: string,
-    rawFilter: (raw: string) => boolean
-): AsyncGenerator<CaidoEntry> {
+async function* streamCaidoEntries(filePath: string, rawFilter: (raw: string) => boolean): AsyncGenerator<CaidoEntry> {
     const stream = fs.createReadStream(filePath, { encoding: "utf8", highWaterMark: 1024 * 1024 });
     let depth = 0;
     let inString = false;
@@ -115,7 +112,9 @@ function parseHeaders(headerText: string): { firstLine: string; headers: Record<
 }
 
 function decodeBody(body: Buffer, headers: Record<string, string>): Buffer {
-    const enc = Object.entries(headers).find(([k]) => k.toLowerCase() === "content-encoding")?.[1]?.toLowerCase();
+    const enc = Object.entries(headers)
+        .find(([k]) => k.toLowerCase() === "content-encoding")?.[1]
+        ?.toLowerCase();
     if (!enc) return body;
     try {
         if (enc.includes("gzip")) return zlib.gunzipSync(body);

--- a/src/load/index.ts
+++ b/src/load/index.ts
@@ -1,0 +1,281 @@
+import fs from "fs";
+import chalk from "chalk";
+import { URL } from "url";
+import zlib from "zlib";
+import * as globals from "../utility/globals.js";
+
+interface CaidoEntry {
+    id: number;
+    host: string;
+    method: string;
+    path: string;
+    port: number;
+    raw: string;
+    is_tls: boolean;
+    query: string | null;
+    response?: {
+        id: number;
+        status_code: number;
+        raw: string;
+    };
+}
+
+const DEFAULT_PORTS: Record<string, number> = { "http:": 80, "https:": 443 };
+
+async function* streamCaidoEntries(
+    filePath: string,
+    rawFilter: (raw: string) => boolean
+): AsyncGenerator<CaidoEntry> {
+    const stream = fs.createReadStream(filePath, { encoding: "utf8", highWaterMark: 1024 * 1024 });
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    let started = false;
+    let inObject = false;
+    let pending: string[] = [];
+    let startIdx = -1;
+
+    for await (const chunk of stream) {
+        const buf = chunk as string;
+        for (let i = 0; i < buf.length; i++) {
+            const c = buf[i];
+            if (!started) {
+                if (c === "[") started = true;
+                continue;
+            }
+            if (!inObject) {
+                if (c === "{") {
+                    inObject = true;
+                    depth = 1;
+                    startIdx = i;
+                }
+                continue;
+            }
+            if (inString) {
+                if (escape) escape = false;
+                else if (c === "\\") escape = true;
+                else if (c === '"') inString = false;
+                continue;
+            }
+            if (c === '"') {
+                inString = true;
+            } else if (c === "{") {
+                depth++;
+            } else if (c === "}") {
+                depth--;
+                if (depth === 0) {
+                    pending.push(buf.slice(startIdx, i + 1));
+                    const objStr = pending.length === 1 ? pending[0] : pending.join("");
+                    pending = [];
+                    inObject = false;
+                    startIdx = -1;
+                    if (rawFilter(objStr)) {
+                        try {
+                            yield JSON.parse(objStr) as CaidoEntry;
+                        } catch {
+                            // skip malformed object
+                        }
+                    }
+                }
+            }
+        }
+        if (inObject && startIdx !== -1) {
+            pending.push(buf.slice(startIdx));
+            startIdx = 0;
+        }
+    }
+}
+
+function splitHttpMessage(raw: Buffer): { headerText: string; body: Buffer } | null {
+    const sep = Buffer.from("\r\n\r\n");
+    const idx = raw.indexOf(sep);
+    if (idx === -1) {
+        const lfSep = Buffer.from("\n\n");
+        const idx2 = raw.indexOf(lfSep);
+        if (idx2 === -1) return null;
+        return { headerText: raw.slice(0, idx2).toString("utf8"), body: raw.slice(idx2 + 2) };
+    }
+    return { headerText: raw.slice(0, idx).toString("utf8"), body: raw.slice(idx + 4) };
+}
+
+function parseHeaders(headerText: string): { firstLine: string; headers: Record<string, string> } {
+    const lines = headerText.split(/\r?\n/);
+    const firstLine = lines.shift() || "";
+    const headers: Record<string, string> = {};
+    for (const line of lines) {
+        if (!line) continue;
+        const colon = line.indexOf(":");
+        if (colon === -1) continue;
+        const key = line.slice(0, colon).trim();
+        const value = line.slice(colon + 1).trim();
+        if (!key) continue;
+        headers[key] = value;
+    }
+    return { firstLine, headers };
+}
+
+function decodeBody(body: Buffer, headers: Record<string, string>): Buffer {
+    const enc = Object.entries(headers).find(([k]) => k.toLowerCase() === "content-encoding")?.[1]?.toLowerCase();
+    if (!enc) return body;
+    try {
+        if (enc.includes("gzip")) return zlib.gunzipSync(body);
+        if (enc.includes("br")) return zlib.brotliDecompressSync(body);
+        if (enc.includes("deflate")) {
+            try {
+                return zlib.inflateSync(body);
+            } catch {
+                return zlib.inflateRawSync(body);
+            }
+        }
+        if (enc.includes("zstd") && (zlib as any).zstdDecompressSync) {
+            return (zlib as any).zstdDecompressSync(body);
+        }
+    } catch {
+        // fall through and return raw body
+    }
+    return body;
+}
+
+function buildUrlVariants(entry: CaidoEntry): string[] {
+    const scheme = entry.is_tls ? "https:" : "http:";
+    const defaultPort = DEFAULT_PORTS[scheme];
+    const hasNonDefaultPort = entry.port && entry.port !== defaultPort;
+    const hostWithPort = hasNonDefaultPort ? `${entry.host}:${entry.port}` : entry.host;
+    const hostNoPort = entry.host;
+    const path = entry.path || "/";
+    const query = entry.query ? `?${entry.query}` : "";
+
+    const variants = new Set<string>();
+    variants.add(`${scheme}//${hostWithPort}${path}${query}`);
+    if (hasNonDefaultPort) {
+        variants.add(`${scheme}//${hostNoPort}${path}${query}`);
+    } else {
+        variants.add(`${scheme}//${entry.host}:${entry.port}${path}${query}`);
+    }
+    if (path === "/" && !query) {
+        variants.add(`${scheme}//${hostWithPort}`);
+        if (hasNonDefaultPort) variants.add(`${scheme}//${hostNoPort}`);
+    }
+    return Array.from(variants);
+}
+
+const load = async (caidoFile: string, targetUrl: string): Promise<void> => {
+    console.log(chalk.cyan("[i] Loading 'Load' module"));
+
+    if (!fs.existsSync(caidoFile)) {
+        console.log(chalk.red(`[!] Caido file not found: ${caidoFile}`));
+        process.exit(1);
+    }
+
+    let targetHost: string;
+    let targetPort: number;
+    let targetScheme: string;
+    try {
+        const u = new URL(targetUrl);
+        targetHost = u.hostname;
+        targetScheme = u.protocol;
+        targetPort = u.port ? parseInt(u.port, 10) : DEFAULT_PORTS[u.protocol];
+    } catch {
+        console.log(chalk.red(`[!] Invalid target URL: ${targetUrl}`));
+        process.exit(1);
+    }
+
+    const cacheFile = globals.getRespCacheFile();
+    let cache: Record<string, any> = {};
+    if (fs.existsSync(cacheFile)) {
+        try {
+            cache = JSON.parse(fs.readFileSync(cacheFile, "utf-8"));
+        } catch {
+            cache = {};
+        }
+    }
+
+    console.log(
+        chalk.cyan(`[i] Filtering Caido entries for ${targetScheme}//${targetHost}:${targetPort} → ${cacheFile}`)
+    );
+
+    let scanned = 0;
+    let matched = 0;
+    let stored = 0;
+
+    const hostNeedle = `"host":"${targetHost}"`;
+    const rawFilter = (raw: string): boolean => raw.includes(hostNeedle);
+
+    for await (const entry of streamCaidoEntries(caidoFile, rawFilter)) {
+        scanned++;
+        if (scanned % 5000 === 0) {
+            process.stdout.write(chalk.dim(`\r[i] Scanned ${scanned} entries (matched ${matched})`));
+        }
+
+        if (!entry || !entry.host) continue;
+        if (entry.host !== targetHost) continue;
+        if (entry.port !== targetPort) continue;
+        const entryScheme = entry.is_tls ? "https:" : "http:";
+        if (entryScheme !== targetScheme) continue;
+        if (!entry.response) continue;
+
+        matched++;
+
+        let respRaw: Buffer;
+        let reqRaw: Buffer;
+        try {
+            respRaw = Buffer.from(entry.response.raw, "base64");
+            reqRaw = Buffer.from(entry.raw, "base64");
+        } catch {
+            continue;
+        }
+
+        const respParts = splitHttpMessage(respRaw);
+        if (!respParts) continue;
+        const reqParts = splitHttpMessage(reqRaw);
+
+        const respParsed = parseHeaders(respParts.headerText);
+        const reqHeaders = reqParts ? parseHeaders(reqParts.headerText).headers : {};
+
+        const decodedBody = decodeBody(respParts.body, respParsed.headers);
+        const bodyB64 = decodedBody.toString("base64");
+
+        const respHeaders: Record<string, string> = {};
+        for (const [k, v] of Object.entries(respParsed.headers)) {
+            const lk = k.toLowerCase();
+            if (lk === "content-length" || lk === "content-encoding" || lk === "transfer-encoding") continue;
+            respHeaders[k] = v;
+        }
+
+        const status = entry.response.status_code || parseInt(respParsed.firstLine.split(/\s+/)[1] || "200", 10);
+
+        const isRsc = Object.keys(reqHeaders).some((h) => h.toUpperCase() === "RSC");
+        const entryKey = isRsc ? "rsc" : "normal";
+
+        for (const url of buildUrlVariants(entry)) {
+            if (!cache[url]) cache[url] = {};
+            cache[url][entryKey] = {
+                req_headers: reqHeaders,
+                status,
+                body_b64: bodyB64,
+                resp_headers: respHeaders,
+            };
+            stored++;
+        }
+    }
+
+    process.stdout.write("\r");
+
+    try {
+        fs.writeFileSync(cacheFile, JSON.stringify(cache));
+    } catch (err: any) {
+        if (err instanceof RangeError) {
+            console.log(chalk.red(`[!] Cache too large to serialize as one JSON string.`));
+            process.exit(1);
+        }
+        throw err;
+    }
+
+    console.log(
+        chalk.green(
+            `[✓] Load complete — scanned ${scanned}, matched ${matched}, wrote ${stored} cache entries to ${cacheFile}`
+        )
+    );
+};
+
+export default load;

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -7,7 +7,7 @@ import getTurbopackConnections from "./next_js/getTurbopackConnections.js";
 import getFetchInstances from "./next_js/getFetchInstances.js";
 import resolveFetch from "./next_js/resolveFetch.js";
 import resolveNewRequest from "./next_js/resolveNewRequest.js";
-import interactive from "./next_js/interactive.js";
+import interactive, { runCommands as nextRunCommands } from "./next_js/interactive.js";
 import { existsSync, readFileSync } from "fs";
 import { Chunks } from "../utility/interfaces.js";
 import getAxiosInstances from "./next_js/getAxiosInstances.js";
@@ -19,7 +19,7 @@ import getExports from "./next_js/getExports.js";
 
 // Vue.JS
 import getViteConnections from "./vue_js/getViteConnections.js";
-import vueInteractive from "./vue_js/interactive.js";
+import vueInteractive, { runCommands as vueRunCommands } from "./vue_js/interactive.js";
 import vue_resolveFetch from "./vue_js/vue_resolveFetch.js";
 
 const availableTech = {
@@ -55,7 +55,8 @@ const map = async (
     formats: Array<keyof typeof availableFormats>,
     tech: string,
     list: boolean,
-    interactive_mode: boolean
+    interactive_mode: boolean,
+    commands: string[] = []
 ): Promise<void> => {
     console.log(chalk.cyan("[i] Running 'map' module"));
 
@@ -128,7 +129,9 @@ const map = async (
         // wrapper-class HTTP requests:  new X({url, method, ...})
         await resolveNewRequest(chunks, directory);
 
-        if (interactive_mode) {
+        if (commands.length > 0) {
+            await nextRunCommands(chunks, `${output}.json`, commands);
+        } else if (interactive_mode) {
             await interactive(chunks, `${output}.json`);
         }
 
@@ -165,7 +168,9 @@ const map = async (
         // Resolve fetch instances across all Vue.JS files
         await vue_resolveFetch(directory);
 
-        if (interactive_mode) {
+        if (commands.length > 0) {
+            await vueRunCommands(chunks, `${output}.json`, commands);
+        } else if (interactive_mode) {
             await vueInteractive(chunks, `${output}.json`);
         }
 

--- a/src/map/next_js/interactive.ts
+++ b/src/map/next_js/interactive.ts
@@ -45,4 +45,35 @@ const interactive = async (chunks: Chunks, map_file: string) => {
     ui.screen.render();
 };
 
+/**
+ * Run a list of interactive-mode commands non-interactively. The blessed UI is
+ * replaced by a thin shim that pipes `outputBox.log` to stdout, so a caller
+ * (e.g. `map -c ...` or `run -c ...`) can drive the same command surface
+ * without a TTY.
+ */
+const runCommands = async (chunks: Chunks, map_file: string, commands: string[]): Promise<void> => {
+    const state: State = {
+        chunks,
+        lastCommandStatus: true,
+        functionNavHistory: [],
+        functionNavHistoryIndex: -1,
+        funcWriteFile: undefined,
+        commandHistory: [],
+        commandHistoryIndex: -1,
+        writeimports: false,
+        mapFile: map_file,
+    };
+
+    const headlessUi: any = {
+        screen: { render: () => {} },
+        outputBox: { log: (s: string) => console.log(s), setText: () => {} },
+        inputBox: { clearValue: () => {}, focus: () => {} },
+    };
+
+    for (const command of commands) {
+        await handleCommand(command, state, headlessUi);
+    }
+};
+
+export { runCommands };
 export default interactive;

--- a/src/map/next_js/interactive.ts
+++ b/src/map/next_js/interactive.ts
@@ -1,6 +1,7 @@
 import { createUI } from "./interactive_helpers/ui.js";
 import { handleCommand } from "./interactive_helpers/commandHandler.js";
 import { setupKeybindings } from "./interactive_helpers/keybindings.js";
+import { enableCursorInput } from "./interactive_helpers/inputPatch.js";
 import { Chunks } from "../../utility/interfaces.js";
 
 export interface State {
@@ -40,6 +41,7 @@ const interactive = async (chunks: Chunks, map_file: string) => {
     });
 
     setupKeybindings(ui.screen, ui.inputBox, ui.outputBox, state);
+    enableCursorInput(ui.inputBox);
 
     ui.inputBox.focus();
     ui.screen.render();

--- a/src/map/next_js/interactive_helpers/commandHandler.ts
+++ b/src/map/next_js/interactive_helpers/commandHandler.ts
@@ -3,6 +3,7 @@ import path from "path";
 import commandHelpers from "./commandHelpers.js";
 import { helpMenu } from "./helpMenu.js";
 import { printFunction } from "./printer.js";
+import { runEsqueryCommand } from "./esqueryGen.js";
 import { State } from "../interactive.js";
 import { Widgets } from "blessed";
 import fs from "fs";
@@ -224,6 +225,18 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                 outputBox.log(chalk.red(option) + " is not a valid option");
                 state.lastCommandStatus = false;
             }
+        }
+    } else if (text.startsWith("esquery")) {
+        const usage = helpMenu.esquery;
+        const parts = text.split(" ");
+        if (parts.length < 3) {
+            outputBox.log(chalk.magenta(usage));
+            state.lastCommandStatus = false;
+        } else {
+            const chunkId = parts[1];
+            const search = parts.slice(2).join(" ");
+            outputBox.log(runEsqueryCommand(state.chunks, chunkId, search));
+            state.lastCommandStatus = true;
         }
     } else if (text.startsWith("trace")) {
         const usage = helpMenu.trace;

--- a/src/map/next_js/interactive_helpers/commandHandler.ts
+++ b/src/map/next_js/interactive_helpers/commandHandler.ts
@@ -235,8 +235,14 @@ async function handleCommand(text: string, state: State, ui: Screen) {
         } else {
             const chunkId = parts[1];
             const search = parts.slice(2).join(" ");
-            outputBox.log(runEsqueryCommand(state.chunks, chunkId, search));
-            state.lastCommandStatus = true;
+            try {
+                const result = runEsqueryCommand(state.chunks, chunkId, search);
+                outputBox.log(result);
+                state.lastCommandStatus = true;
+            } catch (err) {
+                outputBox.log(chalk.red(err instanceof Error ? err.message : String(err)));
+                state.lastCommandStatus = false;
+            }
         }
     } else if (text.startsWith("trace")) {
         const usage = helpMenu.trace;

--- a/src/map/next_js/interactive_helpers/esqueryGen.ts
+++ b/src/map/next_js/interactive_helpers/esqueryGen.ts
@@ -211,7 +211,10 @@ function normalizeCode(code: string): string {
                 target = program.body[0].expression;
             }
             const out = generator(target, { compact: true, comments: false }).code;
-            return out.replace(/^\(|\);?$/g, "").replace(/;+$/g, "").trim();
+            return out
+                .replace(/^\(|\);?$/g, "")
+                .replace(/;+$/g, "")
+                .trim();
         } catch {
             // try next strategy
         }

--- a/src/map/next_js/interactive_helpers/esqueryGen.ts
+++ b/src/map/next_js/interactive_helpers/esqueryGen.ts
@@ -1,0 +1,379 @@
+import chalk from "chalk";
+import parser from "@babel/parser";
+import _traverse from "@babel/traverse";
+const traverse = (_traverse as any).default ?? _traverse;
+import _generator from "@babel/generator";
+const generator: any = (_generator as any).default ?? _generator;
+import { Node } from "@babel/types";
+import { Chunks } from "../../../utility/interfaces.js";
+
+/**
+ * Escape a string so it can be safely embedded inside a double-quoted
+ * esquery attribute value.
+ */
+function escapeAttr(value: string): string {
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Build an esquery selector from a Babel AST node. The selector aims to be
+ * specific enough to match the original node while still being readable so
+ * the user can broaden or trim it when authoring a rule.
+ */
+function generateSelector(node: Node): string {
+    switch (node.type) {
+        case "Identifier":
+            return `Identifier[name="${escapeAttr((node as any).name)}"]`;
+        case "StringLiteral":
+            return `StringLiteral[value="${escapeAttr((node as any).value)}"]`;
+        case "NumericLiteral":
+            return `NumericLiteral[value=${(node as any).value}]`;
+        case "BooleanLiteral":
+            return `BooleanLiteral[value=${(node as any).value}]`;
+        case "RegExpLiteral":
+            return `RegExpLiteral[pattern="${escapeAttr((node as any).pattern)}"]`;
+        case "TemplateLiteral":
+            return "TemplateLiteral";
+        case "MemberExpression": {
+            const me = node as any;
+            const parts: string[] = ["MemberExpression"];
+            if (me.object?.type === "Identifier") {
+                parts.push(`[object.name="${escapeAttr(me.object.name)}"]`);
+            } else {
+                parts.push(`[object.type="${me.object?.type}"]`);
+            }
+            if (me.property?.type === "Identifier") {
+                parts.push(`[property.name="${escapeAttr(me.property.name)}"]`);
+            } else if (me.property?.type === "StringLiteral") {
+                parts.push(`[property.value="${escapeAttr(me.property.value)}"]`);
+            }
+            return parts.join("");
+        }
+        case "CallExpression":
+        case "NewExpression": {
+            const ce = node as any;
+            const parts: string[] = [node.type];
+            const callee = ce.callee;
+            if (callee?.type === "Identifier") {
+                parts.push(`[callee.name="${escapeAttr(callee.name)}"]`);
+            } else if (callee?.type === "MemberExpression") {
+                parts.push(`[callee.type="MemberExpression"]`);
+                if (callee.object?.type === "Identifier") {
+                    parts.push(`[callee.object.name="${escapeAttr(callee.object.name)}"]`);
+                }
+                if (callee.property?.type === "Identifier") {
+                    parts.push(`[callee.property.name="${escapeAttr(callee.property.name)}"]`);
+                }
+            } else if (callee?.type) {
+                parts.push(`[callee.type="${callee.type}"]`);
+            }
+            return parts.join("");
+        }
+        case "AssignmentExpression": {
+            const ae = node as any;
+            return `AssignmentExpression[operator="${escapeAttr(ae.operator)}"]`;
+        }
+        case "BinaryExpression":
+        case "LogicalExpression": {
+            const be = node as any;
+            return `${node.type}[operator="${escapeAttr(be.operator)}"]`;
+        }
+        case "ObjectProperty": {
+            const op = node as any;
+            if (op.key?.type === "Identifier") {
+                return `${node.type}[key.name="${escapeAttr(op.key.name)}"]`;
+            }
+            if (op.key?.type === "StringLiteral") {
+                return `${node.type}[key.value="${escapeAttr(op.key.value)}"]`;
+            }
+            return node.type;
+        }
+        case "FunctionDeclaration":
+        case "FunctionExpression":
+        case "ArrowFunctionExpression": {
+            const fd = node as any;
+            if (fd.id?.name) {
+                return `${node.type}[id.name="${escapeAttr(fd.id.name)}"]`;
+            }
+            return node.type;
+        }
+        case "VariableDeclarator": {
+            const vd = node as any;
+            if (vd.id?.type === "Identifier") {
+                return `VariableDeclarator[id.name="${escapeAttr(vd.id.name)}"]`;
+            }
+            return "VariableDeclarator";
+        }
+        case "JSXIdentifier":
+            return `JSXIdentifier[name="${escapeAttr((node as any).name)}"]`;
+        case "JSXAttribute": {
+            const ja = node as any;
+            if (ja.name?.type === "JSXIdentifier") {
+                return `JSXAttribute[name.name="${escapeAttr(ja.name.name)}"]`;
+            }
+            return "JSXAttribute";
+        }
+        default:
+            return node.type;
+    }
+}
+
+/**
+ * Generate a tighter esquery selector that pins the immediate children of
+ * the matched node by type. Useful when the user wants to detect this exact
+ * shape (e.g. fetch(`/api/...${x}`)) rather than any fetch().
+ */
+function generateStrictSelector(node: Node): string {
+    const base = generateSelector(node);
+    const extras: string[] = [];
+    switch (node.type) {
+        case "CallExpression":
+        case "NewExpression": {
+            const ce = node as any;
+            const args = ce.arguments || [];
+            extras.push(`[arguments.length=${args.length}]`);
+            args.forEach((arg: any, i: number) => {
+                if (arg?.type) extras.push(`[arguments.${i}.type="${escapeAttr(arg.type)}"]`);
+            });
+            break;
+        }
+        case "AssignmentExpression": {
+            const ae = node as any;
+            if (ae.left?.type) extras.push(`[left.type="${escapeAttr(ae.left.type)}"]`);
+            if (ae.right?.type) extras.push(`[right.type="${escapeAttr(ae.right.type)}"]`);
+            if (ae.left?.type === "MemberExpression" && ae.left.property?.type === "Identifier") {
+                extras.push(`[left.property.name="${escapeAttr(ae.left.property.name)}"]`);
+            }
+            break;
+        }
+        case "BinaryExpression":
+        case "LogicalExpression": {
+            const be = node as any;
+            if (be.left?.type) extras.push(`[left.type="${escapeAttr(be.left.type)}"]`);
+            if (be.right?.type) extras.push(`[right.type="${escapeAttr(be.right.type)}"]`);
+            break;
+        }
+        case "ObjectProperty": {
+            const op = node as any;
+            if (op.value?.type) extras.push(`[value.type="${escapeAttr(op.value.type)}"]`);
+            break;
+        }
+        case "MemberExpression": {
+            const me = node as any;
+            if (me.computed !== undefined) extras.push(`[computed=${me.computed ? "true" : "false"}]`);
+            break;
+        }
+        case "VariableDeclarator": {
+            const vd = node as any;
+            if (vd.init?.type) extras.push(`[init.type="${escapeAttr(vd.init.type)}"]`);
+            break;
+        }
+    }
+    return base + extras.join("");
+}
+
+/**
+ * Reformat code so it matches regardless of whitespace, indentation, or
+ * comments. We parse it and re-emit it via @babel/generator in compact mode;
+ * if parsing fails (e.g. a fragment that can't stand alone) we fall back to a
+ * simple whitespace-collapse.
+ */
+function normalizeCode(code: string): string {
+    const trimmed = code.trim();
+    if (trimmed.length === 0) return "";
+    const attempts = [
+        () => parser.parse(trimmed, { sourceType: "unambiguous", plugins: ["jsx", "typescript"], errorRecovery: true }),
+        // Fragments like `fetch(x)` parse fine as a Program — but isolated
+        // expressions like `{a: 1}` parse as a Block. Wrap as an expression
+        // statement to coerce parsing in that case.
+        () =>
+            parser.parse(`(${trimmed})`, {
+                sourceType: "unambiguous",
+                plugins: ["jsx", "typescript"],
+                errorRecovery: true,
+            }),
+    ];
+    for (const attempt of attempts) {
+        try {
+            const ast = attempt();
+            // Prefer emitting just the inner expression when the source is a single
+            // expression-statement program (e.g. `fetch(x)` or `a.b.c`) — the
+            // statement-level generator appends a trailing `;` that AST nodes
+            // generated standalone never carry, which prevents substring matches.
+            const program = (ast as any).program;
+            let target: any = ast;
+            if (
+                program &&
+                Array.isArray(program.body) &&
+                program.body.length === 1 &&
+                program.body[0].type === "ExpressionStatement"
+            ) {
+                target = program.body[0].expression;
+            }
+            const out = generator(target, { compact: true, comments: false }).code;
+            return out.replace(/^\(|\);?$/g, "").replace(/;+$/g, "").trim();
+        } catch {
+            // try next strategy
+        }
+    }
+    // last-resort fallback: collapse whitespace
+    return trimmed.replace(/\s+/g, "");
+}
+
+interface Candidate {
+    index: number;
+    type: string;
+    line: number;
+    column: number;
+    chunkId: string;
+    snippet: string;
+    selector: string;
+    strictSelector: string;
+}
+
+/**
+ * Parse the chunk and collect AST nodes whose normalized (minified) source
+ * contains the normalized search term. Returns up to `limit` candidates.
+ */
+function findCandidates(code: string, search: string, limit: number, chunkId: string): Candidate[] {
+    let ast: any;
+    try {
+        ast = parser.parse(code, {
+            sourceType: "unambiguous",
+            plugins: ["jsx", "typescript"],
+            errorRecovery: true,
+        });
+    } catch (e) {
+        return [];
+    }
+
+    const needle = normalizeCode(search);
+    if (needle.length === 0) return [];
+
+    type RawMatch = { node: Node; start: number; end: number; normalized: string };
+    const raw: RawMatch[] = [];
+
+    traverse(ast, {
+        enter(path: any) {
+            const node: Node = path.node;
+            const start = (node as any).start;
+            const end = (node as any).end;
+            if (typeof start !== "number" || typeof end !== "number") return;
+
+            // Re-emit the node compact so the comparison is independent of the
+            // chunk's whitespace/comments/formatting.
+            let nodeNormalized: string;
+            try {
+                nodeNormalized = generator(node, { compact: true, comments: false }).code;
+            } catch {
+                return;
+            }
+            if (nodeNormalized.indexOf(needle) === -1) return;
+
+            raw.push({ node, start, end, normalized: nodeNormalized });
+        },
+    });
+
+    // Keep only minimal matches: drop any match that strictly contains another match.
+    // (Ancestors of a real match always also match the substring, but they're noise.)
+    const minimal: RawMatch[] = raw.filter((m) => {
+        for (const other of raw) {
+            if (other === m) continue;
+            if (other.start >= m.start && other.end <= m.end && (other.start > m.start || other.end < m.end)) {
+                return false;
+            }
+        }
+        return true;
+    });
+
+    const candidates: Candidate[] = [];
+    for (const m of minimal) {
+        if (candidates.length >= limit) break;
+        const node = m.node;
+        const snippet = m.normalized.length > 120 ? m.normalized.slice(0, 117) + "..." : m.normalized;
+        candidates.push({
+            index: candidates.length,
+            type: node.type,
+            line: node.loc?.start.line ?? 0,
+            column: node.loc?.start.column ?? 0,
+            chunkId,
+            snippet,
+            selector: generateSelector(node),
+            strictSelector: generateStrictSelector(node),
+        });
+    }
+
+    // Dedupe candidates that share the exact same strict selector + snippet.
+    const seen = new Set<string>();
+    const deduped: Candidate[] = [];
+    for (const c of candidates) {
+        const key = `${c.strictSelector}|${c.snippet}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        deduped.push({ ...c, index: deduped.length });
+    }
+    return deduped;
+}
+
+/**
+ * Public entry point used by the interactive command handler.
+ *
+ * `chunkId` may be a specific chunk key or `*` / `all` to scan every chunk.
+ * `search` is normalized (minified via babel) before being matched against
+ * each AST node's also-normalized source, so the user can paste a snippet
+ * verbatim from prettified source and still hit a node inside a minified
+ * production chunk.
+ *
+ * Returns a formatted, colorised string ready to be logged.
+ */
+function runEsqueryCommand(chunks: Chunks, chunkId: string, search: string): string {
+    if (!search || search.length === 0) {
+        return chalk.red("Search term is required");
+    }
+
+    const scanAll = chunkId === "*" || chunkId.toLowerCase() === "all";
+    const targets: { id: string; code: string }[] = [];
+    if (scanAll) {
+        for (const [id, ch] of Object.entries(chunks)) {
+            targets.push({ id, code: (ch as any).code });
+        }
+    } else {
+        const chunk = chunks[chunkId];
+        if (!chunk) return chalk.red(`Chunk ${chunkId} not found`);
+        targets.push({ id: chunkId, code: chunk.code });
+    }
+
+    const limitPerChunk = scanAll ? 5 : 25;
+    const all: Candidate[] = [];
+    for (const t of targets) {
+        const hits = findCandidates(t.code, search, limitPerChunk, t.id);
+        for (const c of hits) all.push(c);
+        if (all.length >= 200) break;
+    }
+
+    if (all.length === 0) {
+        return chalk.yellow(
+            `No AST nodes in ${scanAll ? `${targets.length} chunk(s)` : `chunk ${chunkId}`} matched the snippet`
+        );
+    }
+
+    // re-index for display
+    all.forEach((c, i) => (c.index = i));
+
+    let out = chalk.cyan(
+        `Found ${all.length} candidate node(s) ${scanAll ? `across ${targets.length} chunk(s)` : `in chunk ${chunkId}`} matching the (normalized) snippet:\n`
+    );
+    for (const c of all) {
+        out += chalk.green(`\n[${c.index}] `) + chalk.bold(c.type);
+        out += chalk.gray(` (chunk ${c.chunkId}, line ${c.line}:${c.column})`);
+        out += `\n  ${chalk.gray("snippet:")}  ${c.snippet}`;
+        out += `\n  ${chalk.gray("loose:")}    ${chalk.yellow(c.selector)}`;
+        out += `\n  ${chalk.gray("strict:")}   ${chalk.yellow(c.strictSelector)}\n`;
+    }
+    out += chalk.gray(
+        "\nTip: paste the loose selector into a rule's `esquery.query` and refine; use strict to check whether an exact node is already covered."
+    );
+    return out;
+}
+
+export { runEsqueryCommand, generateSelector, generateStrictSelector, findCandidates, normalizeCode };

--- a/src/map/next_js/interactive_helpers/helpMenu.ts
+++ b/src/map/next_js/interactive_helpers/helpMenu.ts
@@ -6,6 +6,8 @@ const helpMenu = {
     go: "Usage: go <option>\n  to <functionID>: Go to a specific function\n  back:          Go back to the previous function\n  ahead:         Go to the next function",
     set: "Usage: set <option> <value>\n  funcwritefile <filename>: Set file to write function code to\n  writeimports [true/false]: When using `go *` command, also write all the imports to the file\n  funcdesc <functionId> <description>: Set the description of the provided function ID with provided value",
     trace: "Usage: trace <functionName>\n  Traces imports for a function",
+    esquery:
+        "Usage: esquery <chunkId|*> <code-snippet>\n  Find AST nodes whose minified source contains the (also minified) snippet, and print a loose + strict esquery selector for each. Use `*` (or `all`) as the chunk to scan every chunk. Example: esquery * fetch(`/api/docs/${file}`)",
 };
 
 export { helpMenu };

--- a/src/map/next_js/interactive_helpers/inputPatch.ts
+++ b/src/map/next_js/interactive_helpers/inputPatch.ts
@@ -1,0 +1,199 @@
+import { Widgets } from "blessed";
+
+/**
+ * Enable standard line-editor behavior on a blessed textbox: cursor movement
+ * (left/right/home/end/ctrl-a/ctrl-e), word-wise delete (ctrl-w), kill-to-end
+ * (ctrl-k), kill-to-start (ctrl-u), delete-at-cursor, mid-string insertion
+ * (so paste lands where the cursor is), and horizontal scroll when the value
+ * is longer than the visible width.
+ *
+ * Implementation notes: blessed's Textarea installs a keypress listener on
+ * every focus by binding `this._listener` and storing it as `this.__listener`.
+ * Removing that listener after the fact races with re-installation, so we
+ * instead override `_listener` itself on the instance — blessed then binds
+ * *our* function as its handler and only one listener is ever attached.
+ */
+export function enableCursorInput(inputBox: Widgets.TextboxElement): void {
+    const box: any = inputBox as any;
+
+    box.cursorPos = box.value ? box.value.length : 0;
+    box.scrollOffset = 0;
+
+    const updateDisplay = () => {
+        const width = Math.max(1, (box.width as number) - box.iwidth - 1);
+        if (box.cursorPos < box.scrollOffset) {
+            box.scrollOffset = box.cursorPos;
+        } else if (box.cursorPos > box.scrollOffset + width) {
+            box.scrollOffset = box.cursorPos - width;
+        }
+        const visible = box.value.slice(box.scrollOffset, box.scrollOffset + width + 1);
+        box.setContent(visible.replace(/\t/g, box.screen.tabc));
+    };
+
+    box.setValue = function (value: string | null) {
+        if (value == null) value = box.value;
+        value = value.replace(/\n/g, "");
+        if (box._value !== value) {
+            box.value = value;
+            box._value = value;
+            box.cursorPos = value.length;
+            box.scrollOffset = 0;
+            updateDisplay();
+            box._updateCursor();
+        }
+    };
+
+    box.clearValue = box.clearInput = function () {
+        box.cursorPos = 0;
+        box.scrollOffset = 0;
+        box.value = "";
+        box._value = "";
+        box.setContent("");
+        box._updateCursor();
+    };
+
+    box._updateCursor = function () {
+        if (box.screen.focused !== box) return;
+        const lpos = box._getCoords();
+        if (!lpos) return;
+        const col = box.cursorPos - box.scrollOffset;
+        const cx = lpos.xi + box.ileft + Math.max(0, col);
+        const cy = lpos.yi + box.itop;
+        const program = box.screen.program;
+        if (cy === program.y && cx === program.x) return;
+        if (cy === program.y) {
+            if (cx > program.x) program.cuf(cx - program.x);
+            else if (cx < program.x) program.cub(program.x - cx);
+        } else if (cx === program.x) {
+            if (cy > program.y) program.cud(cy - program.y);
+            else if (cy < program.y) program.cuu(program.y - cy);
+        } else {
+            program.cup(cy, cx);
+        }
+    };
+
+    // Replace the instance's _listener. blessed's readInput() will bind this
+    // and attach it as __listener — so we end up as the sole keypress handler.
+    box._listener = function (ch: string | undefined, key: any) {
+        const k = key && key.name;
+
+        if (k === "enter" || k === "return") {
+            box._done(null, box.value);
+            return;
+        }
+        if (k === "escape") {
+            box._done(null, null);
+            return;
+        }
+
+        // Up/down are owned by the history-navigation keybindings.
+        if (k === "up" || k === "down") return;
+
+        if (k === "left") {
+            if (key.ctrl) {
+                let p = box.cursorPos;
+                while (p > 0 && /\s/.test(box.value[p - 1])) p--;
+                while (p > 0 && !/\s/.test(box.value[p - 1])) p--;
+                box.cursorPos = p;
+            } else if (box.cursorPos > 0) {
+                box.cursorPos--;
+            }
+            updateDisplay();
+            box._updateCursor();
+            box.screen.render();
+            return;
+        }
+        if (k === "right") {
+            if (key.ctrl) {
+                let p = box.cursorPos;
+                while (p < box.value.length && /\s/.test(box.value[p])) p++;
+                while (p < box.value.length && !/\s/.test(box.value[p])) p++;
+                box.cursorPos = p;
+            } else if (box.cursorPos < box.value.length) {
+                box.cursorPos++;
+            }
+            updateDisplay();
+            box._updateCursor();
+            box.screen.render();
+            return;
+        }
+        if (k === "home" || (key && key.ctrl && k === "a")) {
+            box.cursorPos = 0;
+            updateDisplay();
+            box._updateCursor();
+            box.screen.render();
+            return;
+        }
+        if (k === "end" || (key && key.ctrl && k === "e")) {
+            box.cursorPos = box.value.length;
+            updateDisplay();
+            box._updateCursor();
+            box.screen.render();
+            return;
+        }
+
+        if (k === "backspace") {
+            if (box.cursorPos > 0) {
+                box.value = box.value.slice(0, box.cursorPos - 1) + box.value.slice(box.cursorPos);
+                box.cursorPos--;
+                box._value = box.value;
+                updateDisplay();
+                box._updateCursor();
+                box.screen.render();
+            }
+            return;
+        }
+        if (k === "delete") {
+            if (box.cursorPos < box.value.length) {
+                box.value = box.value.slice(0, box.cursorPos) + box.value.slice(box.cursorPos + 1);
+                box._value = box.value;
+                updateDisplay();
+                box._updateCursor();
+                box.screen.render();
+            }
+            return;
+        }
+        if (key && key.ctrl && k === "u") {
+            box.value = box.value.slice(box.cursorPos);
+            box.cursorPos = 0;
+            box._value = box.value;
+            updateDisplay();
+            box._updateCursor();
+            box.screen.render();
+            return;
+        }
+        if (key && key.ctrl && k === "k") {
+            box.value = box.value.slice(0, box.cursorPos);
+            box._value = box.value;
+            updateDisplay();
+            box._updateCursor();
+            box.screen.render();
+            return;
+        }
+        if (key && key.ctrl && k === "w") {
+            let p = box.cursorPos;
+            while (p > 0 && /\s/.test(box.value[p - 1])) p--;
+            while (p > 0 && !/\s/.test(box.value[p - 1])) p--;
+            box.value = box.value.slice(0, p) + box.value.slice(box.cursorPos);
+            box.cursorPos = p;
+            box._value = box.value;
+            updateDisplay();
+            box._updateCursor();
+            box.screen.render();
+            return;
+        }
+
+        // ctrl-c is handled by an outer keybinding.
+        if (key && key.ctrl) return;
+
+        // Printable char (paste arrives as a burst of single-char events).
+        if (ch && !/^[\x00-\x08\x0b-\x0c\x0e-\x1f\x7f]$/.test(ch)) {
+            box.value = box.value.slice(0, box.cursorPos) + ch + box.value.slice(box.cursorPos);
+            box.cursorPos += ch.length;
+            box._value = box.value;
+            updateDisplay();
+            box._updateCursor();
+            box.screen.render();
+        }
+    };
+}

--- a/src/map/next_js/interactive_helpers/ui.ts
+++ b/src/map/next_js/interactive_helpers/ui.ts
@@ -59,7 +59,6 @@ function createUI() {
         },
         keys: true,
         vi: true,
-        mouse: true,
         scrollSpeed: 0.5,
     });
 

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -33,7 +33,12 @@ const describeSpreadArg = (arg: any): string => {
     if (arg.type === "MemberExpression") {
         const parts: string[] = [];
         let walker: any = arg;
-        while (walker && walker.type === "MemberExpression" && !walker.computed && walker.property?.type === "Identifier") {
+        while (
+            walker &&
+            walker.type === "MemberExpression" &&
+            !walker.computed &&
+            walker.property?.type === "Identifier"
+        ) {
             parts.unshift(walker.property.name);
             walker = walker.object;
         }
@@ -1627,11 +1632,7 @@ export const resolveNodeValue = (
                         // pass knows this part of the URL is a query expansion of
                         // an object reference, not just an inert placeholder.
                         const memberChain = memberChainToString(spArg);
-                        if (
-                            memberChain &&
-                            spArg.type === "MemberExpression" &&
-                            !(spArg as any).computed
-                        ) {
+                        if (memberChain && spArg.type === "MemberExpression" && !(spArg as any).computed) {
                             return `[urlsearchparams:${memberChain}]`;
                         }
                         if (spArg.type === "ObjectExpression") {

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -6,6 +6,52 @@ import { Chunks } from "../../utility/interfaces.js";
 const traverse = _traverse.default;
 
 /**
+ * Builds a dotted identifier path from a chain of MemberExpression nodes
+ * rooted at an Identifier. Returns null when the chain contains computed
+ * properties, non-Identifier nodes, or anything we can't render as `a.b.c`.
+ */
+export const memberChainToString = (node: any): string | null => {
+    if (!node) return null;
+    if (node.type === "Identifier") return node.name;
+    if (node.type === "MemberExpression" && !node.computed && node.property?.type === "Identifier") {
+        const obj = memberChainToString(node.object);
+        if (!obj) return null;
+        return `${obj}.${node.property.name}`;
+    }
+    return null;
+};
+
+/**
+ * Produces a short human-readable label for a spread argument we couldn't fully
+ * resolve. Identifiers keep their name; member chains collapse into `a.b.c`;
+ * call expressions show their callee name with `()`. Anything else falls back
+ * to the AST node type so the placeholder still signals *something* was there.
+ */
+const describeSpreadArg = (arg: any): string => {
+    if (!arg) return "unknown";
+    if (arg.type === "Identifier") return arg.name;
+    if (arg.type === "MemberExpression") {
+        const parts: string[] = [];
+        let walker: any = arg;
+        while (walker && walker.type === "MemberExpression" && !walker.computed && walker.property?.type === "Identifier") {
+            parts.unshift(walker.property.name);
+            walker = walker.object;
+        }
+        if (walker && walker.type === "Identifier") parts.unshift(walker.name);
+        if (parts.length > 0) return parts.join(".");
+        return "member";
+    }
+    if (arg.type === "CallExpression") {
+        if (arg.callee?.type === "Identifier") return `${arg.callee.name}()`;
+        if (arg.callee?.type === "MemberExpression" && arg.callee.property?.type === "Identifier") {
+            return `${arg.callee.property.name}()`;
+        }
+        return "call()";
+    }
+    return arg.type;
+};
+
+/**
  * Resolves a variable in a chunk by finding its declaration/assignment.
  *
  * @param varName - The name of the variable to resolve
@@ -1126,8 +1172,31 @@ export const resolveNodeValue = (
                                             ) ?? `[${prop.value.type}]`;
                                     }
                                 } else if (prop.type === "SpreadElement") {
-                                    // Skip unresolvable spread elements — they're code artifacts,
-                                    // not actual body fields.
+                                    // Resolve the spread argument; if it's a known object, merge its
+                                    // keys. Otherwise surface the spread as a sentinel key so the
+                                    // downstream body shape advertises that there are unresolvable
+                                    // additional fields, rather than silently shrinking the body.
+                                    const spreadResolved = resolveNodeValue(
+                                        prop.argument,
+                                        scope,
+                                        "",
+                                        callType,
+                                        chunkCode,
+                                        chunks,
+                                        thirdArgName
+                                    );
+                                    if (
+                                        spreadResolved &&
+                                        typeof spreadResolved === "object" &&
+                                        !Array.isArray(spreadResolved)
+                                    ) {
+                                        for (const [sk, sv] of Object.entries(spreadResolved)) {
+                                            if (!(sk in obj)) obj[sk] = sv;
+                                        }
+                                    } else {
+                                        const argName = describeSpreadArg(prop.argument);
+                                        obj[`...${argName}`] = "<spread>";
+                                    }
                                 }
                             }
                             return obj;
@@ -1260,6 +1329,11 @@ export const resolveNodeValue = (
                             const spreadObj = resolved;
                             if (typeof spreadObj === "object" && spreadObj !== null) {
                                 Object.assign(obj, spreadObj);
+                            } else {
+                                // Couldn't resolve to a concrete object — keep the spread visible
+                                // in the output so callers know fields are missing.
+                                const argName = describeSpreadArg(prop.argument);
+                                obj[`...${argName}`] = "<spread>";
                             }
                         }
                     }
@@ -1548,6 +1622,18 @@ export const resolveNodeValue = (
                         currentNode.arguments.length > 0
                     ) {
                         const spArg = currentNode.arguments[0];
+                        // If the argument is a plain MemberExpression like `a.b`,
+                        // emit a typed marker so the downstream caller-substitution
+                        // pass knows this part of the URL is a query expansion of
+                        // an object reference, not just an inert placeholder.
+                        const memberChain = memberChainToString(spArg);
+                        if (
+                            memberChain &&
+                            spArg.type === "MemberExpression" &&
+                            !(spArg as any).computed
+                        ) {
+                            return `[urlsearchparams:${memberChain}]`;
+                        }
                         if (spArg.type === "ObjectExpression") {
                             const params: string[] = [];
                             for (const prop of spArg.properties) {

--- a/src/map/vue_js/getViteConnections.ts
+++ b/src/map/vue_js/getViteConnections.ts
@@ -71,7 +71,7 @@ const getViteConnections = async (directory: string, output: string, formats: st
         encoding: "utf8",
     }) as string[];
 
-    files = files.filter((f) => f.endsWith(".js") && !f.includes("___subsequent_requests"));
+    files = files.filter((f) => (f.endsWith(".js") || f.endsWith(".vue")) && !f.includes("___subsequent_requests"));
     files = files.filter((f) => !fs.lstatSync(path.join(directory, f)).isDirectory());
 
     const fileMeta = new Map<string, FileMeta>();
@@ -96,7 +96,6 @@ const getViteConnections = async (directory: string, output: string, formats: st
     console.log(chalk.cyan(`[i] Scanning ${files.length} JS files for root functions`));
     for (const file of files) {
         const meta = fileMeta.get(file);
-        if (!meta) continue;
 
         const filePath = path.join(directory, file);
         let code: string;
@@ -123,6 +122,7 @@ const getViteConnections = async (directory: string, output: string, formats: st
         for (const node of ast.program.body) {
             if (node.type !== "FunctionDeclaration") continue;
             if (!node.id || !FUNC_NAME_RE.test(node.id.name)) continue;
+            if (!meta) continue;
             const funcName = node.id.name;
             const key = computeChunkKey(funcName, meta);
             if (chunks[key]) continue;
@@ -140,6 +140,31 @@ const getViteConnections = async (directory: string, output: string, formats: st
                 file: file,
             };
             fileFuncs.set(funcName, key);
+        }
+
+        // Fallback for Vite dev-mode / non-bundled files: production-style 2-char
+        // function chunking doesn't apply, so emit the whole file as a single chunk
+        // so the AST analysis engine still has something to scan.
+        if (fileFuncs.size === 0) {
+            const baseId = path.basename(file).replace(/[^a-zA-Z0-9]+/g, "_");
+            let key = baseId;
+            let suffix = 0;
+            while (chunks[key]) {
+                suffix++;
+                key = `${baseId}_${suffix}`;
+            }
+            chunks[key] = {
+                id: key,
+                description: "none",
+                loadedOn: [],
+                containsFetch: /\bfetch\s*\(/.test(code),
+                isAxiosLibrary: false,
+                exports: [],
+                callStack: [],
+                code: code,
+                imports: [],
+                file: file,
+            };
         }
     }
 

--- a/src/map/vue_js/interactive.ts
+++ b/src/map/vue_js/interactive.ts
@@ -1,6 +1,7 @@
 import { createUI } from "../next_js/interactive_helpers/ui.js";
 import { handleCommand } from "./interactive_helpers/commandHandler.js";
 import { setupKeybindings } from "../next_js/interactive_helpers/keybindings.js";
+import { enableCursorInput } from "../next_js/interactive_helpers/inputPatch.js";
 import { Chunks } from "../../utility/interfaces.js";
 
 export interface State {
@@ -40,6 +41,7 @@ const interactive = async (chunks: Chunks, map_file: string) => {
     });
 
     setupKeybindings(ui.screen, ui.inputBox, ui.outputBox, state as any);
+    enableCursorInput(ui.inputBox);
 
     ui.inputBox.focus();
     ui.screen.render();

--- a/src/map/vue_js/interactive.ts
+++ b/src/map/vue_js/interactive.ts
@@ -45,4 +45,33 @@ const interactive = async (chunks: Chunks, map_file: string) => {
     ui.screen.render();
 };
 
+/**
+ * Vue.JS counterpart of the Next.js `runCommands` helper — drives the
+ * interactive command handler non-interactively using a stdout-backed UI shim.
+ */
+const runCommands = async (chunks: Chunks, map_file: string, commands: string[]): Promise<void> => {
+    const state: State = {
+        chunks,
+        lastCommandStatus: true,
+        functionNavHistory: [],
+        functionNavHistoryIndex: -1,
+        funcWriteFile: undefined,
+        commandHistory: [],
+        commandHistoryIndex: -1,
+        writeimports: false,
+        mapFile: map_file,
+    };
+
+    const headlessUi: any = {
+        screen: { render: () => {} },
+        outputBox: { log: (s: string) => console.log(s), setText: () => {} },
+        inputBox: { clearValue: () => {}, focus: () => {} },
+    };
+
+    for (const command of commands) {
+        await handleCommand(command, state, headlessUi);
+    }
+};
+
+export { runCommands };
 export default interactive;

--- a/src/map/vue_js/interactive_helpers/commandHandler.ts
+++ b/src/map/vue_js/interactive_helpers/commandHandler.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import path from "path";
 import nextCommandHelpers from "../../next_js/interactive_helpers/commandHelpers.js";
 import { printFunction } from "../../next_js/interactive_helpers/printer.js";
+import { runEsqueryCommand } from "../../next_js/interactive_helpers/esqueryGen.js";
 import vueCommandHelpers from "./commandHelpers.js";
 import { helpMenu } from "./helpMenu.js";
 import { State } from "../interactive.js";
@@ -232,6 +233,18 @@ async function handleCommand(text: string, state: State, ui: Screen) {
                 outputBox.log(chalk.red(option) + " is not a valid option");
                 state.lastCommandStatus = false;
             }
+        }
+    } else if (text.startsWith("esquery")) {
+        const usage = helpMenu.esquery;
+        const parts = text.split(" ");
+        if (parts.length < 3) {
+            outputBox.log(chalk.magenta(usage));
+            state.lastCommandStatus = false;
+        } else {
+            const chunkId = parts[1];
+            const search = parts.slice(2).join(" ");
+            outputBox.log(runEsqueryCommand(state.chunks, chunkId, search));
+            state.lastCommandStatus = true;
         }
     } else if (text.startsWith("trace")) {
         const usage = helpMenu.trace;

--- a/src/map/vue_js/interactive_helpers/commandHandler.ts
+++ b/src/map/vue_js/interactive_helpers/commandHandler.ts
@@ -243,8 +243,14 @@ async function handleCommand(text: string, state: State, ui: Screen) {
         } else {
             const chunkId = parts[1];
             const search = parts.slice(2).join(" ");
-            outputBox.log(runEsqueryCommand(state.chunks, chunkId, search));
-            state.lastCommandStatus = true;
+            try {
+                const result = runEsqueryCommand(state.chunks, chunkId, search);
+                outputBox.log(result);
+                state.lastCommandStatus = true;
+            } catch (err) {
+                outputBox.log(chalk.red(err instanceof Error ? err.message : String(err)));
+                state.lastCommandStatus = false;
+            }
         }
     } else if (text.startsWith("trace")) {
         const usage = helpMenu.trace;

--- a/src/map/vue_js/interactive_helpers/helpMenu.ts
+++ b/src/map/vue_js/interactive_helpers/helpMenu.ts
@@ -6,6 +6,8 @@ const helpMenu = {
     go: "Usage: go <option>\n  to <functionID>: Go to a specific function\n  back:          Go back to the previous function\n  ahead:         Go to the next function",
     set: "Usage: set <option> <value>\n  funcwritefile <filename>: Set file to write function code to\n  writeimports [true/false]: When using `go *` command, also write all the imports to the file\n  funcdesc <functionId> <description>: Set the description of the provided function ID with provided value",
     trace: "Usage: trace <functionID>\n  Traces imports/exports for a function",
+    esquery:
+        "Usage: esquery <chunkId|*> <code-snippet>\n  Find AST nodes whose minified source contains the (also minified) snippet, and print a loose + strict esquery selector for each. Use `*` (or `all`) as the chunk to scan every chunk. Example: esquery * fetch(`/api/docs/${file}`)",
 };
 
 export { helpMenu };

--- a/src/map/vue_js/vue_resolveFetch.ts
+++ b/src/map/vue_js/vue_resolveFetch.ts
@@ -3,10 +3,421 @@ import parser from "@babel/parser";
 import _traverse from "@babel/traverse";
 import fs from "fs";
 import path from "path";
-import { resolveNodeValue, substituteVariablesInString } from "../next_js/utils.js";
+import { resolveNodeValue, substituteVariablesInString, memberChainToString } from "../next_js/utils.js";
 import * as globals from "../../utility/globals.js";
 
 const traverse = _traverse.default;
+
+/**
+ * Checks whether invoking the given function body would directly execute a
+ * `fetch(...)` call (as a bare Identifier callee). Used to recognise functions
+ * that wrap the native fetch API so destructured aliases of those wrappers can
+ * be resolved as fetch calls.
+ *
+ * The walk stops at nested function boundaries so a factory function that
+ * RETURNS a fetch-wrapping arrow isn't itself classified as a wrapper — only
+ * the arrow it returns is.
+ */
+const NESTED_FN_TYPES = new Set([
+    "ArrowFunctionExpression",
+    "FunctionExpression",
+    "FunctionDeclaration",
+]);
+
+/**
+ * A function is treated as a "transparent" fetch wrapper only if its first
+ * argument is forwarded as-is to fetch as the URL. Wrappers that construct the
+ * URL from a property of their input object have a different calling convention
+ * than `fetch(url, options)` — treating callsites of those as fetch calls
+ * produces garbage URLs. So we require that fetch's first arg is the function's
+ * first param (an Identifier match).
+ */
+const bodyCallsFetch = (functionNode: any): boolean => {
+    if (!functionNode || typeof functionNode !== "object") return false;
+    const params = Array.isArray(functionNode.params) ? functionNode.params : [];
+    const firstParamName =
+        params[0] && params[0].type === "Identifier"
+            ? params[0].name
+            : params[0] && params[0].type === "AssignmentPattern" && params[0].left?.type === "Identifier"
+              ? params[0].left.name
+              : null;
+    if (!firstParamName) return false;
+
+    let found = false;
+    const visit = (n: any, depth: number) => {
+        if (found || !n || typeof n !== "object") return;
+        if (Array.isArray(n)) {
+            for (const child of n) visit(child, depth);
+            return;
+        }
+        if (typeof n.type !== "string") return;
+        // Don't descend into nested functions — they have their own invocation context.
+        if (depth > 0 && NESTED_FN_TYPES.has(n.type)) return;
+        if (
+            n.type === "CallExpression" &&
+            n.callee &&
+            n.callee.type === "Identifier" &&
+            n.callee.name === "fetch" &&
+            Array.isArray(n.arguments) &&
+            n.arguments.length > 0 &&
+            n.arguments[0].type === "Identifier" &&
+            n.arguments[0].name === firstParamName
+        ) {
+            found = true;
+            return;
+        }
+        for (const key of Object.keys(n)) {
+            if (key === "loc" || key === "start" || key === "end" || key === "leadingComments" || key === "trailingComments") {
+                continue;
+            }
+            visit(n[key], depth + 1);
+        }
+    };
+    visit(functionNode, 0);
+    return found;
+};
+
+const isFunctionLike = (node: any): boolean =>
+    !!node && (node.type === "ArrowFunctionExpression" || node.type === "FunctionExpression" || node.type === "FunctionDeclaration");
+
+interface EnclosingFn {
+    bindingName: string | null;
+    firstParamName: string | null;
+    node: any;
+    file: string;
+}
+
+interface CallerInfo {
+    file: string;
+    fileContent: string;
+    callNode: any;
+    scope: any;
+    args: any[];
+    // Function that contains this call — used for transitive resolution when
+    // the call's argument is itself the enclosing function's parameter.
+    enclosingFn: EnclosingFn | null;
+}
+
+interface FetchEntry {
+    file: string;
+    filePath: string;
+    fileContent: string;
+    fileLine: number;
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+    enclosingFn: EnclosingFn | null;
+}
+
+/**
+ * Pulls out the function binding name from the surrounding declarator /
+ * assignment so we can later match callsites by identifier. Handles four
+ * common shapes seen in Vite-bundled code:
+ *   const fn = (arg) => { ... }
+ *   fn = (arg) => { ... }
+ *   function fn(arg) { ... }
+ *   { fn: (arg) => { ... } }  // object-literal property value
+ */
+const inferEnclosingFn = (callPath: any, file: string): EnclosingFn | null => {
+    const fnPath = callPath.getFunctionParent();
+    if (!fnPath) return null;
+    const fnNode = fnPath.node;
+    const firstParamName =
+        fnNode.params && fnNode.params[0]?.type === "Identifier"
+            ? fnNode.params[0].name
+            : fnNode.params && fnNode.params[0]?.type === "AssignmentPattern" && fnNode.params[0].left?.type === "Identifier"
+              ? fnNode.params[0].left.name
+              : null;
+
+    let bindingName: string | null = null;
+    if (fnNode.type === "FunctionDeclaration" && fnNode.id?.type === "Identifier") {
+        bindingName = fnNode.id.name;
+    } else {
+        const parentNode = fnPath.parentPath?.node;
+        if (parentNode) {
+            if (parentNode.type === "VariableDeclarator" && parentNode.id?.type === "Identifier") {
+                bindingName = parentNode.id.name;
+            } else if (parentNode.type === "AssignmentExpression" && parentNode.left?.type === "Identifier") {
+                bindingName = parentNode.left.name;
+            } else if (
+                parentNode.type === "ObjectProperty" &&
+                !parentNode.computed &&
+                parentNode.key?.type === "Identifier"
+            ) {
+                bindingName = parentNode.key.name;
+            }
+        }
+    }
+
+    return { bindingName, firstParamName, node: fnNode, file };
+};
+
+/**
+ * Walks an ObjectExpression and returns the property value for the given
+ * dotted property path (e.g. ["data"] -> the value node of `data: ...`).
+ * Returns null if any segment of the path isn't a literal property.
+ */
+const lookupObjectExpressionProp = (objExpr: any, propPath: string[]): any => {
+    if (!objExpr || objExpr.type !== "ObjectExpression") return null;
+    let current: any = objExpr;
+    for (const segment of propPath) {
+        if (!current || current.type !== "ObjectExpression") return null;
+        let next: any = null;
+        for (const prop of current.properties) {
+            if (prop.type !== "ObjectProperty") continue;
+            const key =
+                prop.key.type === "Identifier"
+                    ? prop.key.name
+                    : prop.key.type === "StringLiteral"
+                      ? prop.key.value
+                      : null;
+            if (key === segment) {
+                next = prop.value;
+                break;
+            }
+        }
+        if (!next) return null;
+        current = next;
+    }
+    return current;
+};
+
+/**
+ * Resolves the value of `paramName.propPath` by walking back through the
+ * enclosing function's callers. If a caller's argument is itself an Identifier
+ * pointing to a constant initializer, we follow that binding; if it's the
+ * caller's own first parameter, we recurse to that function's callers.
+ *
+ * Returns the resolved AST node + the scope it lives in (so further sub-property
+ * resolution can use the correct binding lookup), or null when the chain breaks.
+ */
+const resolveParamProperty = (
+    paramName: string,
+    propPath: string[],
+    enclosingFn: EnclosingFn | null,
+    getCallers: (bindingName: string) => CallerInfo[],
+    depth: number = 0,
+): { node: any; scope: any; fileContent: string } | null => {
+    if (!enclosingFn || !enclosingFn.bindingName || depth > 6) return null;
+    // Only the function's first parameter is supported for now — every observed
+    // case has fetch wrappers shaped as `(e) => fetch(... e.X ...)`.
+    if (enclosingFn.firstParamName !== paramName) return null;
+
+    const callers = getCallers(enclosingFn.bindingName);
+    if (!callers || callers.length === 0) return null;
+
+    for (const caller of callers) {
+        const arg = caller.args[0];
+        if (!arg) continue;
+
+        // Case 1: caller passes an object literal directly — fn({ a: ..., b: ... })
+        if (arg.type === "ObjectExpression") {
+            const node = lookupObjectExpressionProp(arg, propPath);
+            if (node) return { node, scope: caller.scope, fileContent: caller.fileContent };
+        }
+
+        // Case 2: caller passes an Identifier pointing to a const-initialized
+        // object literal — `const x = { a: ... }; fn(x)`.
+        if (arg.type === "Identifier") {
+            const binding = caller.scope.getBinding(arg.name);
+            const initNode = binding?.path?.node?.init;
+            if (initNode && initNode.type === "ObjectExpression") {
+                const node = lookupObjectExpressionProp(initNode, propPath);
+                if (node) return { node, scope: caller.scope, fileContent: caller.fileContent };
+            }
+            // Case 3: caller passes its own first param straight through —
+            // `outer = (p) => fn(p)`. Recurse up to that function's callers.
+            if (caller.enclosingFn?.firstParamName === arg.name) {
+                const result = resolveParamProperty(
+                    arg.name,
+                    propPath,
+                    caller.enclosingFn,
+                    getCallers,
+                    depth + 1,
+                );
+                if (result) return result;
+            }
+        }
+    }
+    return null;
+};
+
+/**
+ * Renders an ObjectExpression as a `k1={k1}&k2={k2}` query-string fragment.
+ * Literal property values are URL-encoded directly; non-literal values fall
+ * back to the placeholder form so the schema reader can see what's missing.
+ */
+const renderObjectAsQuery = (objExpr: any, scope: any, fileContent: string): string | null => {
+    if (!objExpr || objExpr.type !== "ObjectExpression") return null;
+    const parts: string[] = [];
+    for (const prop of objExpr.properties) {
+        if (prop.type !== "ObjectProperty") continue;
+        const key =
+            prop.key.type === "Identifier"
+                ? prop.key.name
+                : prop.key.type === "StringLiteral"
+                  ? prop.key.value
+                  : null;
+        if (!key) continue;
+        let valStr: string;
+        try {
+            const resolved = resolveNodeValue(prop.value, scope, "", "fetch", fileContent);
+            if (resolved !== null && resolved !== undefined && !String(resolved).startsWith("[")) {
+                valStr = encodeURIComponent(String(resolved));
+            } else {
+                valStr = `{${key}}`;
+            }
+        } catch {
+            valStr = `{${key}}`;
+        }
+        parts.push(`${key}=${valStr}`);
+    }
+    return parts.length > 0 ? parts.join("&") : null;
+};
+
+/**
+ * Returns a plain object derived from an ObjectExpression's properties.
+ * Spread elements are merged in when they themselves resolve to a literal
+ * object; otherwise the spread is preserved as a sentinel key so the schema
+ * reader knows extra fields exist at runtime.
+ */
+const renderObjectExpression = (objExpr: any, scope: any, fileContent: string): Record<string, string> | null => {
+    if (!objExpr || objExpr.type !== "ObjectExpression") return null;
+    const out: Record<string, string> = {};
+    for (const prop of objExpr.properties) {
+        if (prop.type === "ObjectProperty") {
+            const key =
+                prop.key.type === "Identifier"
+                    ? prop.key.name
+                    : prop.key.type === "StringLiteral"
+                      ? prop.key.value
+                      : null;
+            if (!key) continue;
+            try {
+                const resolved = resolveNodeValue(prop.value, scope, "", "fetch", fileContent);
+                out[key] = resolved === undefined || resolved === null ? "" : String(resolved);
+            } catch {
+                out[key] = "";
+            }
+        } else if (prop.type === "SpreadElement") {
+            try {
+                const resolved = resolveNodeValue(prop.argument, scope, "", "fetch", fileContent);
+                if (resolved && typeof resolved === "object") {
+                    for (const [k, v] of Object.entries(resolved)) {
+                        if (!(k in out)) out[k] = v === undefined || v === null ? "" : String(v);
+                    }
+                } else {
+                    const chain = memberChainToString(prop.argument);
+                    out[`...${chain ?? "spread"}`] = "<spread>";
+                }
+            } catch {
+                const chain = memberChainToString(prop.argument);
+                out[`...${chain ?? "spread"}`] = "<spread>";
+            }
+        }
+    }
+    return out;
+};
+
+/**
+ * Tries to convert a value node into a printable string, transparently
+ * unwrapping template literals built from caller-side bindings. Returns null
+ * when the value is itself a Vue-style ref / member expression that we can't
+ * pin down statically.
+ */
+const renderValueNode = (node: any, scope: any, fileContent: string): string | null => {
+    if (!node) return null;
+    try {
+        const resolved = resolveNodeValue(node, scope, "", "fetch", fileContent);
+        if (resolved === null || resolved === undefined) return null;
+        if (typeof resolved === "object") {
+            // Avoid emitting `[object Object]` — leave it to the upstream
+            // placeholder so the consumer knows it's structured.
+            return null;
+        }
+        const s = String(resolved);
+        if (s.startsWith("[unresolved")) return null;
+        return s;
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * Substitutes [member:P.X], [param:P], and [urlsearchparams:P.X] markers in a
+ * string by walking back to the enclosing function's caller(s). The string is
+ * returned with as many markers resolved as we could trace.
+ */
+const substituteCallerPlaceholders = (
+    input: string,
+    enclosingFn: EnclosingFn | null,
+    getCallers: (bindingName: string) => CallerInfo[],
+): string => {
+    if (!input || !enclosingFn) return input;
+
+    let output = input;
+
+    output = output.replace(/\[urlsearchparams:([A-Za-z_$][\w$.]*)\]/g, (match, chain: string) => {
+        const parts = chain.split(".");
+        if (parts.length < 1) return match;
+        const paramName = parts[0];
+        const propPath = parts.slice(1);
+        const resolved = resolveParamProperty(paramName, propPath, enclosingFn, getCallers);
+        if (!resolved) return match;
+        const rendered = renderObjectAsQuery(resolved.node, resolved.scope, resolved.fileContent);
+        return rendered ?? match;
+    });
+
+    output = output.replace(/\[member:([A-Za-z_$][\w$.]*)\]/g, (match, chain: string) => {
+        const parts = chain.split(".");
+        if (parts.length < 1) return match;
+        const paramName = parts[0];
+        const propPath = parts.slice(1);
+        const resolved = resolveParamProperty(paramName, propPath, enclosingFn, getCallers);
+        if (!resolved) return match;
+        const rendered = renderValueNode(resolved.node, resolved.scope, resolved.fileContent);
+        return rendered ?? match;
+    });
+
+    return output;
+};
+
+/**
+ * Substitutes placeholders in a header bag. `...P.X: <spread>` entries are
+ * expanded when the corresponding caller-side value is a literal object;
+ * `[member:P.X]` markers inside header values are substituted in-place.
+ */
+const substituteCallerHeaders = (
+    headers: Record<string, string>,
+    enclosingFn: EnclosingFn | null,
+    getCallers: (bindingName: string) => CallerInfo[],
+): Record<string, string> => {
+    if (!enclosingFn) return headers;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(headers)) {
+        if (k.startsWith("...") && v === "<spread>") {
+            const chain = k.slice(3);
+            const parts = chain.split(".");
+            const paramName = parts[0];
+            const propPath = parts.slice(1);
+            const resolved = resolveParamProperty(paramName, propPath, enclosingFn, getCallers);
+            if (resolved && resolved.node.type === "ObjectExpression") {
+                const obj = renderObjectExpression(resolved.node, resolved.scope, resolved.fileContent);
+                if (obj) {
+                    for (const [hk, hv] of Object.entries(obj)) {
+                        if (!(hk in out)) out[hk] = hv;
+                    }
+                    continue;
+                }
+            }
+            out[k] = v;
+        } else {
+            out[k] = substituteCallerPlaceholders(v, enclosingFn, getCallers);
+        }
+    }
+    return out;
+};
 
 /**
  * Scans all JS files in the given directory for fetch() calls,
@@ -31,7 +442,13 @@ const vue_resolveFetch = async (directory: string): Promise<void> => {
         .filter((f) => f.endsWith(".js") && !f.includes("___subsequent_requests"))
         .filter((f) => !fs.lstatSync(path.join(directory, f)).isDirectory());
 
-    let totalFetchCalls = 0;
+    // Pre-pass: scan every file for object-literal properties whose value is a
+    // function that ultimately calls fetch(). Their property names are the
+    // fetch-wrapper keys downstream code destructures and invokes in place of
+    // fetch — so we need to recognise those aliases.
+    const wrapperKeyNames = new Set<string>();
+    const fileAstCache = new Map<string, any>();
+    const fileContentCache = new Map<string, string>();
 
     for (const file of files) {
         const filePath = path.join(directory, file);
@@ -41,10 +458,7 @@ const vue_resolveFetch = async (directory: string): Promise<void> => {
         } catch {
             continue;
         }
-
-        // Fast path: skip files with no fetch keyword at all
         if (!fileContent.includes("fetch")) continue;
-
         let fileAst: any;
         try {
             fileAst = parser.parse(fileContent, {
@@ -55,16 +469,145 @@ const vue_resolveFetch = async (directory: string): Promise<void> => {
         } catch {
             continue;
         }
+        fileAstCache.set(filePath, fileAst);
+        fileContentCache.set(filePath, fileContent);
 
-        // Collect fetch aliases (const x = fetch)
+        traverse(fileAst, {
+            ObjectProperty(p) {
+                const key = p.node.key;
+                const value: any = p.node.value;
+                if (!isFunctionLike(value)) return;
+                if (!bodyCallsFetch(value)) return;
+                const keyName =
+                    key.type === "Identifier"
+                        ? key.name
+                        : key.type === "StringLiteral"
+                          ? key.value
+                          : null;
+                if (keyName) wrapperKeyNames.add(keyName);
+            },
+        });
+    }
+
+    // Lazy caller lookup. Rather than building a global index of every
+    // CallExpression in every bundle (which becomes O(huge) for minified Vite
+    // chunks), we only search when phase-2 actually asks for a specific binding
+    // name, and cache the per-name result. The fast `fileContent.includes`
+    // check skips files that can't possibly contain the call. When the call
+    // count blows past a sane budget we treat the name as too ambiguous to be
+    // useful for tracing and short-circuit to an empty list.
+    const MAX_CALLERS_PER_NAME = 64;
+    const callerCache = new Map<string, CallerInfo[]>();
+    const getCallers = (bindingName: string): CallerInfo[] => {
+        const cached = callerCache.get(bindingName);
+        if (cached) return cached;
+        const needle = `${bindingName}(`;
+        const out: CallerInfo[] = [];
+        let overflowed = false;
+        for (const [filePath, fileAst] of fileAstCache.entries()) {
+            if (overflowed) break;
+            const fileContent = fileContentCache.get(filePath) ?? "";
+            if (!fileContent.includes(needle)) continue;
+            traverse(fileAst, {
+                CallExpression(callPath) {
+                    if (overflowed) {
+                        callPath.stop();
+                        return;
+                    }
+                    const callee = callPath.node.callee;
+                    if (callee.type !== "Identifier" || callee.name !== bindingName) return;
+                    if (out.length >= MAX_CALLERS_PER_NAME) {
+                        overflowed = true;
+                        callPath.stop();
+                        return;
+                    }
+                    out.push({
+                        file: filePath,
+                        fileContent,
+                        callNode: callPath.node,
+                        scope: callPath.scope,
+                        args: callPath.node.arguments,
+                        enclosingFn: inferEnclosingFn(callPath, filePath),
+                    });
+                },
+            });
+        }
+        // A name with this many callsites is almost certainly a minifier
+        // single-letter local (e, t, n, …) — tracing it is noise, not signal.
+        const result = overflowed ? [] : out;
+        callerCache.set(bindingName, result);
+        return result;
+    };
+
+    let totalFetchCalls = 0;
+    // Counter for per-callsite uniqueness so two callsites at the same path+method
+    // are kept distinct in mapped.json and downstream specs.
+    let callsiteCounter = 0;
+    const entries: FetchEntry[] = [];
+
+    for (const file of files) {
+        const filePath = path.join(directory, file);
+        let fileContent = fileContentCache.get(filePath);
+        let fileAst = fileAstCache.get(filePath);
+        if (!fileContent || !fileAst) {
+            try {
+                fileContent = fs.readFileSync(filePath, "utf-8");
+            } catch {
+                continue;
+            }
+            if (!fileContent.includes("fetch")) continue;
+            try {
+                fileAst = parser.parse(fileContent, {
+                    sourceType: "unambiguous",
+                    plugins: ["jsx", "typescript"],
+                    errorRecovery: true,
+                });
+            } catch {
+                continue;
+            }
+        }
+
+        // Collect fetch aliases:
+        //   1. `const x = fetch` (direct identifier aliasing)
+        //   2. `const x = (i, l) => fetch(i, l)` (function-literal wrappers)
+        //   3. `const { wrapperKey: x } = factory({...})` (destructured wrapper keys)
         const fetchAliases = new Set<any>();
         traverse(fileAst, {
             VariableDeclarator(p) {
                 const { id, init } = p.node;
-                if (id.type !== "Identifier" || !init) return;
-                if (init.type === "Identifier" && init.name === "fetch") {
-                    const binding = p.scope.getBinding(id.name);
-                    if (binding) fetchAliases.add(binding);
+                if (!init) return;
+
+                if (id.type === "Identifier") {
+                    if (init.type === "Identifier" && init.name === "fetch") {
+                        const binding = p.scope.getBinding(id.name);
+                        if (binding) fetchAliases.add(binding);
+                        return;
+                    }
+                    if (isFunctionLike(init) && bodyCallsFetch(init)) {
+                        const binding = p.scope.getBinding(id.name);
+                        if (binding) fetchAliases.add(binding);
+                        return;
+                    }
+                }
+
+                if (id.type === "ObjectPattern") {
+                    for (const prop of id.properties) {
+                        if (prop.type !== "ObjectProperty") continue;
+                        const keyName =
+                            prop.key.type === "Identifier"
+                                ? prop.key.name
+                                : prop.key.type === "StringLiteral"
+                                  ? prop.key.value
+                                  : null;
+                        if (!keyName || !wrapperKeyNames.has(keyName)) continue;
+                        const valueName =
+                            prop.value.type === "Identifier"
+                                ? prop.value.name
+                                : null;
+                        if (!valueName) continue;
+                        const binding = p.scope.getBinding(valueName);
+                        if (binding) fetchAliases.add(binding);
+                    }
                 }
             },
         });
@@ -106,8 +649,6 @@ const vue_resolveFetch = async (directory: string): Promise<void> => {
                     }
                 }
 
-                console.log(chalk.green(`    URL: ${url}`));
-
                 let method = "GET";
                 let headers: Record<string, string> = {};
                 let body = "";
@@ -134,25 +675,85 @@ const vue_resolveFetch = async (directory: string): Promise<void> => {
                             body =
                                 typeof options.body === "object" ? JSON.stringify(options.body) : String(options.body);
                         }
-
-                        console.log(chalk.green(`    Method: ${method}`));
-                        if (Object.keys(headers).length > 0)
-                            console.log(chalk.green(`    Headers: ${JSON.stringify(headers)}`));
-                        if (body) console.log(chalk.green(`    Body: ${body}`));
                     }
                 }
 
-                globals.addOpenapiOutput({
-                    url: String(url),
+                const enclosingFn = inferEnclosingFn(callPath, filePath);
+
+                entries.push({
+                    file,
+                    filePath,
+                    fileContent,
+                    fileLine,
+                    url: typeof url === "string" ? url : "",
                     method,
-                    path: String(url),
                     headers,
                     body,
-                    chunkId: file,
-                    functionFile: filePath,
-                    functionFileLine: fileLine,
+                    enclosingFn,
                 });
             },
+        });
+    }
+
+    // Second pass: walk back to each fetch's enclosing function callers and
+    // substitute markers we couldn't resolve in the first pass. This is where
+    // `?[urlsearchparams:p.q]` turns into `?k1={k1}&k2={k2}`, and where
+    // `...p.q: <spread>` gets expanded if a literal object was passed.
+    const MARKER_RE = /\[(urlsearchparams|member|param):/;
+    const headersHaveMarkers = (h: Record<string, string>): boolean => {
+        for (const [k, v] of Object.entries(h)) {
+            if (k.startsWith("...") && v === "<spread>") return true;
+            if (MARKER_RE.test(v)) return true;
+        }
+        return false;
+    };
+
+    for (const entry of entries) {
+        if (
+            entry.enclosingFn &&
+            entry.enclosingFn.bindingName &&
+            entry.enclosingFn.firstParamName &&
+            (MARKER_RE.test(entry.url) || MARKER_RE.test(entry.body) || headersHaveMarkers(entry.headers))
+        ) {
+            entry.url = substituteCallerPlaceholders(entry.url, entry.enclosingFn, getCallers);
+            entry.headers = substituteCallerHeaders(entry.headers, entry.enclosingFn, getCallers);
+            entry.body = substituteCallerPlaceholders(entry.body, entry.enclosingFn, getCallers);
+        }
+
+        console.log(chalk.green(`    URL: ${entry.url}`));
+        if (entry.method !== "GET" || Object.keys(entry.headers).length > 0 || entry.body) {
+            console.log(chalk.green(`    Method: ${entry.method}`));
+        }
+        if (Object.keys(entry.headers).length > 0)
+            console.log(chalk.green(`    Headers: ${JSON.stringify(entry.headers)}`));
+        if (entry.body) console.log(chalk.green(`    Body: ${entry.body}`));
+
+        // Skip the openapi/postman registration for callsites where the URL
+        // never resolved to anything URL-shaped. Examples:
+        //   - inner wrapper bodies like `fetch(i, l)` where `i` is a param
+        //   - non-string AST nodes (objects, member expressions) that have
+        //     no chance of being a real path
+        const urlStr = entry.url;
+        const looksLikeUrl =
+            urlStr.length > 0 &&
+            !urlStr.startsWith("[") &&
+            urlStr !== "[object Object]" &&
+            (urlStr.startsWith("http://") ||
+                urlStr.startsWith("https://") ||
+                urlStr.startsWith("/") ||
+                /^[A-Za-z0-9_\-.]+\//.test(urlStr));
+        if (!looksLikeUrl) continue;
+
+        callsiteCounter++;
+        globals.addOpenapiOutput({
+            url: urlStr,
+            method: entry.method,
+            path: urlStr,
+            headers: entry.headers,
+            body: entry.body,
+            chunkId: `${entry.file}:${entry.fileLine}`,
+            functionFile: entry.filePath,
+            functionFileLine: entry.fileLine,
         });
     }
 

--- a/src/map/vue_js/vue_resolveFetch.ts
+++ b/src/map/vue_js/vue_resolveFetch.ts
@@ -18,11 +18,7 @@ const traverse = _traverse.default;
  * RETURNS a fetch-wrapping arrow isn't itself classified as a wrapper — only
  * the arrow it returns is.
  */
-const NESTED_FN_TYPES = new Set([
-    "ArrowFunctionExpression",
-    "FunctionExpression",
-    "FunctionDeclaration",
-]);
+const NESTED_FN_TYPES = new Set(["ArrowFunctionExpression", "FunctionExpression", "FunctionDeclaration"]);
 
 /**
  * A function is treated as a "transparent" fetch wrapper only if its first
@@ -67,7 +63,13 @@ const bodyCallsFetch = (functionNode: any): boolean => {
             return;
         }
         for (const key of Object.keys(n)) {
-            if (key === "loc" || key === "start" || key === "end" || key === "leadingComments" || key === "trailingComments") {
+            if (
+                key === "loc" ||
+                key === "start" ||
+                key === "end" ||
+                key === "leadingComments" ||
+                key === "trailingComments"
+            ) {
                 continue;
             }
             visit(n[key], depth + 1);
@@ -78,7 +80,10 @@ const bodyCallsFetch = (functionNode: any): boolean => {
 };
 
 const isFunctionLike = (node: any): boolean =>
-    !!node && (node.type === "ArrowFunctionExpression" || node.type === "FunctionExpression" || node.type === "FunctionDeclaration");
+    !!node &&
+    (node.type === "ArrowFunctionExpression" ||
+        node.type === "FunctionExpression" ||
+        node.type === "FunctionDeclaration");
 
 interface EnclosingFn {
     bindingName: string | null;
@@ -126,7 +131,9 @@ const inferEnclosingFn = (callPath: any, file: string): EnclosingFn | null => {
     const firstParamName =
         fnNode.params && fnNode.params[0]?.type === "Identifier"
             ? fnNode.params[0].name
-            : fnNode.params && fnNode.params[0]?.type === "AssignmentPattern" && fnNode.params[0].left?.type === "Identifier"
+            : fnNode.params &&
+                fnNode.params[0]?.type === "AssignmentPattern" &&
+                fnNode.params[0].left?.type === "Identifier"
               ? fnNode.params[0].left.name
               : null;
 
@@ -197,7 +204,7 @@ const resolveParamProperty = (
     propPath: string[],
     enclosingFn: EnclosingFn | null,
     getCallers: (bindingName: string) => CallerInfo[],
-    depth: number = 0,
+    depth: number = 0
 ): { node: any; scope: any; fileContent: string } | null => {
     if (!enclosingFn || !enclosingFn.bindingName || depth > 6) return null;
     // Only the function's first parameter is supported for now — every observed
@@ -229,13 +236,7 @@ const resolveParamProperty = (
             // Case 3: caller passes its own first param straight through —
             // `outer = (p) => fn(p)`. Recurse up to that function's callers.
             if (caller.enclosingFn?.firstParamName === arg.name) {
-                const result = resolveParamProperty(
-                    arg.name,
-                    propPath,
-                    caller.enclosingFn,
-                    getCallers,
-                    depth + 1,
-                );
+                const result = resolveParamProperty(arg.name, propPath, caller.enclosingFn, getCallers, depth + 1);
                 if (result) return result;
             }
         }
@@ -254,11 +255,7 @@ const renderObjectAsQuery = (objExpr: any, scope: any, fileContent: string): str
     for (const prop of objExpr.properties) {
         if (prop.type !== "ObjectProperty") continue;
         const key =
-            prop.key.type === "Identifier"
-                ? prop.key.name
-                : prop.key.type === "StringLiteral"
-                  ? prop.key.value
-                  : null;
+            prop.key.type === "Identifier" ? prop.key.name : prop.key.type === "StringLiteral" ? prop.key.value : null;
         if (!key) continue;
         let valStr: string;
         try {
@@ -352,7 +349,7 @@ const renderValueNode = (node: any, scope: any, fileContent: string): string | n
 const substituteCallerPlaceholders = (
     input: string,
     enclosingFn: EnclosingFn | null,
-    getCallers: (bindingName: string) => CallerInfo[],
+    getCallers: (bindingName: string) => CallerInfo[]
 ): string => {
     if (!input || !enclosingFn) return input;
 
@@ -391,7 +388,7 @@ const substituteCallerPlaceholders = (
 const substituteCallerHeaders = (
     headers: Record<string, string>,
     enclosingFn: EnclosingFn | null,
-    getCallers: (bindingName: string) => CallerInfo[],
+    getCallers: (bindingName: string) => CallerInfo[]
 ): Record<string, string> => {
     if (!enclosingFn) return headers;
     const out: Record<string, string> = {};
@@ -478,12 +475,7 @@ const vue_resolveFetch = async (directory: string): Promise<void> => {
                 const value: any = p.node.value;
                 if (!isFunctionLike(value)) return;
                 if (!bodyCallsFetch(value)) return;
-                const keyName =
-                    key.type === "Identifier"
-                        ? key.name
-                        : key.type === "StringLiteral"
-                          ? key.value
-                          : null;
+                const keyName = key.type === "Identifier" ? key.name : key.type === "StringLiteral" ? key.value : null;
                 if (keyName) wrapperKeyNames.add(keyName);
             },
         });
@@ -600,10 +592,7 @@ const vue_resolveFetch = async (directory: string): Promise<void> => {
                                   ? prop.key.value
                                   : null;
                         if (!keyName || !wrapperKeyNames.has(keyName)) continue;
-                        const valueName =
-                            prop.value.type === "Identifier"
-                                ? prop.value.name
-                                : null;
+                        const valueName = prop.value.type === "Identifier" ? prop.value.name : null;
                         if (!valueName) continue;
                         const binding = p.scope.getBinding(valueName);
                         if (binding) fetchAliases.add(binding);

--- a/src/report/utility/populateDb/populateAnalysisFindings.ts
+++ b/src/report/utility/populateDb/populateAnalysisFindings.ts
@@ -26,7 +26,7 @@ export const populateAnalysisFindings = async (db: Database.Database, findings: 
                 item.ruleType,
                 item.ruleDescription,
                 item.ruleAuthor,
-                item.ruleTech,
+                Array.isArray(item.ruleTech) ? item.ruleTech.join(",") : item.ruleTech,
                 item.severity,
                 item.message,
                 item.findingLocation

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -215,7 +215,7 @@ const processUrl = async (
 
     console.log(chalk.bgCyan("[7/8] Running analyze to extract endpoints..."));
     // @ts-ignore
-    await analyze("", mappedJsonFile, globalsUtil.getTech(), false, openapiFile, false, analyzeFile);
+    await analyze(cmd.rules || "", mappedJsonFile, globalsUtil.getTech(), false, openapiFile, false, analyzeFile);
     console.log(chalk.bgGreen("[+] Analyze complete."));
 
     console.log(chalk.bgCyan("[8/8] Running report module..."));

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -110,19 +110,38 @@ const processUrl = async (
     }
 
     if (globalsUtil.getTech() === "vue") {
-        // Vue.JS pipeline: lazyload (done) + map + OpenAPI/Postman output.
+        // Vue.JS pipeline: lazyload (done) + map + analyze + report.
         // Scan the whole download directory: Vue builds frequently spread chunks
         // across multiple asset hosts, and relative imports resolve within each tree.
         const mappedFileVue = isBatch ? `${workingDir}/mapped` : "mapped";
+        const mappedJsonFileVue = isBatch ? `${workingDir}/mapped.json` : "mapped.json";
         const openapiFile = isBatch ? `${workingDir}/mapped-openapi.json` : "mapped-openapi.json";
+        const analyzeFile = isBatch ? `${workingDir}/analyze.json` : "analyze.json";
+        const reportDbFile = isBatch ? `${workingDir}/js-recon.db` : "js-recon.db";
+        const reportFile = isBatch ? `${workingDir}/report` : "report";
+        const endpointsFile = isBatch ? `${workingDir}/endpoints` : "endpoints";
 
-        console.log(chalk.bgCyan("[2/3] Running map to find functions and API calls..."));
+        console.log(chalk.bgCyan("[2/4] Running map to find functions and API calls..."));
         globalsUtil.setOpenapi(true);
         if (isBatch) {
             globalsUtil.setOpenapiOutputFile(openapiFile);
         }
         await map(outputDir, mappedFileVue, ["json"], "vue", false, false);
         console.log(chalk.bgGreen("[+] Map complete."));
+
+        console.log(chalk.bgCyan("[3/4] Running analyze..."));
+        // @ts-ignore
+        await analyze(cmd.rules || "", mappedJsonFileVue, "vue", false, openapiFile, false, analyzeFile);
+        console.log(chalk.bgGreen("[+] Analyze complete."));
+
+        console.log(chalk.bgCyan("[4/4] Running report module..."));
+        // Endpoints extraction isn't implemented for Vue yet; pass an empty file if absent.
+        const endpointsJson = `${endpointsFile}.json`;
+        if (!fs.existsSync(endpointsJson)) {
+            fs.writeFileSync(endpointsJson, "[]");
+        }
+        await report(reportDbFile, mappedJsonFileVue, analyzeFile, endpointsJson, openapiFile, reportFile);
+        console.log(chalk.bgGreen("[+] Report complete."));
 
         console.log(chalk.bgGreenBright(`[+] Analysis complete for ${url}.`));
         return;

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -126,7 +126,7 @@ const processUrl = async (
         if (isBatch) {
             globalsUtil.setOpenapiOutputFile(openapiFile);
         }
-        await map(outputDir, mappedFileVue, ["json"], "vue", false, false);
+        await map(outputDir, mappedFileVue, ["json"], "vue", false, false, cmd.command || []);
         console.log(chalk.bgGreen("[+] Map complete."));
 
         console.log(chalk.bgCyan("[3/4] Running analyze..."));
@@ -221,7 +221,7 @@ const processUrl = async (
     if (isBatch) {
         globalsUtil.setOpenapiOutputFile(openapiFile);
     }
-    await map(cdnOutputDir, mappedFile, ["json"], globalsUtil.getTech(), false, false);
+    await map(cdnOutputDir, mappedFile, ["json"], globalsUtil.getTech(), false, false, cmd.command || []);
     console.log(chalk.bgGreen("[+] Map complete."));
 
     console.log(chalk.bgCyan("[6/8] Running endpoints to extract endpoints..."));

--- a/src/utility/globals.ts
+++ b/src/utility/globals.ts
@@ -58,6 +58,18 @@ export const getRespCacheFile = (): string => {
     return respCacheFile;
 };
 
+// Cache-only Configuration
+/** When true, makeRequest never hits the network — only the cache is consulted */
+export let cacheOnly = false;
+
+export const setCacheOnly = (value: boolean): void => {
+    cacheOnly = value;
+};
+
+export const getCacheOnly = (): boolean => {
+    return cacheOnly;
+};
+
 // Sandbox Configuration
 /** Whether to disable the browser sandbox */
 export let disableSandbox = false;

--- a/src/utility/makeReq.ts
+++ b/src/utility/makeReq.ts
@@ -5,6 +5,19 @@ import { get } from "../api_gateway/genReq.js";
 import fs from "fs";
 import { EventEmitter } from "events";
 
+const reportedFailures = new Set<string>();
+
+const reportFailure = (url: string, err: unknown): void => {
+    if (reportedFailures.has(url)) return;
+    reportedFailures.add(url);
+    if (globals.getCacheOnly()) {
+        console.log(chalk.dim(`[!] Cache miss (cache-only mode): ${url}`));
+        return;
+    }
+    console.log(chalk.red(`[!] Failed to fetch ${url} : ${err}`));
+    console.log(chalk.dim("[i] Often, using -k flag (ignore SSL errors) fixes the problem"));
+};
+
 // random user agents
 const UAs = [
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
@@ -196,8 +209,7 @@ const singleFetch = async (
                 return null;
             }
             if (counter > 10) {
-                console.log(chalk.red(`[!] Failed to fetch ${url} : ${err}`));
-                console.log(chalk.dim("[i] Often, using -k flag (ignore SSL errors) fixes the problem"));
+                reportFailure(url, err);
                 return null;
             }
             // sleep 0.5 s before retrying
@@ -283,11 +295,17 @@ const makeRequest = async (
         "Sec-Fetch-Dest": "empty",
     };
 
+    let parsedOrigin: string | null = null;
+    try {
+        parsedOrigin = new URL(url).origin;
+    } catch {
+        return null;
+    }
     if (!requestOptions.headers) {
         requestOptions.headers = {
             ...baseHeaders,
-            Referer: new URL(url).origin,
-            Origin: new URL(url).origin,
+            Referer: parsedOrigin,
+            Origin: parsedOrigin,
         };
     }
 
@@ -305,6 +323,11 @@ const makeRequest = async (
             }
             return cachedResponse;
         }
+    }
+
+    if (globals.getCacheOnly()) {
+        reportFailure(url, "cache miss in cache-only mode");
+        return null;
     }
 
     if (globals.useApiGateway) {

--- a/src/utility/openapiGenerator.ts
+++ b/src/utility/openapiGenerator.ts
@@ -144,6 +144,12 @@ export const generateOpenapiV3Spec = (items: OpenapiOutputItem[], chunks: Chunks
         paths: {},
     };
 
+    // Tracks how many times we've already seen the same (path, method) so a
+    // second callsite gets a disambiguating fragment on its path key rather than
+    // being silently dropped. OpenAPI paths are opaque strings so a `#N` suffix
+    // is preserved by tools that key on it.
+    const callsiteCounts = new Map<string, number>();
+
     for (const item of items) {
         let rawItemPath = typeof item.path === "string" ? item.path : "";
         try {
@@ -152,7 +158,7 @@ export const generateOpenapiV3Spec = (items: OpenapiOutputItem[], chunks: Chunks
             }
         } catch {}
         const pathKeyBeforeQuery = rawItemPath.split("?")[0];
-        const pathKey = replacePlaceholders(
+        const basePathKey = replacePlaceholders(
             pathKeyBeforeQuery.startsWith("/") ? pathKeyBeforeQuery : `/${pathKeyBeforeQuery}`
         );
         const VALID_METHODS = new Set(["get", "post", "put", "patch", "delete", "head", "options", "trace"]);
@@ -160,11 +166,18 @@ export const generateOpenapiV3Spec = (items: OpenapiOutputItem[], chunks: Chunks
         const methodIsValid = VALID_METHODS.has(rawMethod);
         const method = methodIsValid ? rawMethod : "get";
 
+        const dedupeKey = `${method} ${basePathKey}`;
+        const seenBefore = callsiteCounts.get(dedupeKey) ?? 0;
+        const pathKey = seenBefore === 0 ? basePathKey : `${basePathKey}#${seenBefore + 1}`;
+        callsiteCounts.set(dedupeKey, seenBefore + 1);
+
         if (!spec.paths[pathKey]) {
             spec.paths[pathKey] = {};
         }
 
-        // Avoid overwriting if the same path & method already processed
+        // Avoid overwriting if the same path & method already processed (only
+        // possible now when two identical items collide on the disambiguated
+        // path — guard kept for safety).
         if (spec.paths[pathKey][method]) {
             continue;
         }

--- a/src/utility/postmanGenerator.ts
+++ b/src/utility/postmanGenerator.ts
@@ -111,9 +111,11 @@ export const generatePostmanCollection = (items: OpenapiOutputItem[]): PMCollect
         return parent;
     };
 
-    // Deduplicate (path, method) — the OpenAPI generator already does this; we
-    // mirror the behaviour here so reimporting doesn't produce duplicates.
-    const seen = new Set<string>();
+    // Track repeat (path, method) occurrences so duplicate callsites get a
+    // disambiguating suffix on their request name. We intentionally do NOT
+    // skip duplicates here — each distinct callsite is preserved so a reviewer
+    // can compare the headers/body shapes for the same endpoint.
+    const callsiteCounts = new Map<string, number>();
 
     for (const item of items) {
         let rawPath = typeof item.path === "string" ? item.path : "";
@@ -130,8 +132,8 @@ export const generatePostmanCollection = (items: OpenapiOutputItem[]): PMCollect
         const normalized = replacePlaceholders(rawPath.startsWith("/") ? rawPath : `/${rawPath}`);
         const method = typeof item.method === "string" ? item.method.toUpperCase() : "GET";
         const dedupeKey = `${method} ${normalized}`;
-        if (seen.has(dedupeKey)) continue;
-        seen.add(dedupeKey);
+        const occurrenceIndex = callsiteCounts.get(dedupeKey) ?? 0;
+        callsiteCounts.set(dedupeKey, occurrenceIndex + 1);
 
         const { segments, query } = splitPath(normalized);
 
@@ -202,9 +204,12 @@ export const generatePostmanCollection = (items: OpenapiOutputItem[]): PMCollect
 
         // Friendly request label — keep the leaf in the name to disambiguate
         // siblings under the same parent (e.g. invoices vs invoices/latest).
+        // When the same (path, method) is hit by multiple callsites, append a
+        // counter so the second/third occurrences are distinguishable in tree views.
         const leafName = leaf || segments[segments.length - 1] || "/";
+        const suffix = occurrenceIndex > 0 ? ` #${occurrenceIndex + 1}` : "";
         const itemEntry: PMItem = {
-            name: `${method} ${leafName}`,
+            name: `${method} ${leafName}${suffix}`,
             request,
         };
 


### PR DESCRIPTION
### Added

- Add version for rule templates
- Add Vue js support for analyze module
- `esquery` interactive command + headless `-c/--command` runner for `map` and `run`, with `&&` chaining (`map`)
- Line-editor behavior in interactive mode: cursor movement (left/right/home/end/ctrl-a/ctrl-e), word-wise motion/delete (ctrl-w, ctrl-left/right), kill-to-start/end (ctrl-u/ctrl-k), delete-at-cursor, mid-string insertion so paste lands at the cursor, and horizontal scroll for long inputs (`map -i`)

### Changed

- Removed `mouse: true` from the interactive output pane so terminal-native text selection/copy works in the output area (`map -i`)

### Fixed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Vue.js support added to analyze module.
  * Interactive `esquery` command now available for code searching and selector generation.
  * `-c/--command` flag enables preset command execution in map mode.
  * `--cache-only` flag supports offline analysis.
  * New `load` command for importing Caido files.
  * Rule version compatibility filtering implemented.

* **Changed**
  * Mouse input disabled in interactive output pane.

* **Documentation**
  * Added comprehensive project documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shriyanss/js-recon/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->