### PR TITLE
v1.4.1-alpha.8

### DIFF
--- a/.github/workflows/promote-js-recon.yml
+++ b/.github/workflows/promote-js-recon.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   update-homebrew-tap:
     runs-on: ubuntu-latest
+    environment: homebrew-publish
     steps:
       - name: Fetch published tarball and compute SHA256
         id: sha256
@@ -31,6 +32,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: shriyanss/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_GH_PAT }}
           path: homebrew-tap
 
       - name: Update formula fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
-## 1.4.1-alpha.7 - (unreleased)
+## 1.4.1-alpha.8 - (unreleased)
+
+### Changed
+
+- CI: `promote-js-recon.yml`'s Homebrew tap job now reads its push token (`HOMEBREW_TAP_GH_PAT`) from a scoped `homebrew-publish` GitHub Environment, restoring push access after the previous repo-wide `HOMEBREW_TAP_TOKEN` was retired. (`ci`)
+
+## 1.4.1-alpha.7 - 2026-07-14
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shriyanss/js-recon",
-    "version": "1.4.1-alpha.7",
+    "version": "1.4.1-alpha.8",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,6 @@
 const githubURL = "https://github.com/shriyanss/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
-const version = "1.4.1-alpha.7";
+const version = "1.4.1-alpha.8";
 const toolDesc = "JavaScript Enumeration and SAST";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests
 


### PR DESCRIPTION
## 1.4.1-alpha.8 - (unreleased)

### Changed

- CI: `promote-js-recon.yml`'s Homebrew tap job now reads its push token (`HOMEBREW_TAP_GH_PAT`) from a scoped `homebrew-publish` GitHub Environment, restoring push access after the previous repo-wide `HOMEBREW_TAP_TOKEN` was retired. (`ci`)