### PR TITLE
fix: prevent progress spinner from cluttering error output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@shriyanss/js-recon",
-    "version": "1.3.1-alpha.1",
+    "version": "1.3.1-alpha.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@shriyanss/js-recon",
-            "version": "1.3.1-alpha.1",
+            "version": "1.3.1-alpha.3",
             "license": "MIT",
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.82.0",
@@ -2056,6 +2056,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
             "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -2868,7 +2869,8 @@
             "version": "0.0.1608973",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
             "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -4109,6 +4111,7 @@
             "integrity": "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@puppeteer/browsers": "2.13.2",
                 "chromium-bidi": "14.0.0",
@@ -4147,6 +4150,7 @@
             "resolved": "https://registry.npmjs.org/puppeteer-extra/-/puppeteer-extra-3.3.6.tgz",
             "integrity": "sha512-rsLBE/6mMxAjlLd06LuGacrukP2bqbzKCLzV1vrhHFavqQE/taQ2UXv3H5P0Ls7nsrASa+6x3bDbXHpqMwq+7A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/debug": "^4.1.0",
                 "debug": "^4.1.1",
@@ -4816,6 +4820,7 @@
             "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4928,6 +4933,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
             "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -5029,6 +5035,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/src/mcp/cli.ts
+++ b/src/mcp/cli.ts
@@ -398,17 +398,25 @@ export const startCli = async (
                 session.history = [system, ...session.history.slice(-(config.history_limit - 1))];
             }
 
+            const spinner = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+            let spinIdx = 0;
+            let spinnerInterval: ReturnType<typeof setInterval> | undefined;
+            const clearThinkingSpinner = () => {
+                if (spinnerInterval) {
+                    clearInterval(spinnerInterval);
+                    spinnerInterval = undefined;
+                }
+                process.stdout.write("\r" + " ".repeat(120) + "\r");
+            };
+
             try {
                 session.currentAbortController = new AbortController();
-                const spinner = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-                let spinIdx = 0;
-                const spinnerInterval = setInterval(() => {
+                spinnerInterval = setInterval(() => {
                     process.stdout.write(`\r${chalk.cyan(spinner[spinIdx++ % spinner.length])} Thinking...`);
                 }, 80);
 
                 const response = await session.provider.chat(session.history);
-                clearInterval(spinnerInterval);
-                process.stdout.write("\r" + " ".repeat(20) + "\r");
+                clearThinkingSpinner();
                 session.currentAbortController = undefined;
 
                 usage.addUsage(response.promptTokens, response.completionTokens);
@@ -416,6 +424,7 @@ export const startCli = async (
 
                 console.log(chalk.white("\n" + response.content + "\n"));
             } catch (err: any) {
+                clearThinkingSpinner();
                 session.currentAbortController = undefined;
                 if (err.name !== "AbortError") {
                     console.log(chalk.red(`\n[!] ${err.message}\n`));


### PR DESCRIPTION
## What Changed

Cleared the MCP thinking spinner before printing both success and error output so terminal messages render on clean lines without colliding with the active spinner.

Also centralized spinner cleanup logic to ensure consistent behavior across success, failure, and abort flows.

## Root Cause

The spinner interval continued running while error messages were printed, causing the terminal to redraw the animated spinner on the same line as the error output.

## How It Was Tested

* Rebuilt the project using `npm run cleanup`
* Ran multiple failing MCP chat attempts using an invalid API key
* Verified that:

  * errors render on separate clean lines
  * spinner stops correctly
  * terminal prompt restores normally afterward


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal chat session handling and error management for enhanced stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shriyanss/js-recon/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->