### PR TITLE
v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 1.4.2 - (unreleased)
+
+### Fixed
+
+- Front-end framework detection (`lazyload`/`run`'s first step) could stall for a very long time on sites with many third-party script tags (analytics, tag managers, ad SDKs, etc.). `checkVueJS` and `checkReact` (`techDetect/`) fetched every `<script src>`/`<link rel="modulepreload">` URL referenced on the page — including third-party and `data:` URI ones — with no same-origin restriction, and each of those fetches could retry up to 10 times against an unreachable/slow host. Both checks now only fetch same-origin assets during detection, matching the intent already documented for this kind of check. (`lazyload`, `run`)
+
+### Added
+
+- `lazyload`/`run`: added a `--detection-timeout <seconds>` flag (default `30`, `0` disables) that bounds the front-end framework detection step. If it fires, detection falls back to the same "framework not detected" path used for a genuine no-match. (`lazyload`, `run`)
+
 ## 1.4.1 - 2026-07-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - `lazyload`/`run`: added a `--detection-timeout <seconds>` flag (default `30`, `0` disables) that bounds the front-end framework detection step. If it fires, detection falls back to the same "framework not detected" path used for a genuine no-match. (`lazyload`, `run`)
+- `run`: added a `--proxy-waf-fallback` flag. When a proxy is configured (`--proxy-config`), it runs the same feasibility check as `proxy --feasibility` against each target before processing it, and automatically decides whether to use the proxy: skips it if no firewall/WAF is detected without a proxy, keeps using it if it bypasses a detected firewall, or skips the target (new exit code 29 in single-URL mode) if the proxy can't bypass it. (`run`, `proxy`)
 
 ## 1.4.1 - 2026-07-27
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@js-recon/js-recon",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "JS Recon Tool",
     "main": "build/index.js",
     "type": "module",

--- a/src/__tests__/proxy/checkFeasibility.test.ts
+++ b/src/__tests__/proxy/checkFeasibility.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { determineFeasibilityOutcome } from "../../proxy/checkFeasibility.js";
+
+describe("determineFeasibilityOutcome", () => {
+    it("returns code 27 when no firewall is detected without a proxy", () => {
+        const outcome = determineFeasibilityOutcome(false, false);
+        expect(outcome.code).toBe(27);
+    });
+
+    it("returns code 27 regardless of the with-proxy result when unblocked without a proxy", () => {
+        const outcome = determineFeasibilityOutcome(false, true);
+        expect(outcome.code).toBe(27);
+    });
+
+    it("returns code 28 when the firewall is detected both without and with the proxy", () => {
+        const outcome = determineFeasibilityOutcome(true, true);
+        expect(outcome.code).toBe(28);
+    });
+
+    it("returns code 0 when the firewall is detected without the proxy but bypassed with it", () => {
+        const outcome = determineFeasibilityOutcome(true, false);
+        expect(outcome.code).toBe(0);
+    });
+});

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -1,6 +1,6 @@
 const githubURL = "https://github.com/js-recon/js-recon";
 const modulesDocs = "https://js-recon.io/docs/category/modules";
-const version = "1.4.1";
+const version = "1.4.2";
 const toolDesc = "JavaScript Enumeration and SAST";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,8 +276,12 @@ program
     )
     .option("-c, --config <config>", "Name of the config file", ".proxy_config.json")
     .option("-l, --list", "List all the API created by this tool [aws method]", false)
-    .option("--feasibility", "Check feasibility of API Gateway [aws method]", false)
-    .option("--feasibility-url <url>", "URL to check feasibility of [aws method]")
+    .option(
+        "--feasibility",
+        "Check whether a firewall/WAF blocks the target directly and, if so, whether the proxy method (--proxy-method, or the one already configured via -i/--init) bypasses it",
+        false
+    )
+    .option("--feasibility-url <url>", "URL to check feasibility of")
     .option(
         "--proxy-method <method>",
         "Proxy method to configure with -i/--init: aws, socks, http, or oxylabs (omit for an interactive prompt)"

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,11 @@ program
     .option("--max-iterations <iterations>", "Maximum number of recursive crawl iterations", "10")
     .option("--max-js-size <mb>", "Maximum JS file size in MB to parse (Vue only)", "2")
     .option("--lazyload-timeout <minutes>", "Hard timeout for the lazyload module in minutes (0 = no timeout)", "30")
+    .option(
+        "--detection-timeout <seconds>",
+        "Timeout for front-end framework detection in seconds (0 = no timeout)",
+        "30"
+    )
     .option("--max-pages <pages>", "Maximum HTML pages to visit during Next.js crawl (0 = unlimited)", "200")
     .option(
         "--include-methods <methods>",
@@ -199,7 +204,8 @@ program
             Number(cmd.lazyloadTimeout) * 60 * 1000,
             Number(cmd.maxPages),
             includeMethods,
-            excludeMethods
+            excludeMethods,
+            Number(cmd.detectionTimeout) * 1000
         );
     });
 
@@ -557,6 +563,11 @@ program
     .option("--max-iterations <iterations>", "Maximum number of recursive crawl iterations", "10")
     .option("--max-js-size <mb>", "Maximum JS file size in MB to parse (Vue only)", "2")
     .option("--lazyload-timeout <minutes>", "Hard timeout for each lazyload step in minutes (0 = no timeout)", "30")
+    .option(
+        "--detection-timeout <seconds>",
+        "Timeout for front-end framework detection in seconds (0 = no timeout)",
+        "30"
+    )
     .option("--max-heap <mb>", "V8 heap size cap in MB (0 = all available RAM)")
     .option("--max-pages <pages>", "Maximum HTML pages to visit during Next.js crawl (0 = unlimited)", "200")
     .option(

--- a/src/index.ts
+++ b/src/index.ts
@@ -543,6 +543,11 @@ program
     .option("-t, --threads <threads>", "Number of threads to use", "1")
     .option("--proxy-config <file>", "Proxy config file (generated via the `proxy` module)", ".proxy_config.json")
     .option("--ignore-proxy-env", "Skip JS_RECON_* proxy environment variables during resolution", false)
+    .option(
+        "--proxy-waf-fallback",
+        "Before each target, check whether the configured proxy is needed and can bypass a WAF/firewall (reuses the `proxy --feasibility` logic); skip the target if the proxy can't bypass it",
+        false
+    )
     .option("--cache-file <file>", "File to store response cache", ".resp_cache.json")
     .option("--disable-cache", "Disable response caching", false)
     .option("--cache-only", "Only use the response cache; never make network requests", false)

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -83,7 +83,8 @@ const lazyLoad = async (
     hardTimeoutMs: number = 30 * 60 * 1000,
     maxPageVisits: number = 200,
     includeMethods: string[] = [],
-    excludeMethods: string[] = []
+    excludeMethods: string[] = [],
+    detectionTimeoutMs: number = 30 * 1000
 ) => {
     // Hoisted so the timeout handler can stop discovery and drain downloads.
     let activeCrawler: NextJsCrawler | null = null;
@@ -134,7 +135,28 @@ const lazyLoad = async (
 
             lazyLoadGlobals.setMaxReqQueue(threads);
 
-            const tech = await frameworkDetect(url);
+            let tech: { name: string; evidence: string } | null;
+            if (detectionTimeoutMs > 0) {
+                let timedOut = false;
+                tech = await Promise.race([
+                    frameworkDetect(url),
+                    new Promise<null>((resolve) =>
+                        setTimeout(() => {
+                            timedOut = true;
+                            resolve(null);
+                        }, detectionTimeoutMs)
+                    ),
+                ]);
+                if (timedOut) {
+                    console.error(
+                        chalk.yellow(
+                            `[!] Framework detection timed out after ${detectionTimeoutMs}ms; treating as not detected`
+                        )
+                    );
+                }
+            } else {
+                tech = await frameworkDetect(url);
+            }
             globals.setTech(tech ? tech.name : "");
 
             if (tech) {

--- a/src/lazyLoad/techDetect/checkReact.ts
+++ b/src/lazyLoad/techDetect/checkReact.ts
@@ -39,6 +39,18 @@ const fetchAndCheck = async (src: string, url: string): Promise<string | null> =
         return `Vite React dev HMR endpoint referenced: ${src}`;
     }
 
+    // Only fetch same-origin assets. Third-party scripts (analytics, tag
+    // managers, ad SDKs, data: URIs) are numerous and often slow/unreachable —
+    // fetching every one of them serially during detection is what caused
+    // detection to stall for a very long time on real-world sites.
+    let assetOrigin: string;
+    try {
+        assetOrigin = new URL(resolvedUrl).origin;
+    } catch {
+        return null;
+    }
+    if (assetOrigin !== new URL(url).origin) return null;
+
     const res = await makeRequest(resolvedUrl, {});
     if (!res) return null;
     const body = await res.text();

--- a/src/lazyLoad/techDetect/checkVueJS.ts
+++ b/src/lazyLoad/techDetect/checkVueJS.ts
@@ -94,8 +94,14 @@ const checkVueJS = async ($, url: string) => {
         }
     });
 
+    // Only scan same-origin assets here. Third-party widgets (analytics, tag
+    // managers, ad SDKs) are numerous and often slow/unreachable, and scanning
+    // their content for "__vue" also risks false positives on sites that don't
+    // use Vue themselves.
+    const pageOrigin = new URL(url).origin;
     for (const assetURL of assetURLs) {
         try {
+            if (new URL(assetURL).origin !== pageOrigin) continue;
             const res = await makeRequest(assetURL);
             if (!res) continue;
             const content: string = await res.text();

--- a/src/proxy/checkFeasibility.ts
+++ b/src/proxy/checkFeasibility.ts
@@ -14,9 +14,9 @@ export interface FeasibilityOutcome {
 /**
  * Decides the `--feasibility` outcome from the two detection stages.
  *
- * - No firewall without a proxy: a proxy isn't needed for this target (exit 29).
+ * - No firewall without a proxy: a proxy isn't needed for this target (exit 27).
  * - Firewall present without a proxy, and still present with the proxy: the proxy couldn't
- *   bypass it (exit 30).
+ *   bypass it (exit 28).
  * - Firewall present without a proxy, but not present with the proxy: the proxy works (exit 0).
  *
  * @param blockedWithoutProxy - Whether the firewall was detected on the direct (no-proxy) request.
@@ -47,33 +47,48 @@ export const determineFeasibilityOutcome = (
 };
 
 /**
- * Checks the feasibility of using a proxy to bypass a firewall/WAF in front of a target.
+ * Probes whether a proxy is needed and able to bypass a firewall/WAF in front of a target.
  *
  * Requests the target directly first. If no firewall is detected, a proxy isn't needed. If a
  * firewall is detected, retries through the resolved proxy method to see whether it's bypassed.
+ * Does not print or exit — callers decide what to do with the outcome (`checkFeasibility` below
+ * exits with its code for the CLI; `run`'s `--proxy-waf-fallback` uses it to decide whether to use
+ * the proxy or skip the target).
+ *
+ * @param resolved - The resolved proxy config (method + its fields) to test.
+ * @param url - The target URL to test.
+ * @returns The feasibility outcome.
+ */
+export const probeFeasibility = async (resolved: ResolvedProxyConfig, url: string): Promise<FeasibilityOutcome> => {
+    console.log(chalk.cyan(`[i] Checking feasibility of the "${resolved.method}" proxy method with ${url}`));
+    const directBody = await (await fetch(url)).text();
+    const blockedWithoutProxy = await checkFireWallBlocking(directBody);
+
+    let blockedWithProxy = false;
+    if (blockedWithoutProxy) {
+        for (let i = 0; i < PROXY_CHECK_REQUESTS; i++) {
+            const body = await proxyFeasibilityRequest(resolved, url);
+            if (await checkFireWallBlocking(body)) {
+                blockedWithProxy = true;
+                break;
+            }
+        }
+    }
+
+    return determineFeasibilityOutcome(blockedWithoutProxy, blockedWithProxy);
+};
+
+/**
+ * Checks the feasibility of using a proxy to bypass a firewall/WAF in front of a target, prints the
+ * result, and exits with the outcome's code. Thin CLI wrapper around `probeFeasibility`.
  *
  * @param resolved - The resolved proxy config (method + its fields) to test.
  * @param url - The target URL to test.
  * @returns Promise that resolves when the feasibility check is complete.
  */
 const checkFeasibility = async (resolved: ResolvedProxyConfig, url: string): Promise<void> => {
-    console.log(chalk.cyan(`[i] Checking feasibility of the "${resolved.method}" proxy method with ${url}`));
     try {
-        const directBody = await (await fetch(url)).text();
-        const blockedWithoutProxy = await checkFireWallBlocking(directBody);
-
-        let blockedWithProxy = false;
-        if (blockedWithoutProxy) {
-            for (let i = 0; i < PROXY_CHECK_REQUESTS; i++) {
-                const body = await proxyFeasibilityRequest(resolved, url);
-                if (await checkFireWallBlocking(body)) {
-                    blockedWithProxy = true;
-                    break;
-                }
-            }
-        }
-
-        const outcome = determineFeasibilityOutcome(blockedWithoutProxy, blockedWithProxy);
+        const outcome = await probeFeasibility(resolved, url);
         console.log(outcome.code === 0 ? chalk.green(outcome.message) : chalk.magenta(outcome.message));
         process.exit(outcome.code);
     } catch (error) {

--- a/src/proxy/checkFeasibility.ts
+++ b/src/proxy/checkFeasibility.ts
@@ -1,32 +1,81 @@
-import { get } from "./genReq.js";
 import chalk from "chalk";
 import checkFireWallBlocking from "./checkFireWallBlocking.js";
+import { proxyFeasibilityRequest } from "./proxyFeasibilityRequest.js";
+import type { ResolvedProxyConfig } from "./resolveProxyConfig.js";
+
+/** Number of requests sent through the proxy method before concluding it reliably bypasses the firewall. */
+const PROXY_CHECK_REQUESTS = 10;
+
+export interface FeasibilityOutcome {
+    code: number;
+    message: string;
+}
 
 /**
- * Checks the feasibility of using API Gateway by testing for firewall blocking.
+ * Decides the `--feasibility` outcome from the two detection stages.
  *
- * Sends multiple test requests to the target URL through the API Gateway
- * to determine if the requests are being blocked by a firewall or security system.
+ * - No firewall without a proxy: a proxy isn't needed for this target (exit 29).
+ * - Firewall present without a proxy, and still present with the proxy: the proxy couldn't
+ *   bypass it (exit 30).
+ * - Firewall present without a proxy, but not present with the proxy: the proxy works (exit 0).
  *
- * @param url - The target URL to test for API Gateway feasibility
- * @returns Promise that resolves when feasibility check is complete
+ * @param blockedWithoutProxy - Whether the firewall was detected on the direct (no-proxy) request.
+ * @param blockedWithProxy - Whether the firewall was detected while routed through the proxy.
+ * @returns The exit code and message to print for this outcome.
  */
-const checkFeasibility = async (url: string): Promise<void> => {
-    console.log(chalk.cyan(`[i] Checking feasibility of API Gateway with ${url}`));
+export const determineFeasibilityOutcome = (
+    blockedWithoutProxy: boolean,
+    blockedWithProxy: boolean
+): FeasibilityOutcome => {
+    if (!blockedWithoutProxy) {
+        return {
+            code: 27,
+            message: "[i] No firewall detected without a proxy. A proxy is not needed for this target.",
+        };
+    }
+    if (blockedWithProxy) {
+        return {
+            code: 28,
+            message: "[!] Firewall still detected while using the proxy. This proxy method could not bypass it.",
+        };
+    }
+    return {
+        code: 0,
+        message:
+            "[✓] Firewall detected without a proxy, but not detected when using the proxy. Please use a proxy for this target.",
+    };
+};
+
+/**
+ * Checks the feasibility of using a proxy to bypass a firewall/WAF in front of a target.
+ *
+ * Requests the target directly first. If no firewall is detected, a proxy isn't needed. If a
+ * firewall is detected, retries through the resolved proxy method to see whether it's bypassed.
+ *
+ * @param resolved - The resolved proxy config (method + its fields) to test.
+ * @param url - The target URL to test.
+ * @returns Promise that resolves when the feasibility check is complete.
+ */
+const checkFeasibility = async (resolved: ResolvedProxyConfig, url: string): Promise<void> => {
+    console.log(chalk.cyan(`[i] Checking feasibility of the "${resolved.method}" proxy method with ${url}`));
     try {
-        // send 10 requests, and check if any of those contain any signs of blocking
-        for (let i = 0; i < 10; i++) {
-            const response = await get(url);
-            const isFireWallBlocking = await checkFireWallBlocking(response);
-            if (isFireWallBlocking) {
-                console.error(chalk.magenta("[!] Please try again without API Gateway"));
-                return;
+        const directBody = await (await fetch(url)).text();
+        const blockedWithoutProxy = await checkFireWallBlocking(directBody);
+
+        let blockedWithProxy = false;
+        if (blockedWithoutProxy) {
+            for (let i = 0; i < PROXY_CHECK_REQUESTS; i++) {
+                const body = await proxyFeasibilityRequest(resolved, url);
+                if (await checkFireWallBlocking(body)) {
+                    blockedWithProxy = true;
+                    break;
+                }
             }
         }
-        console.log(
-            chalk.green("[✓] Feasibility check passed."),
-            chalk.dim("However, this doesn't represent the true nature of the firewall used.")
-        );
+
+        const outcome = determineFeasibilityOutcome(blockedWithoutProxy, blockedWithProxy);
+        console.log(outcome.code === 0 ? chalk.green(outcome.message) : chalk.magenta(outcome.message));
+        process.exit(outcome.code);
     } catch (error) {
         console.error(chalk.red(`[!] An error occured in feasibility check: ${error}`));
     }

--- a/src/proxy/genReq.ts
+++ b/src/proxy/genReq.ts
@@ -14,7 +14,6 @@ import {
 import md5 from "md5";
 import chalk from "chalk";
 import * as globals from "../utility/globals.js";
-import checkFireWallBlocking from "./checkFireWallBlocking.js";
 import { readAwsGatewayMap } from "./awsConfig.js";
 
 /**
@@ -174,9 +173,6 @@ const get = async (url: string, headers: {} = {}): Promise<string> => {
 
     const body = await testInvokeMethodResponse.body;
 
-    // check if any firewall is there in the way
-    const isFireWallBlocking = await checkFireWallBlocking(body);
-
     // delete the resource
     const deleteResourceCommand = new DeleteResourceCommand({
         restApiId: config[apiGateway].id,
@@ -186,11 +182,6 @@ const get = async (url: string, headers: {} = {}): Promise<string> => {
         await client.send(deleteResourceCommand);
     } catch (err) {
         console.error(chalk.red(`[!] Error when sending delete resource command to AWS: ${err}`));
-    }
-
-    if (isFireWallBlocking) {
-        console.error(chalk.magenta("[!] Please try again without API Gateway"));
-        process.exit(18);
     }
 
     return body;

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -3,9 +3,11 @@ import inquirer from "inquirer";
 import { APIGatewayClient, CreateRestApiCommand, DeleteRestApiCommand } from "@aws-sdk/client-api-gateway";
 import checkFeasibility from "./checkFeasibility.js";
 import { readAwsGatewayMap, writeAwsGatewayMap } from "./awsConfig.js";
-import { setActiveProxyMethod, writeMethodConfig } from "./configFile.js";
+import { readProxyConfigFile, setActiveProxyMethod, writeMethodConfig } from "./configFile.js";
 import { parseProxyUrl } from "./genericProxy.js";
 import { composeOxylabsUsername, type OxylabsConfig } from "./oxylabsProxy.js";
+import { resolveProxyConfig } from "./resolveProxyConfig.js";
+import * as globals from "../utility/globals.js";
 
 type ProxyMethod = "aws" | "socks" | "http" | "oxylabs";
 const VALID_PROXY_METHODS: ProxyMethod[] = ["aws", "socks", "http", "oxylabs"];
@@ -416,7 +418,37 @@ const proxy = async (opts: ProxyCliOptions): Promise<void> => {
             console.error(chalk.red("[!] Please provide a URL to check feasibility of"));
             return;
         }
-        await checkFeasibility(opts.feasibilityUrl);
+
+        const resolved = resolveProxyConfig({
+            cli: {
+                proxyMethod: opts.proxyMethod,
+                proxyUrl: opts.proxyUrl,
+                oxylabsUsername: opts.oxylabsUsername,
+                oxylabsPassword: opts.oxylabsPassword,
+                oxylabsCountry: opts.oxylabsCountry,
+                oxylabsCity: opts.oxylabsCity,
+                oxylabsSessionId: opts.oxylabsSessionId,
+            },
+            env: process.env,
+            ignoreEnv: false,
+            configFileParsed: readProxyConfigFile(configFile),
+        });
+
+        if (!resolved.method) {
+            console.error(
+                chalk.red(
+                    "[!] Please specify a proxy method via --proxy-method, or configure one with -i/--init first"
+                )
+            );
+            return;
+        }
+
+        globals.setProxyConfigFile(configFile);
+        globals.setProxyMethod(resolved.method);
+        globals.setProxyUrl(resolved.url);
+        globals.setOxylabsConfig(resolved.oxylabs);
+
+        await checkFeasibility(resolved, opts.feasibilityUrl);
         return;
     }
 

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -436,9 +436,7 @@ const proxy = async (opts: ProxyCliOptions): Promise<void> => {
 
         if (!resolved.method) {
             console.error(
-                chalk.red(
-                    "[!] Please specify a proxy method via --proxy-method, or configure one with -i/--init first"
-                )
+                chalk.red("[!] Please specify a proxy method via --proxy-method, or configure one with -i/--init first")
             );
             return;
         }

--- a/src/proxy/proxyFeasibilityRequest.ts
+++ b/src/proxy/proxyFeasibilityRequest.ts
@@ -1,0 +1,22 @@
+import { get } from "./genReq.js";
+import { buildUndiciDispatcher, type FetchOptsWithDispatcher } from "../utility/makeReq.js";
+import type { ResolvedProxyConfig } from "./resolveProxyConfig.js";
+
+/**
+ * Makes a single request to `url` through the given resolved proxy method and returns the
+ * response body as text. Shared by `checkFeasibility` across all four proxy methods so the
+ * feasibility flow doesn't special-case AWS vs undici-dispatched methods itself.
+ *
+ * @param resolved - The resolved proxy config to route the request through.
+ * @param url - The target URL to request.
+ * @returns The response body text.
+ */
+export const proxyFeasibilityRequest = async (resolved: ResolvedProxyConfig, url: string): Promise<string> => {
+    if (resolved.method === "aws") {
+        return await get(url);
+    }
+    const dispatcher = buildUndiciDispatcher(resolved);
+    const opts: FetchOptsWithDispatcher = dispatcher ? { dispatcher } : {};
+    const res = await fetch(url, opts);
+    return await res.text();
+};

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -111,7 +111,8 @@ const processUrl = async (
             Number(cmd.lazyloadTimeout) * 60 * 1000,
             Number(cmd.maxPages),
             includeMethods,
-            excludeMethods
+            excludeMethods,
+            Number(cmd.detectionTimeout) * 1000
         ),
         getSkipStepPromise(),
     ]);
@@ -599,7 +600,8 @@ const processUrl = async (
             Number(cmd.lazyloadTimeout) * 60 * 1000,
             Number(cmd.maxPages),
             includeMethods,
-            excludeMethods
+            excludeMethods,
+            Number(cmd.detectionTimeout) * 1000
         ),
         getSkipStepPromise(),
     ]);
@@ -640,7 +642,8 @@ const processUrl = async (
             Number(cmd.lazyloadTimeout) * 60 * 1000,
             Number(cmd.maxPages),
             includeMethods,
-            excludeMethods
+            excludeMethods,
+            Number(cmd.detectionTimeout) * 1000
         ),
         getSkipStepPromise(),
     ]);

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -24,6 +24,8 @@ import {
 } from "./interruptHandler.js";
 import { detectBundler } from "./bundler-detect.js";
 import configureProxy from "../utility/configureProxy.js";
+import { probeFeasibility } from "../proxy/checkFeasibility.js";
+import { getResolvedProxyConfigFromGlobals } from "../utility/makeReq.js";
 
 /**
  * Determines the directory for a Content Delivery Network (CDN) if used by the target.
@@ -88,6 +90,37 @@ const processUrl = async (
         clearJsUrls();
         clearJsonUrls();
         globalsUtil.clearOpenapiOutput();
+    }
+
+    if (cmd.proxyWafFallback && cmd._proxyConfigured) {
+        globalsUtil.setUseProxy(true); // reset in case a previous target's fallback check disabled it
+        const resolved = getResolvedProxyConfigFromGlobals();
+        let outcome;
+        try {
+            outcome = await probeFeasibility(resolved, url);
+        } catch (error) {
+            console.error(
+                chalk.bgRed(
+                    `[!] Proxy WAF fallback check failed: ${error}. ${isBatch ? "Skipping this target." : "Quitting."}`
+                )
+            );
+            if (isBatch) return;
+            process.exit(29);
+        }
+        console.log(outcome.code === 0 ? chalk.green(outcome.message) : chalk.yellow(outcome.message));
+        if (outcome.code === 27) {
+            // no firewall detected without a proxy - don't use it for this target
+            globalsUtil.setUseProxy(false);
+        } else if (outcome.code === 28) {
+            console.error(
+                chalk.bgRed(
+                    `[!] Proxy could not bypass the firewall for this target. ${isBatch ? "Skipping this target." : "Quitting."}`
+                )
+            );
+            if (isBatch) return;
+            process.exit(29);
+        }
+        // outcome.code === 0: firewall present, proxy bypasses it - keep using the proxy
     }
 
     console.log(chalk.bgCyan("[1/8] Running lazyload to download JavaScript files..."));
@@ -762,6 +795,9 @@ const processUrl = async (
  */
 export default async (cmd: any): Promise<void> => {
     configureProxy(cmd);
+    // Snapshot the originally-configured proxy state so `processUrl`'s --proxy-waf-fallback check
+    // can reset it before each target in batch mode, regardless of what a previous target left it as.
+    cmd._proxyConfigured = globalsUtil.getUseProxy();
     globalsUtil.setDisableCache(cmd.disableCache);
     globalsUtil.setRespCacheFile(cmd.cacheFile);
     globalsUtil.setYes(cmd.yes);

--- a/src/utility/makeReq.ts
+++ b/src/utility/makeReq.ts
@@ -4,6 +4,7 @@ import puppeteer from "./puppeteerInstance.js";
 import { getChromiumPath } from "./getChromiumPath.js";
 import * as globals from "./globals.js";
 import { get } from "../proxy/genReq.js";
+import checkFireWallBlocking from "../proxy/checkFireWallBlocking.js";
 import { parseProxyUrl } from "../proxy/genericProxy.js";
 import { buildOxylabsProxyUrl, composeOxylabsUsername } from "../proxy/oxylabsProxy.js";
 import type { ResolvedProxyConfig } from "../proxy/resolveProxyConfig.js";
@@ -456,6 +457,12 @@ const makeRequest = async (
         const get_headers = requestOptions.headers;
 
         const body = await get(url, get_headers);
+
+        // check if any firewall is there in the way
+        if (await checkFireWallBlocking(body)) {
+            progressError(chalk.magenta("[!] Please try again without API Gateway"));
+            process.exit(18);
+        }
 
         // craft a Response, and return that
         const response = new Response(body);


### PR DESCRIPTION
## 1.4.2 - (unreleased)

### Fixed

- Front-end framework detection (`lazyload`/`run`'s first step) could stall for a very long time on sites with many third-party script tags (analytics, tag managers, ad SDKs, etc.). `checkVueJS` and `checkReact` (`techDetect/`) fetched every `<script src>`/`<link rel="modulepreload">` URL referenced on the page — including third-party and `data:` URI ones — with no same-origin restriction, and each of those fetches could retry up to 10 times against an unreachable/slow host. Both checks now only fetch same-origin assets during detection, matching the intent already documented for this kind of check. (`lazyload`, `run`)

### Added

- `lazyload`/`run`: added a `--detection-timeout <seconds>` flag (default `30`, `0` disables) that bounds the front-end framework detection step. If it fires, detection falls back to the same "framework not detected" path used for a genuine no-match. (`lazyload`, `run`)
- `run`: added a `--proxy-waf-fallback` flag. When a proxy is configured (`--proxy-config`), it runs the same feasibility check as `proxy --feasibility` against each target before processing it, and automatically decides whether to use the proxy: skips it if no firewall/WAF is detected without a proxy, keeps using it if it bypasses a detected firewall, or skips the target (new exit code 29 in single-URL mode) if the proxy can't bypass it. (`run`, `proxy`)