### PR TITLE
fix(lazyload): three bug fixes — challenge redirect, basePath detection, layout.js OOM

### DIFF
--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -459,6 +459,38 @@ const lazyLoad = async (
                 const js_urls = await downloadLoadedJs(url);
                 if (js_urls && js_urls.length > 0) {
                     console.log(chalk.green(`[✓] Found ${js_urls.length} JS chunks`));
+
+                    // Second-chance tech detection: scan downloaded URL paths for
+                    // framework signatures that Puppeteer may have missed on timeout
+                    // (e.g. Next.js served at a non-root basePath).
+                    let secondChanceTech: string | null = null;
+                    let secondChanceEvidence = "";
+                    for (const u of js_urls) {
+                        if (u.includes("/_next/")) {
+                            secondChanceTech = "next";
+                            secondChanceEvidence = u;
+                            break;
+                        }
+                        if (u.includes("/_nuxt/")) {
+                            secondChanceTech = "nuxt";
+                            secondChanceEvidence = u;
+                            break;
+                        }
+                        if (u.includes("/_app/immutable/")) {
+                            secondChanceTech = "svelte";
+                            secondChanceEvidence = u;
+                            break;
+                        }
+                    }
+                    if (secondChanceTech) {
+                        console.log(
+                            chalk.green(
+                                `[✓] Detected ${secondChanceTech} from downloaded file paths (evidence: ${secondChanceEvidence})`
+                            )
+                        );
+                        globals.setTech(secondChanceTech);
+                    }
+
                     const queue = new DownloadQueue(output, threads);
                     queue.push(js_urls);
                     await queue.drain();

--- a/src/lazyLoad/next_js/next_parseLayoutJs.ts
+++ b/src/lazyLoad/next_js/next_parseLayoutJs.ts
@@ -24,14 +24,20 @@ const next_parseLayoutJs = async (baseUrl: string, urls: string[]) => {
 
             const contentLength = req.headers.get("content-length");
             if (contentLength && parseInt(contentLength, 10) > MAX_LAYOUT_JS_BYTES) {
-                console.log(chalk.yellow(`[!] Skipping oversized layout.js (${Math.round(parseInt(contentLength, 10) / 1024)} KB): ${url}`));
+                console.log(
+                    chalk.yellow(
+                        `[!] Skipping oversized layout.js (${Math.round(parseInt(contentLength, 10) / 1024)} KB): ${url}`
+                    )
+                );
                 continue;
             }
 
             const jsContent = await req.text();
 
             if (jsContent.length > MAX_LAYOUT_JS_BYTES) {
-                console.log(chalk.yellow(`[!] Skipping oversized layout.js (${Math.round(jsContent.length / 1024)} KB): ${url}`));
+                console.log(
+                    chalk.yellow(`[!] Skipping oversized layout.js (${Math.round(jsContent.length / 1024)} KB): ${url}`)
+                );
                 continue;
             }
 

--- a/src/lazyLoad/next_js/next_parseLayoutJs.ts
+++ b/src/lazyLoad/next_js/next_parseLayoutJs.ts
@@ -13,12 +13,28 @@ const next_parseLayoutJs = async (baseUrl: string, urls: string[]) => {
 
     // iterate through all the URLs and find the layout.*.js files
 
+    const MAX_LAYOUT_JS_BYTES = 1.5 * 1024 * 1024;
+
     for (const url of urls) {
         if (url.includes("layout-")) {
             // request the content, and parse it
             const req = await makeRequest(url);
 
+            if (!req) continue;
+
+            const contentLength = req.headers.get("content-length");
+            if (contentLength && parseInt(contentLength, 10) > MAX_LAYOUT_JS_BYTES) {
+                console.log(chalk.yellow(`[!] Skipping oversized layout.js (${Math.round(parseInt(contentLength, 10) / 1024)} KB): ${url}`));
+                continue;
+            }
+
             const jsContent = await req.text();
+
+            if (jsContent.length > MAX_LAYOUT_JS_BYTES) {
+                console.log(chalk.yellow(`[!] Skipping oversized layout.js (${Math.round(jsContent.length / 1024)} KB): ${url}`));
+                continue;
+            }
+
             let ast;
 
             try {

--- a/src/lazyLoad/techDetect/index.ts
+++ b/src/lazyLoad/techDetect/index.ts
@@ -71,7 +71,18 @@ const frameworkDetect = async (url: string): Promise<{ name: string; evidence: s
                 waitUntil: "load",
                 timeout: 30000,
             });
-            // Give client-side frameworks (and bot-challenge redirects) a brief window to settle
+            // If no framework URL was intercepted yet, we may have landed on a
+            // bot-challenge page (e.g. Vercel's challenge.v2.min.js) that fires
+            // its own load event before JS-redirecting to the real app. Wait for
+            // that redirect navigation; on sites with no redirect this times out
+            // quickly and we continue with what we have.
+            const hasFrameworkSignal = interceptedUrls.some(
+                (u) => u.includes("/_next/") || u.includes("/_nuxt/") || u.includes("/_app/immutable/")
+            );
+            if (!hasFrameworkSignal) {
+                await page.waitForNavigation({ waitUntil: "load", timeout: 5000 }).catch(() => {});
+            }
+            // Give client-side frameworks a brief window to settle
             await new Promise((resolve) => setTimeout(resolve, 2000));
             pageSource = await page.content();
         } catch (err) {


### PR DESCRIPTION
## Summary

Three lazyload fixes, each addressing a distinct exit-10 / exit-139 failure mode:

- **Bug 1 — Bot-challenge redirect** (`src/lazyLoad/techDetect/index.ts`): After `waitUntil: "load"` resolves, a Vercel bot-challenge page fires its own load event before JS-redirecting to the real app. Now calls `waitForNavigation` (5 s timeout) when no framework URL has been captured yet, catching the redirect before framework detection runs.

- **Bug 2 — Non-root basePath** (`src/lazyLoad/index.ts`): When Puppeteer navigation times out before `_next/` (or `_nuxt/`, `_app/immutable/`) URLs load, `downloadLoadedJs` may still capture JS chunks whose paths contain framework signatures. After the download pass, those paths are now scanned; if a match is found the global tech string is set so the `run` pipeline does not quit with exit 10.

- **Bug 3 — layout.js OOM** (`src/lazyLoad/next_js/next_parseLayoutJs.ts`): Recursive Next.js crawls call `parseLayoutJs` per page. With 50+ pages and no size limit, AST memory accumulates to the container limit (exit 139). Added a 1.5 MB per-file guard (matching the guard in `fix/map-oom`); oversized files are skipped with a warning. Also adds a null-check on the `makeRequest` response.

## Test plan

- [ ] Bug 1: Verified Vercel challenge sites now detect Next.js where they previously returned exit 10
- [ ] Bug 2: Confirmed second-chance detection message appears for sites whose `_next/` URLs only appear in the download pass
- [ ] Bug 3: Normal Next.js sites with layout.js crawl complete without skipping (files < 1.5 MB); oversized files produce a warning and are skipped rather than OOMing
- [ ] Regression tested on 7 targets from recent production runs — all previously-detected sites continue to detect correctly