### PR TITLE
ci: restore homebrew-tap push auth via scoped homebrew-publish environment

### DIFF
--- a/.github/workflows/promote-js-recon.yml
+++ b/.github/workflows/promote-js-recon.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   update-homebrew-tap:
     runs-on: ubuntu-latest
+    environment: homebrew-publish
     steps:
       - name: Fetch published tarball and compute SHA256
         id: sha256
@@ -31,6 +32,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: shriyanss/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_GH_PAT }}
           path: homebrew-tap
 
       - name: Update formula fields


### PR DESCRIPTION
Cherry-pick of dev commit 1dcdffc. main was still missing this fix, so promote-js-recon.yml's Homebrew job failed with a 403 (workflow_dispatch always runs off the default branch's copy of the workflow file).

Wires update-homebrew-tap to the homebrew-publish environment and its HOMEBREW_TAP_GH_PAT secret, replacing the deleted HOMEBREW_TAP_TOKEN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Homebrew release promotion workflow with authenticated publishing and controlled environment handling.
  * No changes to application functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->