### PR TITLE
chore: migrate references to js-recon org

### DIFF
--- a/.github/workflows/build-and-prettify.yaml
+++ b/.github/workflows/build-and-prettify.yaml
@@ -144,7 +144,7 @@ jobs:
           # Make sure the action checks out the repository to the pull request branch
           ref: ${{ github.ref_name }}
       - name: Build docker container
-        run: docker build -t shriyanss/js-recon .
+        run: docker build -t js-recon/js-recon .
 
   integration-test-docker:
     needs: build-docker
@@ -159,13 +159,13 @@ jobs:
       - name: Checkout js-recon-labs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: shriyanss/js-recon-labs
+          repository: js-recon/js-recon-labs
           path: js-recon-labs
 
       - name: Checkout js-recon-rules
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: shriyanss/js-recon-rules
+          repository: js-recon/js-recon-rules
           path: js-recon-rules
 
       - name: Set up Node.js
@@ -175,7 +175,7 @@ jobs:
           cache: "npm"
 
       - name: Build js-recon Docker image
-        run: docker build -t shriyanss/js-recon .
+        run: docker build -t js-recon/js-recon .
 
       - name: Install vuln-all-rules app dependencies
         working-directory: js-recon-labs/next_js/vuln-all-rules
@@ -206,7 +206,7 @@ jobs:
             --network host \
             -v "$(pwd)/js-recon-rules:/home/pptruser/js-recon-rules" \
             --entrypoint /bin/bash \
-            shriyanss/js-recon \
+            js-recon/js-recon \
             -c 'mkdir -p ~/.js-recon && ln -sf /home/pptruser/js-recon-rules ~/.js-recon/rules && printf "http://localhost:3001\n" > /tmp/urls.txt && node build/index.js run -u /tmp/urls.txt -r ./js-recon-rules --no-sandbox -y -k'
           mkdir -p output
           docker cp js-recon-run:/home/pptruser/output/. ./output/ 2>/dev/null || true
@@ -236,13 +236,13 @@ jobs:
       - name: Checkout js-recon-labs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: shriyanss/js-recon-labs
+          repository: js-recon/js-recon-labs
           path: js-recon-labs
 
       - name: Checkout js-recon-rules
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: shriyanss/js-recon-rules
+          repository: js-recon/js-recon-rules
           path: js-recon-rules
 
       - name: Set up Node.js

--- a/.github/workflows/build-and-prettify.yaml
+++ b/.github/workflows/build-and-prettify.yaml
@@ -136,6 +136,8 @@ jobs:
         run: npm run build
   build-docker:
     needs: build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr_checker.yml
+++ b/.github/workflows/pr_checker.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Redirect PR to dev
-        if: github.head_ref != 'dev' || github.event.pull_request.head.repo.full_name != 'shriyanss/js-recon'
+        if: github.head_ref != 'dev' || github.event.pull_request.head.repo.full_name != 'js-recon/js-recon'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr edit $PR_NUMBER --base dev
-          gh pr comment $PR_NUMBER --body "This PR was targeting \`main\`, but only the \`dev\` branch of \`shriyanss/js-recon\` can merge directly into \`main\`. The target branch has been changed to \`dev\`."
+          gh pr comment $PR_NUMBER --body "This PR was targeting \`main\`, but only the \`dev\` branch of \`js-recon/js-recon\` can merge directly into \`main\`. The target branch has been changed to \`dev\`."

--- a/.github/workflows/promote-js-recon.yml
+++ b/.github/workflows/promote-js-recon.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Fetch published tarball and compute SHA256
         id: sha256
         run: |
-          npm pack "@shriyanss/js-recon@${VERSION}"
-          SHA=$(sha256sum "shriyanss-js-recon-${VERSION}.tgz" | awk '{print $1}')
+          npm pack "@js-recon/js-recon@${VERSION}"
+          SHA=$(sha256sum "js-recon-js-recon-${VERSION}.tgz" | awk '{print $1}')
           echo "sha256=${SHA}" >> "$GITHUB_OUTPUT"
         env:
           VERSION: ${{ inputs.version }}
@@ -45,14 +45,14 @@ jobs:
       - name: Check out homebrew-tap
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: shriyanss/homebrew-tap
+          repository: js-recon/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_GH_PAT }}
           path: homebrew-tap
 
       - name: Update formula fields
         working-directory: homebrew-tap
         run: |
-          sed -i "s|^  url \"https://registry\.npmjs\.org/@shriyanss/js-recon/-/js-recon-[^\"]*\"|  url \"https://registry.npmjs.org/@shriyanss/js-recon/-/js-recon-${VERSION}.tgz\"|" "${FORMULA}"
+          sed -i "s|^  url \"https://registry\.npmjs\.org/@js-recon/js-recon/-/js-recon-[^\"]*\"|  url \"https://registry.npmjs.org/@js-recon/js-recon/-/js-recon-${VERSION}.tgz\"|" "${FORMULA}"
           sed -i "s|^  sha256 \"[a-f0-9]*\"|  sha256 \"${SHA}\"|" "${FORMULA}"
         env:
           VERSION: ${{ inputs.version }}
@@ -71,35 +71,6 @@ jobs:
           VERSION: ${{ inputs.version }}
           FORMULA: ${{ steps.formula.outputs.formula }}
 
-  publish-docker:
-    runs-on: ubuntu-latest
-    environment: docker-publish
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Build and push to dockerhub
-        run: |
-          # login to docker
-          echo $DOCKER_SECRET | docker login -u shriyanss --password-stdin
-
-          # build the image from the published npm artifact
-          docker build -f Dockerfile.release --build-arg JS_RECON_VERSION=$VERSION -t shriyanss/js-recon:$VERSION .
-
-          # check if it is alpha or beta. default to latest
-          TAG="latest"
-          [[ "$VERSION" == *"beta"* ]] && TAG="beta"
-          [[ "$VERSION" == *"alpha"* ]] && TAG="alpha"
-
-          # tag again with whatever has been set
-          docker tag shriyanss/js-recon:$VERSION shriyanss/js-recon:$TAG
-
-          # push images with both tags
-          docker push shriyanss/js-recon:$VERSION
-          docker push shriyanss/js-recon:$TAG
-
-        env:
-          DOCKER_SECRET: ${{ secrets.DOCKER_SECRET }}
-          VERSION: ${{ inputs.version }}
-
   publish-ghcr:
     runs-on: ubuntu-latest
     permissions:
@@ -115,7 +86,7 @@ jobs:
       - name: Build and push to github container registry
         run: |
           # build the image from the published npm artifact
-          docker build -f Dockerfile.release --build-arg JS_RECON_VERSION=$VERSION -t ghcr.io/shriyanss/js-recon:$VERSION .
+          docker build -f Dockerfile.release --build-arg JS_RECON_VERSION=$VERSION -t ghcr.io/js-recon/js-recon:$VERSION .
 
           # check if it is alpha or beta. default to latest
           TAG="latest"
@@ -123,11 +94,11 @@ jobs:
           [[ "$VERSION" == *"alpha"* ]] && TAG="alpha"
 
           # tag again with whatever has been set
-          docker tag ghcr.io/shriyanss/js-recon:$VERSION ghcr.io/shriyanss/js-recon:$TAG
+          docker tag ghcr.io/js-recon/js-recon:$VERSION ghcr.io/js-recon/js-recon:$TAG
 
           # push images with both tags
-          docker push ghcr.io/shriyanss/js-recon:$VERSION
-          docker push ghcr.io/shriyanss/js-recon:$TAG
+          docker push ghcr.io/js-recon/js-recon:$VERSION
+          docker push ghcr.io/js-recon/js-recon:$TAG
 
         env:
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/rules-smoke-test.yaml
+++ b/.github/workflows/rules-smoke-test.yaml
@@ -17,13 +17,13 @@ jobs:
       - name: Checkout js-recon-labs
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: shriyanss/js-recon-labs
+          repository: js-recon/js-recon-labs
           path: js-recon-labs
 
       - name: Checkout js-recon-rules
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: shriyanss/js-recon-rules
+          repository: js-recon/js-recon-rules
           path: js-recon-rules
 
       - name: Set up Node.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.4.1-alpha.10 - 2026-07-15
+
+### Changed
+
+- The project has moved to the `js-recon` GitHub organization. The npm package is now published as **`@js-recon/js-recon`** (previously `@shriyanss/js-recon`) — update your install commands accordingly. Container images are now published only to `ghcr.io/js-recon/js-recon` (Docker Hub publishing has been discontinued). The Homebrew tap is now `js-recon/tap` (`brew tap js-recon/tap`), and the Terraform modules are published under the `js-recon/js-recon/<cloud>` registry namespace. (`all`, `ci`, `docker`, `homebrew`)
+
 ## 1.4.1-alpha.9 - 2026-07-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Homebrew: `brew install js-recon` now always installs the latest **stable** release instead of whichever version (including alphas/betas) was most recently promoted. `promote-js-recon.yml`'s Homebrew tap job is now channel-aware — it updates `Formula/js-recon-alpha.rb` / `Formula/js-recon-beta.rb` for prerelease promotions and leaves the main `Formula/js-recon.rb` (stable) formula untouched. Alpha/beta channels are now available via `brew install shriyanss/tap/js-recon-alpha` / `js-recon-beta`, mirroring the existing `:alpha`/`:beta` Docker/GHCR tags. (`ci`, `homebrew`)
+- Homebrew: `brew install js-recon` now always installs the latest **stable** release instead of whichever version (including alphas/betas) was most recently promoted. `promote-js-recon.yml`'s Homebrew tap job is now channel-aware — it updates `Formula/js-recon-alpha.rb` / `Formula/js-recon-beta.rb` for prerelease promotions and leaves the main `Formula/js-recon.rb` (stable) formula untouched. Alpha/beta channels are now available via `brew install js-recon/tap/js-recon-alpha` / `js-recon-beta`, mirroring the existing `:alpha`/`:beta` Docker/GHCR tags. (`ci`, `homebrew`)
 - `run` (batch mode, `-u <file>`): the generated OpenAPI spec and Postman collection (`mapped-openapi.json`, `mapped-openapi.postman_collection.json`) are no longer contaminated with endpoints from previously-processed targets in the same batch run. `openapiOutput` in `utility/globals.ts` is an accumulator that every map resolver pushes into, and it was never cleared between targets — so target N's output silently inherited every endpoint discovered for targets `1..N-1`. A new `clearOpenapiOutput()` is now called alongside the existing `clearJsUrls()`/`clearJsonUrls()` reset at the start of each target's pipeline. (`run`, `utility`)
 - `refactor`: when the remote CS-MAST-S signature lookup for the active tech/scat/branch combination comes back empty (e.g. a non-default `--scat` value not yet covered by the dataset), the run's final summary now prints an explicit, high-visibility recap block (`LIBRARY STRIPPING WAS SKIPPED FOR THIS RUN`, naming the tech/scat/branch) in addition to the existing inline warning. Previously this was a single line that could scroll by unnoticed mid-run, so batch/automated invocations could silently lose library stripping with no easy signal that the output still contains library code. (`refactor`)
 - `refactor -t next-webpack`: chunks whose module wrapper is a named `function` declaration (`function webpack_<id>(...)`, synthesized whenever the original bundle module was itself a `function` expression — the dominant form on real-world bundles) are now correctly recovered. Previously the traversal only visited `ArrowFunctionExpression` nodes, so these chunks were reported as `No module function found`, and in the rare cases where a nested arrow function's immediate parent happened to be an assignment, that unrelated inner fragment was captured as a false-positive "recovered" module. Both wrapper forms are now supported and the top-level check requires the wrapper to be a direct child of `Program`. Also fixes `next/validator.ts`'s `_generator` import, which was missing the `?? _generator` ESM interop fallback present in the react validator and broke under Vitest, blocking unit test coverage of this module. (`refactor`)
@@ -73,7 +73,7 @@
 ### Added
 
 - `sourcemaps`: new subcommand to extract original source files from `.map` sourcemaps without running the full pipeline. Accepts a single `.map` file or a directory of `.map` files via `-i`/`--input`; writes recovered sources to `-o`/`--output` (default: `extracted`).
-- Homebrew tap distribution: `brew tap shriyanss/tap && brew install js-recon` installs js-recon via the `shriyanss/homebrew-tap` Homebrew tap. The formula (`Formula/js-recon.rb`) auto-updates on every npm publish via the `update-homebrew-tap` CI job in `publish-js-recon.yml`.
+- Homebrew tap distribution: `brew tap js-recon/tap && brew install js-recon` installs js-recon via the `js-recon/homebrew-tap` Homebrew tap. The formula (`Formula/js-recon.rb`) auto-updates on every npm publish via the `update-homebrew-tap` CI job in `publish-js-recon.yml`.
 
 ### Changed
 
@@ -615,7 +615,7 @@
 
 - Added `analyze` module
 - Added analysis of OpenAPI spec file (requestEngine)
-- Use the repo https://github.com/shriyanss/js-recon-rules to remotely store and download rules
+- Use the repo https://github.com/js-recon/js-recon-rules to remotely store and download rules
 
 ### Changed
 
@@ -690,7 +690,7 @@
 
 ### Fixed
 
-- Fixed [issue 30](https://github.com/shriyanss/js-recon/issues/30): `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`
+- Fixed [issue 30](https://github.com/js-recon/js-recon/issues/30): `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`
 
 ## 1.1.3-alpha.2 - 2025.07.23
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,8 +389,8 @@ Before writing any files, gather the current state:
 
 6. **Open PR** using `gh pr create`:
 
-    | Repo                 | Source | Target | Title                                       | Body                                 |
-    | -------------------- | ------ | ------ | ------------------------------------------- | ------------------------------------ |
+    | Repo                | Source | Target | Title                                       | Body                                 |
+    | ------------------- | ------ | ------ | ------------------------------------------- | ------------------------------------ |
     | `js-recon/js-recon` | `dev`  | `main` | bare version string (e.g. `v1.3.1-alpha.4`) | raw `## <version>` changelog section |
 
 7. **Monitor js-recon CI** — use `gh pr checks <pr-number> --repo js-recon/js-recon` and poll until all checks complete. Handle CodeRabbit suggestions (see below). Do NOT merge — wait for user approval.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,7 @@ When `-r` points to a single file, only that rule is loaded. When it points to a
 
 The `rules-smoke-test` GitHub Actions workflow (`.github/workflows/rules-smoke-test.yaml`) runs on every non-main push. It:
 
-1. Checks out `shriyanss/js-recon-labs` and `shriyanss/js-recon-rules` alongside js-recon.
+1. Checks out `js-recon/js-recon-labs` and `js-recon/js-recon-rules` alongside js-recon.
 2. Builds js-recon and the `next_js/vuln-all-rules` lab app.
 3. Starts the lab app on port 3001.
 4. Runs `node build/index.js run -u http://localhost:3001 -r ./js-recon-rules --no-sandbox -y -k`.
@@ -383,7 +383,7 @@ Before writing any files, gather the current state:
 
 3. **Update README** — ensure the Commands table in `README.md` lists every subcommand declared in `src/index.ts`. The `refactor` and `load` subcommands are easy to miss — explicitly verify they are present.
 
-4. **Update rules** (`js-recon-rules` repo, `dev` branch) — if there are substantive unreleased commits (not just merge/cleanup commits), update `CHANGELOG.md` and `version.txt`, push to `dev`, and open a PR (`shriyanss/js-recon-rules` dev→main, title=rules version, body=rules changelog section).
+4. **Update rules** (`js-recon-rules` repo, `dev` branch) — if there are substantive unreleased commits (not just merge/cleanup commits), update `CHANGELOG.md` and `version.txt`, push to `dev`, and open a PR (`js-recon/js-recon-rules` dev→main, title=rules version, body=rules changelog section).
 
 5. **Push** `js-recon` dev branch: `git push origin dev`
 
@@ -391,15 +391,15 @@ Before writing any files, gather the current state:
 
     | Repo                 | Source | Target | Title                                       | Body                                 |
     | -------------------- | ------ | ------ | ------------------------------------------- | ------------------------------------ |
-    | `shriyanss/js-recon` | `dev`  | `main` | bare version string (e.g. `v1.3.1-alpha.4`) | raw `## <version>` changelog section |
+    | `js-recon/js-recon` | `dev`  | `main` | bare version string (e.g. `v1.3.1-alpha.4`) | raw `## <version>` changelog section |
 
-7. **Monitor js-recon CI** — use `gh pr checks <pr-number> --repo shriyanss/js-recon` and poll until all checks complete. Handle CodeRabbit suggestions (see below). Do NOT merge — wait for user approval.
+7. **Monitor js-recon CI** — use `gh pr checks <pr-number> --repo js-recon/js-recon` and poll until all checks complete. Handle CodeRabbit suggestions (see below). Do NOT merge — wait for user approval.
 
 8. **Create GitHub release** — after the PR is merged to main:
 
     ```bash
     gh release create v<version> \
-      --repo shriyanss/js-recon \
+      --repo js-recon/js-recon \
       --title "v<version>" \
       --notes "<changelog section>" \
       --prerelease    # set for any version containing "alpha" or "beta"
@@ -411,46 +411,46 @@ Before writing any files, gather the current state:
 
     Previous tag is left to GitHub's automatic detection (do not set `--target` or `--tag` beyond the tag name itself).
 
-9. **Wait for npm stage publish** — monitor the release pipeline: `gh run list --repo shriyanss/js-recon --workflow "Publish JS Recon"`. `publish-npm` uses OIDC trusted publishing (`npm stage publish`, no token) to _stage_ the release — this is NOT the same as it being live.
+9. **Wait for npm stage publish** — monitor the release pipeline: `gh run list --repo js-recon/js-recon --workflow "Publish JS Recon"`. `publish-npm` uses OIDC trusted publishing (`npm stage publish`, no token) to _stage_ the release — this is NOT the same as it being live.
 
 10. **Approve the staged release** — npm's staged-publish approval always requires interactive 2FA, so this step can never be automated or scripted:
 
-    - Find the stage id: `npm stage list @shriyanss/js-recon` (or the "Staged Packages" tab on npmjs.com)
+    - Find the stage id: `npm stage list @js-recon/js-recon` (or the "Staged Packages" tab on npmjs.com)
     - Approve it: `npm stage approve <stage-id>` (prompts for 2FA), or click "Approve" on npmjs.com
-    - Confirm it's live: `npm view @shriyanss/js-recon@<version>`
+    - Confirm it's live: `npm view @js-recon/js-recon@<version>`
 
 11. **Manually trigger the promote workflow** — once the release is live, run `promote-js-recon.yml` to update Homebrew and publish the Docker/GHCR images:
 
     ```bash
-    gh workflow run promote-js-recon.yml --repo shriyanss/js-recon -f version=<version>
+    gh workflow run promote-js-recon.yml --repo js-recon/js-recon -f version=<version>
     ```
 
-    This workflow installs js-recon from the published npm registry artifact (`npm pack`/`npm install <pkg>@<version>`) rather than building from git source — an additional supply-chain check that the shipped images/formula match exactly what was approved on npm. Monitor: `gh run list --repo shriyanss/js-recon --workflow "Promote JS Recon Release"`.
+    This workflow installs js-recon from the published npm registry artifact (`npm pack`/`npm install <pkg>@<version>`) rather than building from git source — an additional supply-chain check that the shipped images/formula match exactly what was approved on npm. Monitor: `gh run list --repo js-recon/js-recon --workflow "Promote JS Recon Release"`.
 
 ### Homebrew tap (manual, part of `promote-js-recon.yml`)
 
 The `update-homebrew-tap` job (now in `promote-js-recon.yml`, triggered per step 11 above) is **channel-aware** — it updates a different formula depending on the promoted version string, so `brew install js-recon` always tracks the real npm `latest` (stable) release instead of whatever was most recently promoted:
 
 1. Picks the target formula from `inputs.version`: `Formula/js-recon-alpha.rb` if the version contains `alpha`, `Formula/js-recon-beta.rb` if it contains `beta`, otherwise `Formula/js-recon.rb` (stable).
-2. `npm pack @shriyanss/js-recon@<version>` — downloads the exact published tarball from the registry and computes its SHA256 locally (no dependency on a public tarball URL being reachable yet)
-3. Checks out `shriyanss/homebrew-tap` using `HOMEBREW_TAP_GH_PAT` (a fine-grained PAT stored in the `homebrew-publish` environment secrets, scoped to `homebrew-tap` repo `Contents: Read and write` only — automatically masked in all log output, never echoed)
+2. `npm pack @js-recon/js-recon@<version>` — downloads the exact published tarball from the registry and computes its SHA256 locally (no dependency on a public tarball URL being reachable yet)
+3. Checks out `js-recon/homebrew-tap` using `HOMEBREW_TAP_GH_PAT` (a fine-grained PAT stored in the `homebrew-publish` environment secrets, scoped to `homebrew-tap` repo `Contents: Read and write` only — automatically masked in all log output, never echoed)
 4. Updates `url` and `sha256` in the target formula via anchored `sed` — the formula has no explicit `version` field; Homebrew derives it from the `url`
 5. Commits `chore: update <formula> to <version>` and pushes
 
 The `js-recon-alpha` / `js-recon-beta` formulas are `keg_only` with a custom reason string (they install the same `js-recon` binary name as the stable formula, so they can't auto-link into the shared `bin/` without conflicting). Homebrew's built-in `:versioned_formula` reason only applies to numeric `@X.Y`-style names, which is why these use plain `-alpha`/`-beta` filenames rather than the `@`-suffix convention.
 
-Monitor: `gh run list --repo shriyanss/homebrew-tap --workflow ci.yml`
+Monitor: `gh run list --repo js-recon/homebrew-tap --workflow ci.yml`
 
-**If the job fails:** manually update: `npm pack @shriyanss/js-recon@<version> && sha256sum shriyanss-js-recon-<version>.tgz`, edit the correct formula (stable vs `-alpha`/`-beta`, per the version string), commit, and push to `shriyanss/homebrew-tap`.
+**If the job fails:** manually update: `npm pack @js-recon/js-recon@<version> && sha256sum js-recon-js-recon-<version>.tgz`, edit the correct formula (stable vs `-alpha`/`-beta`, per the version string), commit, and push to `js-recon/homebrew-tap`.
 
 **One-time setup** (must be done before the first release, already completed):
 
-- `shriyanss/homebrew-tap` is a public GitHub repo with formulas at `Formula/js-recon.rb` (stable), `Formula/js-recon-alpha.rb`, and `Formula/js-recon-beta.rb`
-- `HOMEBREW_TAP_GH_PAT` is a fine-grained PAT stored in `shriyanss/js-recon` → Settings → Environments → `homebrew-publish` → Environment secrets, scoped exclusively to the `homebrew-tap` repo
+- `js-recon/homebrew-tap` is a public GitHub repo with formulas at `Formula/js-recon.rb` (stable), `Formula/js-recon-alpha.rb`, and `Formula/js-recon-beta.rb`
+- `HOMEBREW_TAP_GH_PAT` is a fine-grained PAT stored in `js-recon/js-recon` → Settings → Environments → `homebrew-publish` → Environment secrets, scoped exclusively to the `homebrew-tap` repo
 
 ### Docker / GHCR images (manual, part of `promote-js-recon.yml`)
 
-`publish-docker` and `publish-ghcr` (now in `promote-js-recon.yml`) build from `Dockerfile.release` instead of the default `Dockerfile`. `Dockerfile.release` runs `npm install -g @shriyanss/js-recon@<version>` against the live registry rather than copying local source and building — the published images are provably built from the approved npm artifact. The default `Dockerfile` (source build) is unchanged and still used for local/dev builds.
+`publish-docker` and `publish-ghcr` (now in `promote-js-recon.yml`) build from `Dockerfile.release` instead of the default `Dockerfile`. `Dockerfile.release` runs `npm install -g @js-recon/js-recon@<version>` against the live registry rather than copying local source and building — the published images are provably built from the approved npm artifact. The default `Dockerfile` (source build) is unchanged and still used for local/dev builds.
 
 ### Phase 2 — js-recon-docs (after npm is live)
 
@@ -472,7 +472,7 @@ Monitor: `gh run list --repo shriyanss/homebrew-tap --workflow ci.yml`
     git -C ../js-recon-docs add .
     git -C ../js-recon-docs commit -m "docs: snapshot v<version>"
     git -C ../js-recon-docs push origin stage
-    gh pr create --repo shriyanss/js-recon-docs \
+    gh pr create --repo js-recon/js-recon-docs \
       --head stage --base main \
       --title "v<version>" \
       --body "<brief summary of doc changes>"
@@ -485,7 +485,7 @@ Monitor: `gh run list --repo shriyanss/homebrew-tap --workflow ci.yml`
 After any PR is created, poll for review comments:
 
 ```bash
-gh api repos/shriyanss/js-recon/pulls/<pr>/comments
+gh api repos/js-recon/js-recon/pulls/<pr>/comments
 ```
 
 For each suggestion: apply a fix commit to `dev` for correctness bugs or convention violations. Skip trivial style preferences. The PR updates automatically.
@@ -498,7 +498,7 @@ Do NOT merge any PR. Once all CI checks pass and CodeRabbit suggestions are addr
 
 When a user asks to fix or implement a GitHub issue, follow these steps:
 
-1. **Read the issue** — `gh issue view <number> --repo shriyanss/js-recon`
+1. **Read the issue** — `gh issue view <number> --repo js-recon/js-recon`
 
 2. **Implement** — make the code, docs, and exit-code changes required. Follow all existing conventions (subcommand structure, CHANGELOG format, README Commands table, js-recon-docs modules page, exit_codes.md). Document new exit codes in both `CLAUDE.md` and `js-recon-docs/docs/docs/exit_codes.md`.
 
@@ -506,14 +506,14 @@ When a user asks to fix or implement a GitHub issue, follow these steps:
 
 4. **Commit and push to `dev`** — use a `feat(...)` or `fix(...)` commit message. Push to `origin dev`.
 
-5. **Monitor CI** — `gh run list --repo shriyanss/js-recon --branch dev --limit 3`. Watch the `Build & Prettify Code` run. If the `version_check` job fails because `CHANGELOG.md` top version doesn't match `package.json`, bump `package.json` and `src/globalConfig.ts` to match (with a `chore: bump version to <X>` commit) and repush.
+5. **Monitor CI** — `gh run list --repo js-recon/js-recon --branch dev --limit 3`. Watch the `Build & Prettify Code` run. If the `version_check` job fails because `CHANGELOG.md` top version doesn't match `package.json`, bump `package.json` and `src/globalConfig.ts` to match (with a `chore: bump version to <X>` commit) and repush.
 
 6. **Pull prettifier commit** — after CI passes, `git pull origin dev` to pick up the `chore: prettify code` auto-commit.
 
 7. **Close the issue** — once all CI checks pass:
 
     ```bash
-    gh issue close <number> --repo shriyanss/js-recon --comment \
+    gh issue close <number> --repo js-recon/js-recon --comment \
       "Implemented in commit <short-sha> on the \`dev\` branch. Will be released in **v<version>**."
     ```
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -13,10 +13,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 ARG JS_RECON_VERSION
-RUN npm install -g @shriyanss/js-recon@${JS_RECON_VERSION}
+RUN npm install -g @js-recon/js-recon@${JS_RECON_VERSION}
 
 USER pptruser
-RUN "$(npm root -g)/@shriyanss/js-recon/node_modules/.bin/puppeteer" browsers install chrome && \
+RUN "$(npm root -g)/@js-recon/js-recon/node_modules/.bin/puppeteer" browsers install chrome && \
     for zip in /home/pptruser/.cache/puppeteer/chrome/*-chrome-linux64.zip; do \
         [ -f "$zip" ] || break; \
         version="${zip%-chrome-linux64.zip}"; version="${version##*/}"; \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JS Recon
 
-![NPM Licence](https://img.shields.io/npm/l/%40shriyanss%2Fjs-recon) ![GitHub repo size](https://img.shields.io/github/repo-size/shriyanss/js-recon) ![NPM Downloads](https://img.shields.io/npm/dm/%40shriyanss%2Fjs-recon) ![GitHub commit activity (dev)](https://img.shields.io/github/commit-activity/w/shriyanss/js-recon/dev) ![NPM Last Update](https://img.shields.io/npm/last-update/%40shriyanss%2Fjs-recon) ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/shriyanss/js-recon)
+![NPM Licence](https://img.shields.io/npm/l/%40js-recon%2Fjs-recon) ![GitHub repo size](https://img.shields.io/github/repo-size/js-recon/js-recon) ![NPM Downloads](https://img.shields.io/npm/dm/%40js-recon%2Fjs-recon) ![GitHub commit activity (dev)](https://img.shields.io/github/commit-activity/w/js-recon/js-recon/dev) ![NPM Last Update](https://img.shields.io/npm/last-update/%40js-recon%2Fjs-recon) ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/js-recon/js-recon)
 
 <p align="center">
   <a href="https://js-recon.io">
@@ -17,15 +17,15 @@ It can also reconstruct HTTP requests that the app makes to the server, and outp
 ### Homebrew (macOS and Linux)
 
 ```bash
-brew tap shriyanss/tap
+brew tap js-recon/tap
 brew install js-recon
 ```
 
 This always installs the latest **stable** release. For the latest alpha or beta prerelease instead:
 
 ```bash
-brew install shriyanss/tap/js-recon-alpha
-brew install shriyanss/tap/js-recon-beta
+brew install js-recon/tap/js-recon-alpha
+brew install js-recon/tap/js-recon-beta
 ```
 
 To update:
@@ -43,7 +43,7 @@ This tool requires Node.JS and `npm` to be installed. The [official download pag
 To install the tool globally, run:
 
 ```bash
-npm i -g @shriyanss/js-recon
+npm i -g @js-recon/js-recon
 ```
 
 For detailed installation and setup process, please refer to the [Installation page](https://js-recon.io/docs/docs/installation)
@@ -116,10 +116,10 @@ For detailed guides, command options, and advanced usage examples, please check 
 ## Labs
 
 <p align="center">
-  <img src="https://github.com/shriyanss/js-recon-labs/blob/main/static/labs-banner.png?raw=true" alt="JS Recon Labs" width="300"/>
+  <img src="https://github.com/js-recon/js-recon-labs/blob/main/static/labs-banner.png?raw=true" alt="JS Recon Labs" width="300"/>
 </p>
 
-Labs to test JS Recon tool are available [here](https://github.com/shriyanss/js-recon-labs). Walkthroughs are available [here](https://js-recon.io/labs).
+Labs to test JS Recon tool are available [here](https://github.com/js-recon/js-recon-labs). Walkthroughs are available [here](https://js-recon.io/labs).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ For detailed guides, command options, and advanced usage examples, please check 
   <img src="https://github.com/js-recon/js-recon-labs/blob/main/static/labs-banner.png?raw=true" alt="JS Recon Labs" width="300"/>
 </p>
 
-Labs to test JS Recon tool are available [here](https://github.com/js-recon/js-recon-labs). Walkthroughs are available [here](https://js-recon.io/labs).
+Labs to test JS Recon tool are available in the [JS Recon Labs repository](https://github.com/js-recon/js-recon-labs). [Labs walkthroughs](https://js-recon.io/labs) are also available.
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@shriyanss/js-recon",
+    "name": "@js-recon/js-recon",
     "version": "1.4.1-alpha.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@shriyanss/js-recon",
+            "name": "@js-recon/js-recon",
             "version": "1.4.1-alpha.5",
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@js-recon/js-recon",
-    "version": "1.4.1-alpha.5",
+    "version": "1.4.1-alpha.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@js-recon/js-recon",
-            "version": "1.4.1-alpha.5",
+            "version": "1.4.1-alpha.10",
             "license": "MIT",
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.102.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@shriyanss/js-recon",
+    "name": "@js-recon/js-recon",
     "version": "1.4.1-alpha.9",
     "description": "JS Recon Tool",
     "main": "build/index.js",
@@ -14,7 +14,7 @@
         "test": "vitest run",
         "test:watch": "vitest",
         "test:build": "node build/index.js -h",
-        "cleanup": "rm -rf build output output_refactored .resp_cache.json endpoints.json extracted_urls{.txt,.json,-openapi.json} strings.json mapped{-openapi.json,.json,-openapi.postman_collection.json} analyze.json test{.yaml,.js} shriyanss-js-recon-*.tgz js-recon.db report.{html,md} js_recon_run_output *_test.js extracted/ research.json results* out.* && tsc"
+        "cleanup": "rm -rf build output output_refactored .resp_cache.json endpoints.json extracted_urls{.txt,.json,-openapi.json} strings.json mapped{-openapi.json,.json,-openapi.postman_collection.json} analyze.json test{.yaml,.js} js-recon-js-recon-*.tgz js-recon.db report.{html,md} js_recon_run_output *_test.js extracted/ research.json results* out.* && tsc"
     },
     "keywords": [],
     "author": "Shriyans Sudhi",
@@ -61,12 +61,12 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/shriyanss/js-recon.git"
+        "url": "git+https://github.com/js-recon/js-recon.git"
     },
     "bugs": {
-        "url": "https://github.com/shriyanss/js-recon/issues"
+        "url": "https://github.com/js-recon/js-recon/issues"
     },
-    "homepage": "https://github.com/shriyanss/js-recon#readme",
+    "homepage": "https://github.com/js-recon/js-recon#readme",
     "devDependencies": {
         "@types/babel__traverse": "^7.28.0",
         "@types/better-sqlite3": "^7.6.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@js-recon/js-recon",
-    "version": "1.4.1-alpha.9",
+    "version": "1.4.1-alpha.10",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/src/analyze/helpers/initRules.ts
+++ b/src/analyze/helpers/initRules.ts
@@ -14,7 +14,7 @@ import extract from "extract-zip";
  */
 const downloadRules = async (homeDir: string): Promise<void> => {
     console.log(chalk.cyan("[i] Rules not found. Downloading from GitHub..."));
-    const response = await fetch("https://api.github.com/repos/shriyanss/js-recon-rules/releases/latest");
+    const response = await fetch("https://api.github.com/repos/js-recon/js-recon-rules/releases/latest");
     const release = await response.json();
     const zipballUrl = release.zipball_url;
 
@@ -102,7 +102,7 @@ const initRules = async (): Promise<void> => {
     // also, if the version.txt exist, check if the version.txt is latest as per the latest release on github
     const version = fs.readFileSync(versionPath, "utf8").trim();
     try {
-        const response = await fetch("https://api.github.com/repos/shriyanss/js-recon-rules/releases/latest");
+        const response = await fetch("https://api.github.com/repos/js-recon/js-recon-rules/releases/latest");
         const release = await response.json();
         const release_tag_name = release.tag_name;
         if (`v${version}` !== release_tag_name) {

--- a/src/analyze/helpers/initRules.ts
+++ b/src/analyze/helpers/initRules.ts
@@ -36,8 +36,7 @@ const downloadRules = async (homeDir: string): Promise<void> => {
     // Find the extracted directory
     const files = fs.readdirSync(extractPath);
     const extractedDir = files.find(
-        (file) =>
-            fs.statSync(path.join(extractPath, file)).isDirectory() && file.startsWith("js-recon-js-recon-rules-")
+        (file) => fs.statSync(path.join(extractPath, file)).isDirectory() && file.startsWith("js-recon-js-recon-rules-")
     );
 
     if (extractedDir) {

--- a/src/analyze/helpers/initRules.ts
+++ b/src/analyze/helpers/initRules.ts
@@ -37,7 +37,7 @@ const downloadRules = async (homeDir: string): Promise<void> => {
     const files = fs.readdirSync(extractPath);
     const extractedDir = files.find(
         (file) =>
-            fs.statSync(path.join(extractPath, file)).isDirectory() && file.startsWith("shriyanss-js-recon-rules-")
+            fs.statSync(path.join(extractPath, file)).isDirectory() && file.startsWith("js-recon-js-recon-rules-")
     );
 
     if (extractedDir) {

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,6 @@
 const githubURL = "https://github.com/js-recon/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
-const version = "1.4.1-alpha.9";
+const version = "1.4.1-alpha.10";
 const toolDesc = "JavaScript Enumeration and SAST";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests
 

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,4 +1,4 @@
-const githubURL = "https://github.com/shriyanss/js-recon";
+const githubURL = "https://github.com/js-recon/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
 const version = "1.4.1-alpha.9";
 const toolDesc = "JavaScript Enumeration and SAST";

--- a/src/report/utility/genHtml.ts
+++ b/src/report/utility/genHtml.ts
@@ -176,7 +176,7 @@ const html = async (
         home: await marked.parse(analyzeMarkdown),
         mappedJson: await marked.parse(mappedJsonMarkdown),
         dataTables: dataTablesHtml,
-        about: `# About\n\n The documentation for this tool is available at [JS Recon Docs](https://js-recon.io/).\n\n## Version\n\nThis report is generated with JS Recon [v${CONFIG.version}](https://github.com/shriyanss/js-recon/releases/tag/v${CONFIG.version}).`,
+        about: `# About\n\n The documentation for this tool is available at [JS Recon Docs](https://js-recon.io/).\n\n## Version\n\nThis report is generated with JS Recon [v${CONFIG.version}](https://github.com/js-recon/js-recon/releases/tag/v${CONFIG.version}).`,
     }).replace(/</g, "\\u003c")}
   </script>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>


### PR DESCRIPTION
Migrates all references from the `shriyanss` namespace to the new `js-recon` org.

- npm scope renamed `@shriyanss/js-recon` → `@js-recon/js-recon` (package.json, lockfile, Dockerfile.release, source labels)
- Docker: GHCR retargeted to `ghcr.io/js-recon/js-recon`; Docker Hub publish job removed from `promote-js-recon.yml`
- GitHub URL references (repository/bugs/homepage, README badges, cross-repo checkouts, rules download URL in initRules.ts)
- Homebrew tap checkout → `js-recon/homebrew-tap`

Part of gitlab.lan/root/js-recon-internal-docs#56.

Note: `dev` has a ruleset requiring 5 status checks, so this goes via PR instead of direct push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the application identity to `js-recon`, including version `1.4.1-alpha.10`.
  - Added updated installation and distribution paths for npm, Homebrew, container images, and Terraform integrations.
  - Updated generated reports and issue links to the new project location.

- **Documentation**
  - Refreshed README, changelog, and release guidance with the latest installation commands and repository locations.

- **Bug Fixes**
  - Rule initialization now retrieves the latest rules release from the updated repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->