### PR TITLE
fix: verify-docker-install non-root permission issue

### DIFF
--- a/.github/workflows/promote-js-recon.yml
+++ b/.github/workflows/promote-js-recon.yml
@@ -198,13 +198,19 @@ jobs:
 
       - name: Run containerized js-recon against the lab app
         run: |
+          # The release image runs as the non-root `pptruser` (see Dockerfile.release),
+          # so a bind-mounted host directory landing inside its home dir inherits the
+          # host-side owner/perms and can be unwritable to that user. Mount outside
+          # $HOME with permissive perms and point js-recon at it explicitly via `-o`
+          # rather than relying on its default CWD-relative output path.
           mkdir -p /tmp/docker-output
+          chmod 777 /tmp/docker-output
           echo "http://localhost:3001" > /tmp/docker-smoke-urls.txt
           docker run --rm --network host \
-            -v /tmp/docker-output:/home/pptruser/output \
-            -v /tmp/docker-smoke-urls.txt:/home/pptruser/urls.txt \
+            -v /tmp/docker-output:/tmp/js-recon-output \
+            -v /tmp/docker-smoke-urls.txt:/tmp/urls.txt \
             ghcr.io/js-recon/js-recon:${VERSION} \
-            run -u /home/pptruser/urls.txt --no-sandbox -y -k
+            run -u /tmp/urls.txt -o /tmp/js-recon-output --no-sandbox -y -k
         env:
           VERSION: ${{ inputs.version }}
 


### PR DESCRIPTION
Root cause of the remaining verify-docker-install failure: `Dockerfile.release` drops to non-root `pptruser` before `ENTRYPOINT`. Bind-mounting the host output dir at `/home/pptruser/output` made js-recon try to write into a directory whose ownership came from the host side (the GitHub Actions runner user), which `pptruser` can't write to — the container crashed silently right after browser launch.

Fix: mount outside $HOME (`/tmp/js-recon-output`, `chmod 777`'d first) and pass `-o <dir>` explicitly to `run` instead of relying on the default CWD-relative output path — same approach `js-recon-action`'s entrypoint.sh uses to sidestep this class of bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker-based verification reliability by ensuring smoke-test output and URL files are written to accessible temporary locations.
  * Resolved permission-related issues when running release-image checks as a non-root user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->