### PR TITLE
v1.4.1-alpha.7

### DIFF
--- a/.github/workflows/build-and-prettify.yaml
+++ b/.github/workflows/build-and-prettify.yaml
@@ -55,13 +55,20 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     needs: audit
+    environment: commit-signing
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Make sure the action checks out the repository to the pull request branch
           ref: ${{ github.ref_name }}
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Configure SSH commit signing
+        uses: shriyanss/verified-commit-action@v1
+        with:
+          ssh-private-key: ${{ secrets.JS_RECON_SIGNING_KEY }}
+          commit-name: "github-actions[bot]"
+          commit-email: ${{ secrets.JS_RECON_SIGNING_EMAIL }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -77,14 +84,12 @@ jobs:
 
       - name: Run Prettier
         run: prettier --write . --config .prettierrc
-      
+
       - name: Remove node_modules
         run: rm -rf node_modules
 
       - name: Commit and push changes
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "chore: prettify code" || echo "No changes to commit"
           git push

--- a/.github/workflows/build-and-prettify.yaml
+++ b/.github/workflows/build-and-prettify.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: shriyanss/verified-commit-action@v1
         with:
           ssh-private-key: ${{ secrets.JS_RECON_SIGNING_KEY }}
-          commit-name: "github-actions[bot]"
+          commit-name: "js-recon-bot"
           commit-email: ${{ secrets.JS_RECON_SIGNING_EMAIL }}
 
       - name: Set up Node.js

--- a/.github/workflows/promote-js-recon.yml
+++ b/.github/workflows/promote-js-recon.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: shriyanss/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
       - name: Update formula fields
@@ -57,6 +56,7 @@ jobs:
 
   publish-docker:
     runs-on: ubuntu-latest
+    environment: docker-publish
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Build and push to dockerhub

--- a/.github/workflows/publish-js-recon.yml
+++ b/.github/workflows/publish-js-recon.yml
@@ -89,15 +89,19 @@ jobs:
     needs:
       - publish-npm
     runs-on: ubuntu-latest
+    environment: commit-signing
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
           fetch-depth: 0
+      - name: Configure SSH commit signing
+        uses: shriyanss/verified-commit-action@v1
+        with:
+          ssh-private-key: ${{ secrets.JS_RECON_SIGNING_KEY }}
+          commit-name: "github-actions[bot]"
+          commit-email: ${{ secrets.JS_RECON_SIGNING_EMAIL }}
       - name: Merge main and dev
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git fetch origin main:main
           git fetch origin dev:dev
           git checkout dev

--- a/.github/workflows/publish-js-recon.yml
+++ b/.github/workflows/publish-js-recon.yml
@@ -98,7 +98,7 @@ jobs:
         uses: shriyanss/verified-commit-action@v1
         with:
           ssh-private-key: ${{ secrets.JS_RECON_SIGNING_KEY }}
-          commit-name: "github-actions[bot]"
+          commit-name: "js-recon-bot"
           commit-email: ${{ secrets.JS_RECON_SIGNING_EMAIL }}
       - name: Merge main and dev
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.4.1-alpha.7 - (unreleased)
 
+### Changed
+
+- CI: bot commits (`chore: prettify code`, `chore: merge changes after release vX.Y.Z`) are now cryptographically signed via SSH (using [`shriyanss/verified-commit-action`](https://github.com/shriyanss/verified-commit-action)) and show as "Verified" on GitHub, under a dedicated `js-recon-bot` identity. The signing key is scoped to a `commit-signing` GitHub Environment so it's only readable by the jobs that need it, not the whole repo. `promote-js-recon.yml`'s Docker/GHCR publish job now reads `DOCKER_SECRET` from a similarly scoped `docker-publish` environment, and the Homebrew tap job no longer references a token secret. (`ci`)
+
 ## 1.4.1-alpha.6 - 2026-07-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## 1.4.1-alpha.7 - (unreleased)
+
 ## 1.4.1-alpha.6 - 2026-07-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,6 +350,16 @@ Releasing a new version touches three repos. Work on `dev` (js-recon, js-recon-r
 
 **Ordering is critical**: release js-recon first (including the GitHub release so CI publishes it to npm), then snapshot and PR js-recon-docs. This ensures the docs `version_check` CI step passes instead of failing due to a missing npm package.
 
+### Overview: automated stage → human approve → human-triggered promote
+
+npm's OIDC trusted publishing for this package is scoped to **`npm stage publish`**, not direct `npm publish`. That means every js-recon release has three distinct phases, only the first of which Claude can execute unattended:
+
+1. **Automated (Claude does this end-to-end):** bump version, update CHANGELOG, open and merge the `dev`→`main` PR (after CI is green and the user gives merge approval — never merge without it), create the GitHub release. That release triggers `publish-js-recon.yml`, which runs `version_check` → `audit` → `build` → `publish-npm` (stages to npm via OIDC, no token) → `merge_main_and_dev` — all fully automatic, no human input needed.
+2. **Human-only (cannot be scripted or delegated):** npm requires interactive 2FA to promote a staged package to actually live on the registry. Claude reports the stage id and waits; the user runs `npm stage approve <stage-id>` (or clicks "Approve" on npmjs.com) themselves, on their own machine or browser.
+3. **Human-triggered, then Claude drives it:** once the user confirms the package is live (e.g. "I've published on npm" / "go ahead"), Claude runs `gh workflow run promote-js-recon.yml -f version=<version>` and watches it to completion. This workflow (Homebrew tap, Docker, GHCR) installs from the published npm artifact rather than git source, so it can only run correctly after step 2 — that's why it's a separate manually-triggered workflow instead of chained onto `publish-js-recon.yml`.
+
+The detailed step-by-step is below; the numbering restarts at 10 for the docs phase since it's a separate concern from the npm/GitHub release phase.
+
 ### When a user asks to prepare a release
 
 Before writing any files, gather the current state:

--- a/README.md
+++ b/README.md
@@ -121,4 +121,3 @@ Please refer to the [Contributing](https://js-recon.io/contributing) page for de
 ## License
 
 JS Recon is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-

--- a/README.md
+++ b/README.md
@@ -121,3 +121,4 @@ Please refer to the [Contributing](https://js-recon.io/contributing) page for de
 ## License
 
 JS Recon is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shriyanss/js-recon",
-    "version": "1.4.1-alpha.6",
+    "version": "1.4.1-alpha.7",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,6 @@
 const githubURL = "https://github.com/shriyanss/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
-const version = "1.4.1-alpha.6";
+const version = "1.4.1-alpha.7";
 const toolDesc = "JavaScript Enumeration and SAST";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests
 


### PR DESCRIPTION
## 1.4.1-alpha.7 - (unreleased)

### Changed

- CI: bot commits (`chore: prettify code`, `chore: merge changes after release vX.Y.Z`) are now cryptographically signed via SSH (using [`shriyanss/verified-commit-action`](https://github.com/shriyanss/verified-commit-action)) and show as "Verified" on GitHub, under a dedicated `js-recon-bot` identity. The signing key is scoped to a `commit-signing` GitHub Environment so it's only readable by the jobs that need it, not the whole repo. `promote-js-recon.yml`'s Docker/GHCR publish job now reads `DOCKER_SECRET` from a similarly scoped `docker-publish` environment, and the Homebrew tap job no longer references a token secret. (`ci`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package to version `1.4.1-alpha.7`.

* **Documentation**
  * Added release notes covering improved commit signing and protected publishing workflows.
  * Clarified the staged release, approval, and promotion process.

* **Chores**
  * Strengthened automated release workflows with verified commit signing and scoped publishing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->