### PR TITLE
v1.4.1-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.4.1-alpha.2 - 2026-06-20
+
+### Fixed
+
+- `lazyload`: `--include-methods`, `--exclude-methods`, and `--list-methods` flags were listed as Added in v1.4.1-alpha.1 but the CLI wiring was absent from that release; they are now fully implemented and functional
+- `lazyload`: `--list-methods` works without `-u`; the URL option is now validated manually so `--list-methods` can run standalone
+- `refactor`: `-l`/`--list` no longer errors with "Mapped JSON file does not exist" when listing technologies — the list early-return now runs before the file-existence check
+
 ## 1.4.1-alpha.1 - 2026-06-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shriyanss/js-recon",
-    "version": "1.4.1-alpha.1",
+    "version": "1.4.1-alpha.2",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,6 @@
 const githubURL = "https://github.com/shriyanss/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
-const version = "1.4.1-alpha.1";
+const version = "1.4.1-alpha.2";
 const toolDesc =
     "Static analysis tool that maps API endpoints and detects client-side security issues by analyzing webpack/turbopack bundles";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,16 +79,27 @@ program
     .option("--max-js-size <mb>", "Maximum JS file size in MB to parse (Vue only)", "2")
     .option("--lazyload-timeout <minutes>", "Hard timeout for the lazyload module in minutes (0 = no timeout)", "30")
     .option("--max-pages <pages>", "Maximum HTML pages to visit during Next.js crawl (0 = unlimited)", "200")
-    .option("--include-methods <methods>", "Comma-separated method names to run (whitelist). Use --list-methods to see valid names.")
-    .option("--exclude-methods <methods>", "Comma-separated method names to skip (blacklist). Use --list-methods to see valid names.")
-    .option("--list-methods [framework]", "Print available method names grouped by framework and exit. Optionally filter by framework (next_js, vue, nuxt_js, svelte, angular, react).")
+    .option(
+        "--include-methods <methods>",
+        "Comma-separated method names to run (whitelist). Use --list-methods to see valid names."
+    )
+    .option(
+        "--exclude-methods <methods>",
+        "Comma-separated method names to skip (blacklist). Use --list-methods to see valid names."
+    )
+    .option(
+        "--list-methods [framework]",
+        "Print available method names grouped by framework and exit. Optionally filter by framework (next_js, vue, nuxt_js, svelte, angular, react)."
+    )
     .action(async (cmd) => {
         // handle --list-methods before any network work
         if (cmd.listMethods !== undefined) {
             const filter = typeof cmd.listMethods === "string" ? cmd.listMethods : null;
             const frameworkKeys = Object.keys(FRAMEWORK_METHODS);
             if (filter && !frameworkKeys.includes(filter)) {
-                console.error(chalk.red(`[!] Unknown framework: "${filter}". Valid frameworks: ${frameworkKeys.join(", ")}`));
+                console.error(
+                    chalk.red(`[!] Unknown framework: "${filter}". Valid frameworks: ${frameworkKeys.join(", ")}`)
+                );
                 process.exit(1);
             }
             const keys = filter ? [filter] : frameworkKeys;
@@ -103,10 +114,16 @@ program
 
         // parse and validate method filter lists
         const includeMethods: string[] = cmd.includeMethods
-            ? cmd.includeMethods.split(",").map((m: string) => m.trim()).filter(Boolean)
+            ? cmd.includeMethods
+                  .split(",")
+                  .map((m: string) => m.trim())
+                  .filter(Boolean)
             : [];
         const excludeMethods: string[] = cmd.excludeMethods
-            ? cmd.excludeMethods.split(",").map((m: string) => m.trim()).filter(Boolean)
+            ? cmd.excludeMethods
+                  .split(",")
+                  .map((m: string) => m.trim())
+                  .filter(Boolean)
             : [];
 
         const allMethods = [...includeMethods, ...excludeMethods];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { program } from "commander";
 import lazyLoad from "./lazyLoad/index.js";
+import { FRAMEWORK_METHODS, VALID_METHODS } from "./lazyLoad/methodFilter.js";
 import endpoints from "./endpoints/index.js";
 import CONFIG from "./globalConfig.js";
 import strings from "./strings/index.js";
@@ -54,7 +55,7 @@ function validateAndSetTimeout(timeoutValue: string): void {
 program
     .command("lazyload")
     .description("Run lazy load module")
-    .requiredOption("-u, --url <url/file>", "Target URL or a file containing a list of URLs (one per line)")
+    .option("-u, --url <url/file>", "Target URL or a file containing a list of URLs (one per line)")
     .option("-o, --output <directory>", "Output directory", "output")
     .option("--strict-scope", "Download JS files from only the input URL domain", false)
     .option("-s, --scope <scope>", "Download JS files from specific domains (comma-separated)", "*")
@@ -78,7 +79,49 @@ program
     .option("--max-js-size <mb>", "Maximum JS file size in MB to parse (Vue only)", "2")
     .option("--lazyload-timeout <minutes>", "Hard timeout for the lazyload module in minutes (0 = no timeout)", "30")
     .option("--max-pages <pages>", "Maximum HTML pages to visit during Next.js crawl (0 = unlimited)", "200")
+    .option("--include-methods <methods>", "Comma-separated method names to run (whitelist). Use --list-methods to see valid names.")
+    .option("--exclude-methods <methods>", "Comma-separated method names to skip (blacklist). Use --list-methods to see valid names.")
+    .option("--list-methods [framework]", "Print available method names grouped by framework and exit. Optionally filter by framework (next_js, vue, nuxt_js, svelte, angular, react).")
     .action(async (cmd) => {
+        // handle --list-methods before any network work
+        if (cmd.listMethods !== undefined) {
+            const filter = typeof cmd.listMethods === "string" ? cmd.listMethods : null;
+            const frameworkKeys = Object.keys(FRAMEWORK_METHODS);
+            if (filter && !frameworkKeys.includes(filter)) {
+                console.error(chalk.red(`[!] Unknown framework: "${filter}". Valid frameworks: ${frameworkKeys.join(", ")}`));
+                process.exit(1);
+            }
+            const keys = filter ? [filter] : frameworkKeys;
+            for (const fw of keys) {
+                console.log(chalk.cyan(`\n[${fw}]`));
+                for (const method of FRAMEWORK_METHODS[fw]) {
+                    console.log(chalk.green(`  - ${method}`));
+                }
+            }
+            process.exit(0);
+        }
+
+        // parse and validate method filter lists
+        const includeMethods: string[] = cmd.includeMethods
+            ? cmd.includeMethods.split(",").map((m: string) => m.trim()).filter(Boolean)
+            : [];
+        const excludeMethods: string[] = cmd.excludeMethods
+            ? cmd.excludeMethods.split(",").map((m: string) => m.trim()).filter(Boolean)
+            : [];
+
+        const allMethods = [...includeMethods, ...excludeMethods];
+        const invalid = allMethods.filter((m) => !VALID_METHODS.includes(m));
+        if (invalid.length > 0) {
+            console.error(chalk.red(`[!] Invalid method name(s): ${invalid.join(", ")}`));
+            console.error(chalk.yellow(`[i] Valid methods: ${VALID_METHODS.join(", ")}`));
+            process.exit(22);
+        }
+
+        if (!cmd.url) {
+            console.error(chalk.red("[!] Missing required option: -u, --url <url/file>"));
+            process.exit(1);
+        }
+
         globalsUtil.setApiGatewayConfigFile(cmd.apiGatewayConfig);
         globalsUtil.setUseApiGateway(cmd.apiGateway);
         globalsUtil.setDisableCache(cmd.disableCache);
@@ -105,7 +148,9 @@ program
             Number(cmd.maxIterations),
             Number(cmd.maxJsSize),
             Number(cmd.lazyloadTimeout) * 60 * 1000,
-            Number(cmd.maxPages)
+            Number(cmd.maxPages),
+            includeMethods,
+            excludeMethods
         );
     });
 

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -50,6 +50,7 @@ import { extractSources } from "./sourcemap.js";
 // import global vars
 import * as lazyLoadGlobals from "./globals.js";
 import * as globals from "../utility/globals.js";
+import { shouldRunMethod } from "./methodFilter.js";
 
 const getMapFilesRecursively = (dir: string): string[] => {
     const entries = readdirSync(dir, { withFileTypes: true });
@@ -126,7 +127,9 @@ const lazyLoad = async (
     maxIterations: number,
     maxJsSizeMb: number = 2,
     hardTimeoutMs: number = 30 * 60 * 1000,
-    maxPageVisits: number = 200
+    maxPageVisits: number = 200,
+    includeMethods: string[] = [],
+    excludeMethods: string[] = []
 ) => {
     // Hoisted so the timeout handler can stop discovery and drain downloads.
     let activeCrawler: NextJsCrawler | null = null;
@@ -195,6 +198,8 @@ const lazyLoad = async (
                         maxIterations,
                         maxPageVisits,
                         onUrlsDiscovered: (urls) => activeQueue!.push(urls),
+                        includeMethods,
+                        excludeMethods,
                     });
                     activeCrawler = crawler;
 
@@ -241,10 +246,10 @@ const lazyLoad = async (
                     const onFilesDiscovered = (files: string[]) => queue.push(files);
 
                     // run the full discovery pipeline against the entry URL
-                    const { clientSidePaths } = await vue_discoverJsFiles(url, maxJsSizeMb, onFilesDiscovered);
+                    const { clientSidePaths } = await vue_discoverJsFiles(url, maxJsSizeMb, onFilesDiscovered, includeMethods, excludeMethods);
 
                     // recurse the same pipeline through every client-side path we found
-                    await vue_recursiveClientSidePathDownload(clientSidePaths, threads, maxJsSizeMb, onFilesDiscovered);
+                    await vue_recursiveClientSidePathDownload(clientSidePaths, threads, maxJsSizeMb, onFilesDiscovered, includeMethods, excludeMethods);
 
                     await queue.drain();
                     queue.printSummary();
@@ -259,18 +264,24 @@ const lazyLoad = async (
                     activeQueue = queue;
 
                     // find the files from the page source
-                    const jsFilesFromPageSource = await nuxt_getFromPageSource(url);
+                    const jsFilesFromPageSource = shouldRunMethod("nuxt_getFromPageSource", includeMethods, excludeMethods)
+                        ? await nuxt_getFromPageSource(url)
+                        : [];
                     queue.push(jsFilesFromPageSource);
 
-                    const jsFilesFromStringAnalysis = await nuxt_stringAnalysisJSFiles(url);
+                    const jsFilesFromStringAnalysis = shouldRunMethod("nuxt_stringAnalysisJSFiles", includeMethods, excludeMethods)
+                        ? await nuxt_stringAnalysisJSFiles(url)
+                        : [];
                     queue.push(jsFilesFromStringAnalysis);
 
                     const firstBatch = [...new Set([...jsFilesFromPageSource, ...jsFilesFromStringAnalysis])];
 
                     let jsFilesFromAST = [];
-                    console.log(chalk.cyan("[i] Analyzing functions in the files found"));
-                    for (const jsFile of firstBatch) {
-                        jsFilesFromAST.push(...(await nuxt_astParse(jsFile)));
+                    if (shouldRunMethod("nuxt_astParse", includeMethods, excludeMethods)) {
+                        console.log(chalk.cyan("[i] Analyzing functions in the files found"));
+                        for (const jsFile of firstBatch) {
+                            jsFilesFromAST.push(...(await nuxt_astParse(jsFile)));
+                        }
                     }
                     queue.push(jsFilesFromAST);
                     queue.push(lazyLoadGlobals.getJsUrls());
@@ -285,15 +296,22 @@ const lazyLoad = async (
                     activeQueue = queue;
 
                     // find the files from the page source
-                    const jsFilesFromPageSource = await svelte_getFromPageSource(url);
+                    const jsFilesFromPageSource = shouldRunMethod("svelte_getFromPageSource", includeMethods, excludeMethods)
+                        ? await svelte_getFromPageSource(url)
+                        : [];
                     queue.push(jsFilesFromPageSource);
 
                     // analyze the strings now
-                    const { jsFiles: jsFilesFromStringAnalysis, mapFiles: mapFilesFromStringAnalysis } =
-                        await svelte_stringAnalysisJSFiles(url);
-                    queue.push(jsFilesFromStringAnalysis);
-                    if (mapFilesFromStringAnalysis.length > 0) {
-                        queue.push(mapFilesFromStringAnalysis);
+                    let jsFilesFromStringAnalysis: string[] = [];
+                    let mapFilesFromStringAnalysis: string[] = [];
+                    if (shouldRunMethod("svelte_stringAnalysisJSFiles", includeMethods, excludeMethods)) {
+                        const result = await svelte_stringAnalysisJSFiles(url);
+                        jsFilesFromStringAnalysis = result.jsFiles;
+                        mapFilesFromStringAnalysis = result.mapFiles;
+                        queue.push(jsFilesFromStringAnalysis);
+                        if (mapFilesFromStringAnalysis.length > 0) {
+                            queue.push(mapFilesFromStringAnalysis);
+                        }
                     }
 
                     // recursively follow ESM static imports (import ... from "./chunk.js")
@@ -309,22 +327,27 @@ const lazyLoad = async (
 
                     // crawl same-origin HTML pages found via <a href> and <link href>,
                     // running the full JS-discovery pipeline on each
-                    const jsFilesFromPageCrawl = await svelte_recursivePageCrawl(url, maxJsSizeMb, (files) =>
-                        queue.push(files)
-                    );
+                    const jsFilesFromPageCrawl = shouldRunMethod("svelte_recursivePageCrawl", includeMethods, excludeMethods)
+                        ? await svelte_recursivePageCrawl(url, maxJsSizeMb, (files) => queue.push(files))
+                        : [];
 
                     // Svelte/Astro apps use client-side routing — the home page rarely has
                     // <a href> links in its server-rendered HTML. Scan downloaded JS for
                     // embedded page path strings (e.g. "/admin", "/debug") and visit each
                     // page to discover the Astro island component-url values for those routes.
                     // Iterates until no new paths or JS files are discovered.
-                    const jsFilesFromPathScan = await svelte_discoverPagesFromJs(url);
+                    const jsFilesFromPathScan = shouldRunMethod("svelte_discoverPagesFromJs", includeMethods, excludeMethods)
+                        ? await svelte_discoverPagesFromJs(url)
+                        : [];
                     if (jsFilesFromPathScan.length > 0) {
                         queue.push(jsFilesFromPathScan);
                     }
 
                     // run string analysis once more to catch JS files discovered during page crawl
-                    if (jsFilesFromPageCrawl.length > 0 || jsFilesFromPathScan.length > 0) {
+                    if (
+                        (jsFilesFromPageCrawl.length > 0 || jsFilesFromPathScan.length > 0) &&
+                        shouldRunMethod("svelte_stringAnalysisJSFiles", includeMethods, excludeMethods)
+                    ) {
                         const { jsFiles: jsFilesFromStringAnalysis2, mapFiles: mapFilesFromStringAnalysis2 } =
                             await svelte_stringAnalysisJSFiles(url);
                         queue.push(jsFilesFromStringAnalysis2);
@@ -345,21 +368,25 @@ const lazyLoad = async (
                     activeQueue = queue;
 
                     // find the files from the page source
-                    const jsFilesFromPageSource = await angular_getFromPageSource(url);
+                    const jsFilesFromPageSource = shouldRunMethod("angular_getFromPageSource", includeMethods, excludeMethods)
+                        ? await angular_getFromPageSource(url)
+                        : [];
                     queue.push(jsFilesFromPageSource);
 
                     // files using the main.js
-                    let mainJsUrl: string | undefined;
-                    for (const jsFile of jsFilesFromPageSource) {
-                        if (jsFile.match(/main[a-zA-Z0-9\-]*\.js/)) {
-                            mainJsUrl = jsFile;
-                            break;
+                    if (shouldRunMethod("angular_getFromMainJs", includeMethods, excludeMethods)) {
+                        let mainJsUrl: string | undefined;
+                        for (const jsFile of jsFilesFromPageSource) {
+                            if (jsFile.match(/main[a-zA-Z0-9\-]*\.js/)) {
+                                mainJsUrl = jsFile;
+                                break;
+                            }
                         }
-                    }
 
-                    if (mainJsUrl) {
-                        const jsFilesFromMainJs = await angular_getFromMainJs(mainJsUrl);
-                        queue.push(jsFilesFromMainJs);
+                        if (mainJsUrl) {
+                            const jsFilesFromMainJs = await angular_getFromMainJs(mainJsUrl);
+                            queue.push(jsFilesFromMainJs);
+                        }
                     }
 
                     await queue.drain();
@@ -372,28 +399,36 @@ const lazyLoad = async (
                     activeQueue = queue;
 
                     // Seed: <script src> tags + <link rel="modulepreload"> (Vite vendor chunks)
-                    const jsFilesFromPageSource = await react_getScriptTags(url, maxJsSizeMb, output);
+                    const jsFilesFromPageSource = shouldRunMethod("react_getScriptTags", includeMethods, excludeMethods)
+                        ? await react_getScriptTags(url, maxJsSizeMb, output)
+                        : [];
                     queue.push(jsFilesFromPageSource);
 
                     // webpack-style chunk path builders (CRA / custom webpack configs)
-                    const webpackChunkPaths = await react_webpackChunkPaths(url, maxJsSizeMb, jsFilesFromPageSource);
+                    const webpackChunkPaths = shouldRunMethod("react_webpackChunkPaths", includeMethods, excludeMethods)
+                        ? await react_webpackChunkPaths(url, maxJsSizeMb, jsFilesFromPageSource)
+                        : [];
                     queue.push(webpackChunkPaths);
 
                     // Recursively follow ESM imports and Vite __vite_mapDeps references.
                     // visited starts empty so the seed files are fetched and parsed in the first round.
                     const visited = new Set<string>();
-                    let toFollow = [...new Set([...jsFilesFromPageSource, ...webpackChunkPaths])];
-                    while (toFollow.length > 0) {
-                        const newFiles = await react_followImports(toFollow, maxJsSizeMb, url, visited);
-                        if (newFiles.length === 0) break;
-                        console.log(chalk.green(`[✓] Discovered ${newFiles.length} more JS file(s) via imports`));
-                        queue.push(newFiles);
-                        toFollow = newFiles;
+                    if (shouldRunMethod("react_followImports", includeMethods, excludeMethods)) {
+                        let toFollow = [...new Set([...jsFilesFromPageSource, ...webpackChunkPaths])];
+                        while (toFollow.length > 0) {
+                            const newFiles = await react_followImports(toFollow, maxJsSizeMb, url, visited);
+                            if (newFiles.length === 0) break;
+                            console.log(chalk.green(`[✓] Discovered ${newFiles.length} more JS file(s) via imports`));
+                            queue.push(newFiles);
+                            toFollow = newFiles;
+                        }
                     }
 
                     // Sourcemaps for everything discovered
-                    const sourcemapUrls = await react_sourcemapUrls([...visited]);
-                    queue.push(sourcemapUrls);
+                    if (shouldRunMethod("react_sourcemapUrls", includeMethods, excludeMethods)) {
+                        const sourcemapUrls = await react_sourcemapUrls([...visited]);
+                        queue.push(sourcemapUrls);
+                    }
 
                     await queue.drain();
                     queue.printSummary();

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -246,10 +246,23 @@ const lazyLoad = async (
                     const onFilesDiscovered = (files: string[]) => queue.push(files);
 
                     // run the full discovery pipeline against the entry URL
-                    const { clientSidePaths } = await vue_discoverJsFiles(url, maxJsSizeMb, onFilesDiscovered, includeMethods, excludeMethods);
+                    const { clientSidePaths } = await vue_discoverJsFiles(
+                        url,
+                        maxJsSizeMb,
+                        onFilesDiscovered,
+                        includeMethods,
+                        excludeMethods
+                    );
 
                     // recurse the same pipeline through every client-side path we found
-                    await vue_recursiveClientSidePathDownload(clientSidePaths, threads, maxJsSizeMb, onFilesDiscovered, includeMethods, excludeMethods);
+                    await vue_recursiveClientSidePathDownload(
+                        clientSidePaths,
+                        threads,
+                        maxJsSizeMb,
+                        onFilesDiscovered,
+                        includeMethods,
+                        excludeMethods
+                    );
 
                     await queue.drain();
                     queue.printSummary();
@@ -264,12 +277,20 @@ const lazyLoad = async (
                     activeQueue = queue;
 
                     // find the files from the page source
-                    const jsFilesFromPageSource = shouldRunMethod("nuxt_getFromPageSource", includeMethods, excludeMethods)
+                    const jsFilesFromPageSource = shouldRunMethod(
+                        "nuxt_getFromPageSource",
+                        includeMethods,
+                        excludeMethods
+                    )
                         ? await nuxt_getFromPageSource(url)
                         : [];
                     queue.push(jsFilesFromPageSource);
 
-                    const jsFilesFromStringAnalysis = shouldRunMethod("nuxt_stringAnalysisJSFiles", includeMethods, excludeMethods)
+                    const jsFilesFromStringAnalysis = shouldRunMethod(
+                        "nuxt_stringAnalysisJSFiles",
+                        includeMethods,
+                        excludeMethods
+                    )
                         ? await nuxt_stringAnalysisJSFiles(url)
                         : [];
                     queue.push(jsFilesFromStringAnalysis);
@@ -296,7 +317,11 @@ const lazyLoad = async (
                     activeQueue = queue;
 
                     // find the files from the page source
-                    const jsFilesFromPageSource = shouldRunMethod("svelte_getFromPageSource", includeMethods, excludeMethods)
+                    const jsFilesFromPageSource = shouldRunMethod(
+                        "svelte_getFromPageSource",
+                        includeMethods,
+                        excludeMethods
+                    )
                         ? await svelte_getFromPageSource(url)
                         : [];
                     queue.push(jsFilesFromPageSource);
@@ -327,7 +352,11 @@ const lazyLoad = async (
 
                     // crawl same-origin HTML pages found via <a href> and <link href>,
                     // running the full JS-discovery pipeline on each
-                    const jsFilesFromPageCrawl = shouldRunMethod("svelte_recursivePageCrawl", includeMethods, excludeMethods)
+                    const jsFilesFromPageCrawl = shouldRunMethod(
+                        "svelte_recursivePageCrawl",
+                        includeMethods,
+                        excludeMethods
+                    )
                         ? await svelte_recursivePageCrawl(url, maxJsSizeMb, (files) => queue.push(files))
                         : [];
 
@@ -336,7 +365,11 @@ const lazyLoad = async (
                     // embedded page path strings (e.g. "/admin", "/debug") and visit each
                     // page to discover the Astro island component-url values for those routes.
                     // Iterates until no new paths or JS files are discovered.
-                    const jsFilesFromPathScan = shouldRunMethod("svelte_discoverPagesFromJs", includeMethods, excludeMethods)
+                    const jsFilesFromPathScan = shouldRunMethod(
+                        "svelte_discoverPagesFromJs",
+                        includeMethods,
+                        excludeMethods
+                    )
                         ? await svelte_discoverPagesFromJs(url)
                         : [];
                     if (jsFilesFromPathScan.length > 0) {
@@ -368,7 +401,11 @@ const lazyLoad = async (
                     activeQueue = queue;
 
                     // find the files from the page source
-                    const jsFilesFromPageSource = shouldRunMethod("angular_getFromPageSource", includeMethods, excludeMethods)
+                    const jsFilesFromPageSource = shouldRunMethod(
+                        "angular_getFromPageSource",
+                        includeMethods,
+                        excludeMethods
+                    )
                         ? await angular_getFromPageSource(url)
                         : [];
                     queue.push(jsFilesFromPageSource);

--- a/src/lazyLoad/next_js/NextJsCrawler.ts
+++ b/src/lazyLoad/next_js/NextJsCrawler.ts
@@ -12,6 +12,7 @@ import next_bruteForceJsFiles from "./next_bruteForceJsFiles.js";
 import next_getClientSidePaths from "./next_getClientSidePaths.js";
 
 import * as lazyLoadGlobals from "../globals.js";
+import { shouldRunMethod } from "../methodFilter.js";
 
 interface NextJsCrawlerOptions {
     url: string;
@@ -25,6 +26,10 @@ interface NextJsCrawlerOptions {
     maxPageVisits?: number;
     /** Called with newly discovered downloadable URLs as they are found. */
     onUrlsDiscovered?: (urls: string[]) => void;
+    /** Whitelist of method names to run (empty = run all). */
+    includeMethods?: string[];
+    /** Blacklist of method names to skip (empty = skip none). */
+    excludeMethods?: string[];
 }
 
 /**
@@ -72,6 +77,9 @@ class NextJsCrawler {
     /** Callback invoked with newly discovered downloadable URLs. */
     private readonly onUrlsDiscovered?: (urls: string[]) => void;
 
+    private readonly includeMethods: string[];
+    private readonly excludeMethods: string[];
+
     constructor(options: NextJsCrawlerOptions) {
         if (
             options.maxPageVisits !== undefined &&
@@ -89,6 +97,8 @@ class NextJsCrawler {
         this.MAX_ITERATIONS = options.maxIterations;
         this.MAX_PAGE_VISITS = options.maxPageVisits ?? 200;
         this.onUrlsDiscovered = options.onUrlsDiscovered;
+        this.includeMethods = options.includeMethods ?? [];
+        this.excludeMethods = options.excludeMethods ?? [];
 
         this.discoveredUrls = new Set();
         this.pageScriptFingerprints = new Map();
@@ -158,8 +168,13 @@ class NextJsCrawler {
      * execute once (puppeteer-based webpack analysis, build-manifest, etc.).
      */
     private async initialDiscovery(): Promise<void> {
+        const inc = this.includeMethods;
+        const exc = this.excludeMethods;
+
         // 1. Script tags on the landing page
-        const jsFromScriptTag = await next_getJSScript(this.url);
+        const jsFromScriptTag = shouldRunMethod("next_GetJSScript", inc, exc)
+            ? await next_getJSScript(this.url)
+            : [];
         this.techniqueEfficiencyMapping["next_getJSScript"] = [
             ...(this.techniqueEfficiencyMapping["next_getJSScript"] || []),
             ...jsFromScriptTag,
@@ -173,18 +188,20 @@ class NextJsCrawler {
         // 1b. Client-side paths from <a href> tags on the landing page.
         // These are page URLs (not JS), so they'll be picked up by the
         // recursivePass loop which visits any newly registered non-JS URL.
-        const pathsFromAnchors = await next_getClientSidePaths(this.url);
-        this.techniqueEfficiencyMapping["next_getClientSidePaths"] = [
-            ...(this.techniqueEfficiencyMapping["next_getClientSidePaths"] || []),
-            ...pathsFromAnchors,
-        ];
-        this.emitDownloadable(this.registerUrls(pathsFromAnchors));
+        if (shouldRunMethod("next_getClientSidePaths", inc, exc)) {
+            const pathsFromAnchors = await next_getClientSidePaths(this.url);
+            this.techniqueEfficiencyMapping["next_getClientSidePaths"] = [
+                ...(this.techniqueEfficiencyMapping["next_getClientSidePaths"] || []),
+                ...pathsFromAnchors,
+            ];
+            this.emitDownloadable(this.registerUrls(pathsFromAnchors));
+        }
 
         // 2. Webpack runtime analysis (puppeteer – expensive, run once per target).
         // Skip in subsequent-requests passes: the webpack chunk URL builders are static
         // and were already resolved in the initial lazyload call; re-running this costs
         // 3-6 minutes per call without discovering new URLs.
-        if (!this.subsequentRequestsFlag) {
+        if (!this.subsequentRequestsFlag && shouldRunMethod("next_GetLazyResourcesWebpackJs", inc, exc)) {
             const jsFromWebpack = await next_GetLazyResourcesWebpackJs(this.url);
             this.techniqueEfficiencyMapping["next_GetLazyResourcesWebpackJs"] = jsFromWebpack;
             lazyLoadGlobals.pushToJsUrls(jsFromWebpack);
@@ -192,27 +209,33 @@ class NextJsCrawler {
         }
 
         // 3. _buildManifest.js
-        const jsFromBuildManifest = await next_getLazyResourcesBuildManifestJs(this.url);
-        this.techniqueEfficiencyMapping["next_getLazyResourcesBuildManifestJs"] = jsFromBuildManifest;
-        lazyLoadGlobals.pushToJsUrls(jsFromBuildManifest);
-        this.emitDownloadable(this.registerUrls(jsFromBuildManifest));
+        if (shouldRunMethod("next_GetLazyResourcesBuildManifestJs", inc, exc)) {
+            const jsFromBuildManifest = await next_getLazyResourcesBuildManifestJs(this.url);
+            this.techniqueEfficiencyMapping["next_getLazyResourcesBuildManifestJs"] = jsFromBuildManifest;
+            lazyLoadGlobals.pushToJsUrls(jsFromBuildManifest);
+            this.emitDownloadable(this.registerUrls(jsFromBuildManifest));
+        }
 
         // 4. Subsequent requests (RSC / script-tags on known endpoints)
         if (this.subsequentRequestsFlag) {
-            const jsFromSubsequent = await subsequentRequests(
-                this.url,
-                this.urlsFile,
-                this.threads,
-                this.output,
-                lazyLoadGlobals.getJsUrls()
-            );
-            this.techniqueEfficiencyMapping["subsequentRequests"] = [...jsFromSubsequent];
-            this.emitDownloadable(this.registerUrls([...jsFromSubsequent]));
+            if (shouldRunMethod("next_SubsequentRequests", inc, exc)) {
+                const jsFromSubsequent = await subsequentRequests(
+                    this.url,
+                    this.urlsFile,
+                    this.threads,
+                    this.output,
+                    lazyLoadGlobals.getJsUrls()
+                );
+                this.techniqueEfficiencyMapping["subsequentRequests"] = [...jsFromSubsequent];
+                this.emitDownloadable(this.registerUrls([...jsFromSubsequent]));
+            }
 
-            const jsFromScriptTagsSR = await next_scriptTagsSubsequentRequests(this.url, this.urlsFile);
-            this.techniqueEfficiencyMapping["next_scriptTagsSubsequentRequests"] = jsFromScriptTagsSR;
-            lazyLoadGlobals.pushToJsUrls(jsFromScriptTagsSR);
-            this.emitDownloadable(this.registerUrls(jsFromScriptTagsSR));
+            if (shouldRunMethod("next_scriptTagsSubsequentRequests", inc, exc)) {
+                const jsFromScriptTagsSR = await next_scriptTagsSubsequentRequests(this.url, this.urlsFile);
+                this.techniqueEfficiencyMapping["next_scriptTagsSubsequentRequests"] = jsFromScriptTagsSR;
+                lazyLoadGlobals.pushToJsUrls(jsFromScriptTagsSR);
+                this.emitDownloadable(this.registerUrls(jsFromScriptTagsSR));
+            }
         }
 
         // Also pull in anything the globals accumulated
@@ -230,27 +253,33 @@ class NextJsCrawler {
      * @returns Newly discovered URLs in this pass.
      */
     private async recursivePass(jsUrls: string[]): Promise<string[]> {
+        const inc = this.includeMethods;
+        const exc = this.excludeMethods;
         let newInThisPass: string[] = [];
 
         // Promise.all pattern analysis on JS file contents
-        const jsFromPromise = await next_promiseResolve(jsUrls);
-        this.techniqueEfficiencyMapping["next_promiseResolve"] = [
-            ...(this.techniqueEfficiencyMapping["next_promiseResolve"] || []),
-            ...jsFromPromise,
-        ];
-        const newFromPromise = this.registerUrls(jsFromPromise);
-        this.emitDownloadable(newFromPromise);
-        newInThisPass.push(...newFromPromise);
+        if (shouldRunMethod("next_promiseResolve", inc, exc)) {
+            const jsFromPromise = await next_promiseResolve(jsUrls);
+            this.techniqueEfficiencyMapping["next_promiseResolve"] = [
+                ...(this.techniqueEfficiencyMapping["next_promiseResolve"] || []),
+                ...jsFromPromise,
+            ];
+            const newFromPromise = this.registerUrls(jsFromPromise);
+            this.emitDownloadable(newFromPromise);
+            newInThisPass.push(...newFromPromise);
+        }
 
         // Layout.js parsing → discovers new client-side page paths → visits them
-        const jsFromLayout = await next_parseLayoutJs(this.url, jsUrls);
-        this.techniqueEfficiencyMapping["next_parseLayoutJs"] = [
-            ...(this.techniqueEfficiencyMapping["next_parseLayoutJs"] || []),
-            ...jsFromLayout,
-        ];
-        const newFromLayout = this.registerUrls(jsFromLayout);
-        this.emitDownloadable(newFromLayout);
-        newInThisPass.push(...newFromLayout);
+        if (shouldRunMethod("next_parseLayoutJs", inc, exc)) {
+            const jsFromLayout = await next_parseLayoutJs(this.url, jsUrls);
+            this.techniqueEfficiencyMapping["next_parseLayoutJs"] = [
+                ...(this.techniqueEfficiencyMapping["next_parseLayoutJs"] || []),
+                ...jsFromLayout,
+            ];
+            const newFromLayout = this.registerUrls(jsFromLayout);
+            this.emitDownloadable(newFromLayout);
+            newInThisPass.push(...newFromLayout);
+        }
 
         // Build a queue of unvisited page URLs to walk. Seed it with:
         //   - unvisited page URLs from the input batch (anchor-derived URLs
@@ -299,7 +328,9 @@ class NextJsCrawler {
             const normalized = this.normalizePageUrl(u);
 
             // Fetch scripts first — used for both fingerprinting and URL registration.
-            const extra = await next_getJSScript(u);
+            const extra = shouldRunMethod("next_GetJSScript", inc, exc)
+                ? await next_getJSScript(u)
+                : [];
 
             if (!extra || !Array.isArray(extra)) {
                 console.error(`[NextJsCrawler] Invalid return value from next_getJSScript for URL: ${u}`);
@@ -331,15 +362,17 @@ class NextJsCrawler {
 
             // Harvest <a href> links from this page so we keep expanding
             // the crawl frontier.
-            const morePaths = await next_getClientSidePaths(u);
-            this.techniqueEfficiencyMapping["next_getClientSidePaths"] = [
-                ...(this.techniqueEfficiencyMapping["next_getClientSidePaths"] || []),
-                ...morePaths,
-            ];
-            const newFromAnchors = this.registerUrls(morePaths);
-            this.emitDownloadable(newFromAnchors);
-            newInThisPass.push(...newFromAnchors);
-            for (const x of newFromAnchors) enqueueIfPage(x);
+            if (shouldRunMethod("next_getClientSidePaths", inc, exc)) {
+                const morePaths = await next_getClientSidePaths(u);
+                this.techniqueEfficiencyMapping["next_getClientSidePaths"] = [
+                    ...(this.techniqueEfficiencyMapping["next_getClientSidePaths"] || []),
+                    ...morePaths,
+                ];
+                const newFromAnchors = this.registerUrls(morePaths);
+                this.emitDownloadable(newFromAnchors);
+                newInThisPass.push(...newFromAnchors);
+                for (const x of newFromAnchors) enqueueIfPage(x);
+            }
         }
 
         return newInThisPass;
@@ -387,7 +420,7 @@ class NextJsCrawler {
         }
 
         // Phase 3 – brute-force .map files on the final set (skip if stopped by timeout)
-        if (!this.stopped) {
+        if (!this.stopped && shouldRunMethod("next_bruteForceJsFiles", this.includeMethods, this.excludeMethods)) {
             const allJsUrls = [...this.discoveredUrls].filter((u) => u.endsWith(".js") || u.endsWith(".js.map"));
             const jsFromBrute = await next_bruteForceJsFiles(allJsUrls);
             this.techniqueEfficiencyMapping["next_bruteForceJsFiles"] = jsFromBrute;

--- a/src/lazyLoad/next_js/NextJsCrawler.ts
+++ b/src/lazyLoad/next_js/NextJsCrawler.ts
@@ -172,9 +172,7 @@ class NextJsCrawler {
         const exc = this.excludeMethods;
 
         // 1. Script tags on the landing page
-        const jsFromScriptTag = shouldRunMethod("next_GetJSScript", inc, exc)
-            ? await next_getJSScript(this.url)
-            : [];
+        const jsFromScriptTag = shouldRunMethod("next_GetJSScript", inc, exc) ? await next_getJSScript(this.url) : [];
         this.techniqueEfficiencyMapping["next_getJSScript"] = [
             ...(this.techniqueEfficiencyMapping["next_getJSScript"] || []),
             ...jsFromScriptTag,
@@ -328,9 +326,7 @@ class NextJsCrawler {
             const normalized = this.normalizePageUrl(u);
 
             // Fetch scripts first — used for both fingerprinting and URL registration.
-            const extra = shouldRunMethod("next_GetJSScript", inc, exc)
-                ? await next_getJSScript(u)
-                : [];
+            const extra = shouldRunMethod("next_GetJSScript", inc, exc) ? await next_getJSScript(u) : [];
 
             if (!extra || !Array.isArray(extra)) {
                 console.error(`[NextJsCrawler] Invalid return value from next_getJSScript for URL: ${u}`);

--- a/src/lazyLoad/vue/vue_discoverJsFiles.ts
+++ b/src/lazyLoad/vue/vue_discoverJsFiles.ts
@@ -8,6 +8,7 @@ import vue_reconstructSourceMaps from "./vue_reconstructSourceMaps.js";
 import vue_getClientSidePaths from "./vue_getClientSidePaths.js";
 import vue_viteMapDeps from "./vue_viteMapDeps.js";
 import vue_stringJsFiles from "./vue_stringJsFiles.js";
+import { shouldRunMethod } from "../methodFilter.js";
 
 export interface VueDiscoveryResult {
     jsFiles: string[];
@@ -29,9 +30,14 @@ export interface VueDiscoveryResult {
 const vue_discoverJsFiles = async (
     url: string,
     maxJsSizeMb: number = 2,
-    onFilesDiscovered?: (files: string[]) => void
+    onFilesDiscovered?: (files: string[]) => void,
+    includeMethods: string[] = [],
+    excludeMethods: string[] = []
 ): Promise<VueDiscoveryResult> => {
     let jsFiles: string[] = [];
+
+    const inc = includeMethods;
+    const exc = excludeMethods;
 
     const emit = (files: string[]) => {
         jsFiles.push(...files);
@@ -41,53 +47,72 @@ const vue_discoverJsFiles = async (
     };
 
     // first, get all the JS files from the page source
-    emit(await vue_pageSrc(url));
+    if (shouldRunMethod("vue_pageSrc", inc, exc)) {
+        emit(await vue_pageSrc(url));
+    }
 
     // method 1: through runtime.<hash>.js
-    emit(await vue_runtimeJs(url));
+    if (shouldRunMethod("vue_RuntimeJs", inc, exc)) {
+        emit(await vue_runtimeJs(url));
+    }
 
     // single JS file on the page (typically dev-mode)
-    const fromSingleJs = await vue_singleJsFileOnHome(url);
-    emit(fromSingleJs);
-    if (fromSingleJs.length > 0) {
-        console.log(chalk.green(`[✓] Found ${fromSingleJs.length} files from the single JS file on home`));
+    if (shouldRunMethod("vue_SingleJsFileOnHome", inc, exc)) {
+        const fromSingleJs = await vue_singleJsFileOnHome(url);
+        emit(fromSingleJs);
+        if (fromSingleJs.length > 0) {
+            console.log(chalk.green(`[✓] Found ${fromSingleJs.length} files from the single JS file on home`));
+        }
     }
 
     // several JS files referenced directly on the page
-    emit(await vue_severalJsFilesHome(url));
+    if (shouldRunMethod("vue_severalJsFilesHome", inc, exc)) {
+        emit(await vue_severalJsFilesHome(url));
+    }
 
     // scan page-loaded JS files for Vite's __vite__mapDeps chunk manifest
-    const fromViteMapDeps = await vue_viteMapDeps(jsFiles, maxJsSizeMb);
-    emit(fromViteMapDeps);
-    if (fromViteMapDeps.length > 0) {
-        console.log(chalk.green(`[✓] Found ${fromViteMapDeps.length} files from __vite__mapDeps`));
+    if (shouldRunMethod("vue_viteMapDeps", inc, exc)) {
+        const fromViteMapDeps = await vue_viteMapDeps(jsFiles, maxJsSizeMb);
+        emit(fromViteMapDeps);
+        if (fromViteMapDeps.length > 0) {
+            console.log(chalk.green(`[✓] Found ${fromViteMapDeps.length} files from __vite__mapDeps`));
+        }
     }
 
     // walk the import graph of everything found so far
-    const fromImports = await vue_jsImports(url, jsFiles, maxJsSizeMb);
-    emit(fromImports);
-    if (fromImports.length > 0) {
-        console.log(chalk.green(`[✓] Found ${fromImports.length} files from import statements`));
+    if (shouldRunMethod("vue_jsImports", inc, exc)) {
+        const fromImports = await vue_jsImports(url, jsFiles, maxJsSizeMb);
+        emit(fromImports);
+        if (fromImports.length > 0) {
+            console.log(chalk.green(`[✓] Found ${fromImports.length} files from import statements`));
+        }
     }
 
     // scan string literals inside known JS files for .js references
-    const fromStringRefs = await vue_stringJsFiles(jsFiles, maxJsSizeMb);
-    emit(fromStringRefs);
-    if (fromStringRefs.length > 0) {
-        console.log(chalk.green(`[✓] Found ${fromStringRefs.length} files from string literal JS references`));
+    if (shouldRunMethod("vue_stringJsFiles", inc, exc)) {
+        const fromStringRefs = await vue_stringJsFiles(jsFiles, maxJsSizeMb);
+        emit(fromStringRefs);
+        if (fromStringRefs.length > 0) {
+            console.log(chalk.green(`[✓] Found ${fromStringRefs.length} files from string literal JS references`));
+        }
     }
 
     // reconstruct sourceMappingURL references
-    const fromSourceMaps = await vue_reconstructSourceMaps(url, jsFiles);
-    emit(fromSourceMaps);
-    if (fromSourceMaps.length > 0) {
-        console.log(chalk.green(`[✓] Found ${fromSourceMaps.length} files from reconstructing source maps`));
+    if (shouldRunMethod("vue_reconstructSourceMaps", inc, exc)) {
+        const fromSourceMaps = await vue_reconstructSourceMaps(url, jsFiles);
+        emit(fromSourceMaps);
+        if (fromSourceMaps.length > 0) {
+            console.log(chalk.green(`[✓] Found ${fromSourceMaps.length} files from reconstructing source maps`));
+        }
     }
 
     jsFiles = [...new Set(jsFiles)].map((f) => (f.startsWith("//") ? "https:" + f : f));
 
     // surface client-side paths so the caller can recurse into them
-    const clientSidePaths = await vue_getClientSidePaths(url, jsFiles, maxJsSizeMb);
+    let clientSidePaths: string[] = [];
+    if (shouldRunMethod("vue_getClientSidePaths", inc, exc)) {
+        clientSidePaths = await vue_getClientSidePaths(url, jsFiles, maxJsSizeMb);
+    }
 
     return { jsFiles, clientSidePaths: [...new Set(clientSidePaths)] };
 };

--- a/src/lazyLoad/vue/vue_recursiveClientSidePathDownload.ts
+++ b/src/lazyLoad/vue/vue_recursiveClientSidePathDownload.ts
@@ -21,7 +21,9 @@ const vue_recursiveClientSidePathDownload = async (
     clientSidePaths: string[],
     threads: number = 1,
     maxJsSizeMb: number = 2,
-    onFilesDiscovered?: (files: string[]) => void
+    onFilesDiscovered?: (files: string[]) => void,
+    includeMethods: string[] = [],
+    excludeMethods: string[] = []
 ): Promise<string[]> => {
     const allJsFiles = new Set<string>();
     const visitedPaths = new Set<string>();
@@ -96,7 +98,9 @@ const vue_recursiveClientSidePathDownload = async (
                         const { jsFiles, clientSidePaths: newPaths } = await vue_discoverJsFiles(
                             path,
                             maxJsSizeMb,
-                            onFilesDiscovered
+                            onFilesDiscovered,
+                            includeMethods,
+                            excludeMethods
                         );
 
                         for (const file of jsFiles) {

--- a/src/refactor/index.ts
+++ b/src/refactor/index.ts
@@ -124,18 +124,18 @@ const refactor = async (
 ): Promise<void> => {
     console.log(chalk.cyan("[i] Loading refactor module..."));
 
+    if (list) {
+        console.log(chalk.cyan("[i] Listing available technologies"));
+        for (const key of Object.keys(availableTechs) as Array<keyof typeof availableTechs>) {
+            console.log(chalk.green(`- ${key}: ${availableTechs[key]}`));
+        }
+        return;
+    }
+
     // check if the file exists
     if (!fs.existsSync(mappedJson)) {
         console.error(chalk.red("[!] Mapped JSON file does not exist"));
         process.exit(7);
-    }
-
-    if (list) {
-        console.log(chalk.cyan("[i] Listing available technologies"));
-        for (const tech of Object.keys(availableTechs)) {
-            console.log(chalk.green(`- ${tech}: ${availableTechs[tech]}`));
-        }
-        return;
     }
 
     // verify if the tech provided is valid


### PR DESCRIPTION
## 1.4.1-alpha.2 - 2026-06-20

### Fixed

- `lazyload`: `--include-methods`, `--exclude-methods`, and `--list-methods` flags were listed as Added in v1.4.1-alpha.1 but the CLI wiring was absent from that release; they are now fully implemented and functional
- `lazyload`: `--list-methods` works without `-u`; the URL option is now validated manually so `--list-methods` can run standalone
- `refactor`: `-l`/`--list` no longer errors with "Mapped JSON file does not exist" when listing technologies — the list early-return now runs before the file-existence check