### PR TITLE
v1.4.1-alpha.6

### DIFF
--- a/.github/workflows/promote-js-recon.yml
+++ b/.github/workflows/promote-js-recon.yml
@@ -1,0 +1,116 @@
+# Manually-triggered second phase of a release, run after a staged npm publish
+# (see publish-js-recon.yml) has been approved by a human with 2FA on npmjs.com.
+# Installs js-recon from the published npm registry artifact rather than
+# building from git source, so the Homebrew/Docker/GHCR outputs are provably
+# the same bits that were reviewed and approved on npm.
+
+name: Promote JS Recon Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Published npm version to promote (e.g. 1.4.1-alpha.6, no leading v)"
+        required: true
+        type: string
+
+jobs:
+  update-homebrew-tap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch published tarball and compute SHA256
+        id: sha256
+        run: |
+          npm pack "@shriyanss/js-recon@${VERSION}"
+          SHA=$(sha256sum "shriyanss-js-recon-${VERSION}.tgz" | awk '{print $1}')
+          echo "sha256=${SHA}" >> "$GITHUB_OUTPUT"
+        env:
+          VERSION: ${{ inputs.version }}
+
+      - name: Check out homebrew-tap
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: shriyanss/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula fields
+        working-directory: homebrew-tap
+        run: |
+          F="Formula/js-recon.rb"
+          sed -i "s|^  url \"https://registry\.npmjs\.org/@shriyanss/js-recon/-/js-recon-[^\"]*\"|  url \"https://registry.npmjs.org/@shriyanss/js-recon/-/js-recon-${VERSION}.tgz\"|" "${F}"
+          sed -i "s|^  sha256 \"[a-f0-9]*\"|  sha256 \"${SHA}\"|" "${F}"
+        env:
+          VERSION: ${{ inputs.version }}
+          SHA: ${{ steps.sha256.outputs.sha256 }}
+
+      - name: Commit and push
+        working-directory: homebrew-tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/js-recon.rb
+          git commit -m "chore: update js-recon formula to ${VERSION}"
+          git push
+        env:
+          VERSION: ${{ inputs.version }}
+
+  publish-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Build and push to dockerhub
+        run: |
+          # login to docker
+          echo $DOCKER_SECRET | docker login -u shriyanss --password-stdin
+
+          # build the image from the published npm artifact
+          docker build -f Dockerfile.release --build-arg JS_RECON_VERSION=$VERSION -t shriyanss/js-recon:$VERSION .
+
+          # check if it is alpha or beta. default to latest
+          TAG="latest"
+          [[ "$VERSION" == *"beta"* ]] && TAG="beta"
+          [[ "$VERSION" == *"alpha"* ]] && TAG="alpha"
+
+          # tag again with whatever has been set
+          docker tag shriyanss/js-recon:$VERSION shriyanss/js-recon:$TAG
+
+          # push images with both tags
+          docker push shriyanss/js-recon:$VERSION
+          docker push shriyanss/js-recon:$TAG
+
+        env:
+          DOCKER_SECRET: ${{ secrets.DOCKER_SECRET }}
+          VERSION: ${{ inputs.version }}
+
+  publish-ghcr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push to github container registry
+        run: |
+          # build the image from the published npm artifact
+          docker build -f Dockerfile.release --build-arg JS_RECON_VERSION=$VERSION -t ghcr.io/shriyanss/js-recon:$VERSION .
+
+          # check if it is alpha or beta. default to latest
+          TAG="latest"
+          [[ "$VERSION" == *"beta"* ]] && TAG="beta"
+          [[ "$VERSION" == *"alpha"* ]] && TAG="alpha"
+
+          # tag again with whatever has been set
+          docker tag ghcr.io/shriyanss/js-recon:$VERSION ghcr.io/shriyanss/js-recon:$TAG
+
+          # push images with both tags
+          docker push ghcr.io/shriyanss/js-recon:$VERSION
+          docker push ghcr.io/shriyanss/js-recon:$TAG
+
+        env:
+          VERSION: ${{ inputs.version }}

--- a/.github/workflows/publish-js-recon.yml
+++ b/.github/workflows/publish-js-recon.yml
@@ -63,6 +63,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -71,129 +74,20 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
-      - name: Publish to npm
+      - name: Ensure npm CLI supports OIDC trusted publishing
+        run: npm install -g npm@latest
+      - name: Stage release to npm via OIDC
         run: |
           TAG="latest"
           [[ "$VERSION" == *"beta"* ]] && TAG="beta"
           [[ "$VERSION" == *"alpha"* ]] && TAG="alpha"
-          npm publish --tag $TAG
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-          VERSION: ${{ github.event.release.tag_name }}
-
-
-  update-homebrew-tap:
-    needs: publish-npm
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get release version
-        id: version
-        run: |
-          RAW="${{ github.event.release.tag_name }}"
-          echo "version=${RAW#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Compute npm tarball SHA256
-        id: sha256
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          URL="https://registry.npmjs.org/@shriyanss/js-recon/-/js-recon-${VERSION}.tgz"
-          SHA=$(curl -fsSL "${URL}" | sha256sum | awk '{print $1}')
-          echo "sha256=${SHA}" >> "$GITHUB_OUTPUT"
-
-      - name: Check out homebrew-tap
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: shriyanss/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: homebrew-tap
-
-      - name: Update formula fields
-        working-directory: homebrew-tap
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          SHA="${{ steps.sha256.outputs.sha256 }}"
-          F="Formula/js-recon.rb"
-          sed -i "s|^  url \"https://registry\.npmjs\.org/@shriyanss/js-recon/-/js-recon-[^\"]*\"|  url \"https://registry.npmjs.org/@shriyanss/js-recon/-/js-recon-${VERSION}.tgz\"|" "${F}"
-          sed -i "s|^  sha256 \"[a-f0-9]*\"|  sha256 \"${SHA}\"|" "${F}"
-
-      - name: Commit and push
-        working-directory: homebrew-tap
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/js-recon.rb
-          git commit -m "chore: update js-recon formula to ${{ steps.version.outputs.version }}"
-          git push
-
-
-  publish-docker:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Build and push to dockerhub
-        run: |
-          # login to docker
-          echo $DOCKER_SECRET | docker login -u shriyanss --password-stdin
-
-          # build the image
-          docker build -t shriyanss/js-recon:$VERSION .
-
-          # check if it is alpha or beta. default to latest
-          TAG="latest"
-          [[ "$VERSION" == *"beta"* ]] && TAG="beta"
-          [[ "$VERSION" == *"alpha"* ]] && TAG="alpha"
-
-          # tag again with whatever has been set
-          docker tag shriyanss/js-recon:$VERSION shriyanss/js-recon:$TAG
-
-          # push images with both tags
-          docker push shriyanss/js-recon:$VERSION
-          docker push shriyanss/js-recon:$TAG
-          
-        env:
-          DOCKER_SECRET: ${{ secrets.DOCKER_SECRET }}
-          VERSION: ${{ github.event.release.tag_name }}
-
-
-  publish-ghcr:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push to github container registry
-        run: |
-          # build the image
-          docker build -t ghcr.io/shriyanss/js-recon:$VERSION .
-
-          # check if it is alpha or beta. default to latest
-          TAG="latest"
-          [[ "$VERSION" == *"beta"* ]] && TAG="beta"
-          [[ "$VERSION" == *"alpha"* ]] && TAG="alpha"
-
-          # tag again with whatever has been set
-          docker tag ghcr.io/shriyanss/js-recon:$VERSION ghcr.io/shriyanss/js-recon:$TAG
-
-          # push images with both tags
-          docker push ghcr.io/shriyanss/js-recon:$VERSION
-          docker push ghcr.io/shriyanss/js-recon:$TAG
-          
+          npm stage publish --tag $TAG
         env:
           VERSION: ${{ github.event.release.tag_name }}
-  
+
   merge_main_and_dev:
     needs:
       - publish-npm
-      - publish-docker
-      - publish-ghcr
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.4.1-alpha.6 - 2026-07-13
+
+### Changed
+
+- CI: npm publishing now uses OIDC trusted publishing with staged releases (`npm stage publish`) instead of a classic auth token, since NPM is restricting tokens that bypass MFA. Promoting a staged release to live still requires a manual, 2FA-gated `npm stage approve` — this cannot be automated. The Homebrew tap update and Docker/GHCR image publishing have moved out of `publish-js-recon.yml` into a new manually-triggered workflow, `promote-js-recon.yml`, run after the staged release is approved. That workflow installs js-recon from the published npm registry artifact (`npm pack`/`npm install <pkg>@<version>`) rather than building from git source, as an additional supply-chain safeguard — what ships in the Docker/GHCR images and what Homebrew hashes is provably the same bits that were reviewed and approved on npm. (`ci`)
+
 ## 1.4.1-alpha.5 - 2026-07-13
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,7 +401,7 @@ Before writing any files, gather the current state:
 
     Previous tag is left to GitHub's automatic detection (do not set `--target` or `--tag` beyond the tag name itself).
 
-9. **Wait for npm stage publish** — monitor the release pipeline: `gh run list --repo shriyanss/js-recon --workflow "Publish JS Recon"`. `publish-npm` uses OIDC trusted publishing (`npm stage publish`, no token) to *stage* the release — this is NOT the same as it being live.
+9. **Wait for npm stage publish** — monitor the release pipeline: `gh run list --repo shriyanss/js-recon --workflow "Publish JS Recon"`. `publish-npm` uses OIDC trusted publishing (`npm stage publish`, no token) to _stage_ the release — this is NOT the same as it being live.
 
 10. **Approve the staged release** — npm's staged-publish approval always requires interactive 2FA, so this step can never be automated or scripted:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,25 +401,43 @@ Before writing any files, gather the current state:
 
     Previous tag is left to GitHub's automatic detection (do not set `--target` or `--tag` beyond the tag name itself).
 
-9. **Wait for npm publish** — monitor the release pipeline: `gh run list --repo shriyanss/js-recon --workflow release`. Confirm the npm package is live at the new version before proceeding to Phase 2.
+9. **Wait for npm stage publish** — monitor the release pipeline: `gh run list --repo shriyanss/js-recon --workflow "Publish JS Recon"`. `publish-npm` uses OIDC trusted publishing (`npm stage publish`, no token) to *stage* the release — this is NOT the same as it being live.
 
-### Homebrew tap (automatic, runs in parallel with Phase 2)
+10. **Approve the staged release** — npm's staged-publish approval always requires interactive 2FA, so this step can never be automated or scripted:
 
-After `publish-npm` succeeds, the `update-homebrew-tap` job in `publish-js-recon.yml` runs automatically. It:
+    - Find the stage id: `npm stage list @shriyanss/js-recon` (or the "Staged Packages" tab on npmjs.com)
+    - Approve it: `npm stage approve <stage-id>` (prompts for 2FA), or click "Approve" on npmjs.com
+    - Confirm it's live: `npm view @shriyanss/js-recon@<version>`
 
-1. Computes the SHA256 of the published npm tarball from the public npmjs.org URL (no auth)
+11. **Manually trigger the promote workflow** — once the release is live, run `promote-js-recon.yml` to update Homebrew and publish the Docker/GHCR images:
+
+    ```bash
+    gh workflow run promote-js-recon.yml --repo shriyanss/js-recon -f version=<version>
+    ```
+
+    This workflow installs js-recon from the published npm registry artifact (`npm pack`/`npm install <pkg>@<version>`) rather than building from git source — an additional supply-chain check that the shipped images/formula match exactly what was approved on npm. Monitor: `gh run list --repo shriyanss/js-recon --workflow "Promote JS Recon Release"`.
+
+### Homebrew tap (manual, part of `promote-js-recon.yml`)
+
+The `update-homebrew-tap` job (now in `promote-js-recon.yml`, triggered per step 11 above):
+
+1. `npm pack @shriyanss/js-recon@<version>` — downloads the exact published tarball from the registry and computes its SHA256 locally (no dependency on a public tarball URL being reachable yet)
 2. Checks out `shriyanss/homebrew-tap` using `HOMEBREW_TAP_TOKEN` (a fine-grained PAT stored in `shriyanss/js-recon` secrets, scoped to `homebrew-tap` repo `Contents: Read and write` only — automatically masked in all log output, never echoed)
 3. Updates `version`, `url`, and `sha256` in `Formula/js-recon.rb` via anchored `sed`
 4. Commits `chore: update js-recon formula to <version>` and pushes
 
 Monitor: `gh run list --repo shriyanss/homebrew-tap --workflow ci.yml`
 
-**If the job fails:** The npm package is already live. Manually update: compute `curl -fsSL <tarball-url> | sha256sum`, edit `Formula/js-recon.rb`, commit, and push to `shriyanss/homebrew-tap`.
+**If the job fails:** manually update: `npm pack @shriyanss/js-recon@<version> && sha256sum shriyanss-js-recon-<version>.tgz`, edit `Formula/js-recon.rb`, commit, and push to `shriyanss/homebrew-tap`.
 
 **One-time setup** (must be done before the first release, already completed):
 
 - `shriyanss/homebrew-tap` is a public GitHub repo with the formula at `Formula/js-recon.rb`
 - `HOMEBREW_TAP_TOKEN` is a fine-grained PAT stored in `shriyanss/js-recon` → Settings → Secrets → Actions, scoped exclusively to the `homebrew-tap` repo
+
+### Docker / GHCR images (manual, part of `promote-js-recon.yml`)
+
+`publish-docker` and `publish-ghcr` (now in `promote-js-recon.yml`) build from `Dockerfile.release` instead of the default `Dockerfile`. `Dockerfile.release` runs `npm install -g @shriyanss/js-recon@<version>` against the live registry rather than copying local source and building — the published images are provably built from the approved npm artifact. The default `Dockerfile` (source build) is unchanged and still used for local/dev builds.
 
 ### Phase 2 — js-recon-docs (after npm is live)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,7 +423,7 @@ The `update-homebrew-tap` job (now in `promote-js-recon.yml`, triggered per step
 
 1. `npm pack @shriyanss/js-recon@<version>` — downloads the exact published tarball from the registry and computes its SHA256 locally (no dependency on a public tarball URL being reachable yet)
 2. Checks out `shriyanss/homebrew-tap` using `HOMEBREW_TAP_TOKEN` (a fine-grained PAT stored in `shriyanss/js-recon` secrets, scoped to `homebrew-tap` repo `Contents: Read and write` only — automatically masked in all log output, never echoed)
-3. Updates `version`, `url`, and `sha256` in `Formula/js-recon.rb` via anchored `sed`
+3. Updates `url` and `sha256` in `Formula/js-recon.rb` via anchored `sed` — the formula has no explicit `version` field; Homebrew derives it from the `url`
 4. Commits `chore: update js-recon formula to <version>` and pushes
 
 Monitor: `gh run list --repo shriyanss/homebrew-tap --workflow ci.yml`

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,29 @@
+FROM ghcr.io/puppeteer/puppeteer:24.43.1
+
+WORKDIR /home/pptruser
+
+USER root
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    unzip \
+    libnspr4 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+    libxcomposite1 libxdamage1 libxrandr2 libgbm1 libxkbcommon0 \
+    libasound2 libpangocairo-1.0-0 libxfixes3 libxi6 libxinerama1 \
+    libxcursor1 libdrm2 && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG JS_RECON_VERSION
+RUN npm install -g @shriyanss/js-recon@${JS_RECON_VERSION}
+
+USER pptruser
+RUN "$(npm root -g)/@shriyanss/js-recon/node_modules/.bin/puppeteer" browsers install chrome && \
+    for zip in /home/pptruser/.cache/puppeteer/chrome/*-chrome-linux64.zip; do \
+        [ -f "$zip" ] || break; \
+        version="${zip%-chrome-linux64.zip}"; version="${version##*/}"; \
+        dest="/home/pptruser/.cache/puppeteer/chrome/linux-${version}"; \
+        unzip -o "$zip" -d "${dest}/" && chmod +x "${dest}/chrome-linux64/chrome"; \
+    done
+
+ENV IS_DOCKER=true
+ENV NODE_OPTIONS="--max-http-header-size=99999999"
+ENTRYPOINT ["js-recon"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM ghcr.io/puppeteer/puppeteer:24.43.1
+FROM ghcr.io/puppeteer/puppeteer:25.3.0
 
 WORKDIR /home/pptruser
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shriyanss/js-recon",
-    "version": "1.4.1-alpha.5",
+    "version": "1.4.1-alpha.6",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,6 @@
 const githubURL = "https://github.com/shriyanss/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
-const version = "1.4.1-alpha.5";
+const version = "1.4.1-alpha.6";
 const toolDesc = "JavaScript Enumeration and SAST";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests
 


### PR DESCRIPTION
## 1.4.1-alpha.6 - 2026-07-13

### Changed

- CI: npm publishing now uses OIDC trusted publishing with staged releases (`npm stage publish`) instead of a classic auth token, since NPM is restricting tokens that bypass MFA. Promoting a staged release to live still requires a manual, 2FA-gated `npm stage approve` — this cannot be automated. The Homebrew tap update and Docker/GHCR image publishing have moved out of `publish-js-recon.yml` into a new manually-triggered workflow, `promote-js-recon.yml`, run after the staged release is approved. That workflow installs js-recon from the published npm registry artifact (`npm pack`/`npm install <pkg>@<version>`) rather than building from git source, as an additional supply-chain safeguard — what ships in the Docker/GHCR images and what Homebrew hashes is provably the same bits that were reviewed and approved on npm. (`ci`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a release promotion workflow for publishing approved versions to Homebrew, Docker Hub, and GitHub Container Registry.
  - Added a release Docker image with the `js-recon` CLI and compatible Chrome runtime.

- **Improvements**
  - npm releases now use staged publishing with trusted OIDC authentication and manual approval.
  - Homebrew and container releases are built from the approved npm artifact.

- **Changelog**
  - Documented release `1.4.1-alpha.6` and the updated promotion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->