### PR TITLE
OpenSSF Best Practices badge compliance

### DIFF
--- a/.github/workflows/build-and-prettify.yaml
+++ b/.github/workflows/build-and-prettify.yaml
@@ -120,8 +120,29 @@ jobs:
       - name: Run unit tests
         run: npm test
 
+  lint:
+    needs: prettier
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
   build:
-    needs: test
+    needs: [test, lint]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+  pull_request:
+    branches:
+      - dev
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          category: "/language:javascript-typescript"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to js-recon
+
+For the full contributor guide — cloning, branch/PR workflow, codebase structure — see
+[js-recon.io/contributing](https://js-recon.io/contributing). This file covers the policies that
+apply once you're making a change here.
+
+## Testing is required for new functionality
+
+New functionality must ship with unit and/or smoke tests. See
+[`contributing/testing.md`](contributing/testing.md) for how to write unit tests (Vitest), fuzz
+tests (fast-check, for anything that parses untrusted bundle input), and smoke tests (the
+`rules-smoke-test` CI workflow).
+
+## Keep js-recon-docs in sync
+
+Changes that affect user-facing behavior, CLI flags, exit codes, or install/usage instructions must
+include a corresponding update to [`js-recon-docs`](https://github.com/js-recon/js-recon-docs) —
+either in the same PR or a linked follow-up PR. Docs-only fixes don't need a corresponding js-recon
+change.
+
+## Static analysis
+
+CI runs [ESLint](https://eslint.org/) (with
+[`eslint-plugin-security`](https://github.com/eslint-community/eslint-plugin-security)) and
+[CodeQL](https://codeql.github.com/) on every push and pull request. Run `npm run lint` locally
+before pushing.
+
+## Reporting vulnerabilities
+
+Do not open a public issue for a security vulnerability — see [`SECURITY.md`](SECURITY.md) for the
+reporting process and response SLAs. Bug reports and feature/tech-support requests use the GitHub
+Issues templates linked from the [contributing page](https://js-recon.io/contributing).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ Include in your report:
 - Affected version(s)
 - Any suggested mitigations, if known
 
-You can expect an acknowledgement within **72 hours**. If a vulnerability is confirmed, a fix will be prioritized based on severity.
+You can expect an acknowledgement within **72 hours**, and no later than **14 days** from the initial report. If a vulnerability is confirmed, a fix will be prioritized based on severity, with a target of **60 days** to ship a patch for confirmed vulnerabilities affecting a publicly released version.
 
 ## Scope
 

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -1,0 +1,106 @@
+# Writing tests for js-recon
+
+New functionality must ship with tests. Which kind depends on what you're adding — see below.
+
+## Unit tests (Vitest)
+
+Test framework is [Vitest](https://vitest.dev/) — ESM-native, TypeScript-native, no build step.
+
+```bash
+npm test          # run all unit tests once
+npm run test:watch  # watch mode
+npm run test:coverage  # run with coverage report
+```
+
+**What to test.** Pure functions: anything that takes plain inputs and returns a value without I/O.
+Puppeteer, network calls (`makeRequest`), and file writes are intentionally left untested at the
+unit level — they're validated end-to-end via the `run` subcommand instead (see below). When a
+function mixes I/O with logic, extract the parse/transform step into an exported pure function and
+test that:
+
+```typescript
+// Exported pure function — testable
+export const parseThings = (content: string, baseUrl: string): string[] => {
+    /* ... */
+};
+
+// Orchestrator — not unit-tested
+const myModule = async (url: string): Promise<string[]> => {
+    const resp = await makeRequest(url);
+    const content = await resp.text();
+    return parseThings(content, url);
+};
+```
+
+**File layout.** Tests live in `src/__tests__/<component>/<name>.test.ts`, mirroring the source
+path. Use `describe`/`it` blocks grouped by function name; cover the happy path, edge cases (empty
+input, malformed input), and threshold boundaries.
+
+**Local imports use the `.js` extension** (this is an ESM project with `"module": "node16"`):
+
+```typescript
+import { fn } from "../../lazyLoad/next_js/myModule.js";
+```
+
+**Constructing Babel AST nodes for tests.** If a function under test requires a real Babel AST node
+(with `scope`, `path`, correct `start`/`end` offsets), parse a snippet and capture the node via a
+`traverse` visitor rather than building it by hand:
+
+```typescript
+import parser from "@babel/parser";
+import _traverse from "@babel/traverse";
+const traverse = (_traverse.default ?? _traverse) as typeof _traverse.default;
+
+function parseExpr(code: string) {
+    const src = `const _x = ${code};`;
+    const ast = parser.parse(src, { sourceType: "unambiguous", plugins: ["jsx", "typescript"] });
+    let node: any;
+    traverse(ast, {
+        VariableDeclarator(p) {
+            node = p.node.init;
+            p.stop();
+        },
+    });
+    return { node, src };
+}
+```
+
+**Avoid GitHub's secret scanner false-positives.** Strings that look like real secrets (webhook
+URLs, API keys) get blocked by push protection even inside test files. Assemble them at runtime:
+
+```typescript
+// BAD — blocked by secret scanner
+const url = "https://hooks.slack.com/services/TABCDEF/BABCDEF/xxxxxxxxxxxx";
+
+// GOOD — assembled at runtime
+const parts = ["https://hooks.slack.com/services/T", "ABCDEF/B", "ABCDEF/xxxx"];
+const url = parts.join("");
+```
+
+## Fuzz tests (fast-check)
+
+js-recon's job is parsing and analyzing JS bundles pulled from third-party targets — that input is
+fully untrusted. Functions on that boundary (parsing raw bundle text, resolving URLs/strings out of
+it) should get a property-based fuzz test in addition to example-based unit tests, using
+[fast-check](https://fast-check.dev/).
+
+```bash
+npm run test:fuzz   # runs src/**/*.fuzz.test.ts via vitest.fuzz.config.ts
+```
+
+Fuzz tests live alongside the function's regular unit test, named `<name>.fuzz.test.ts`, and are
+excluded from the default `npm test` run (they're slower — property-based, hundreds of generated
+cases per run). See `src/__tests__/strings/extractStrings.fuzz.test.ts` for the reference shape:
+generate arbitrary/adversarial strings, feed them through the same parse config the real call site
+uses, and assert the function under test never throws uncaught or hangs. If a parse step can
+legitimately throw on malformed input (Babel's `errorRecovery: true` does not guarantee it won't),
+wrap it in try/catch inside the test exactly as the real call site does — a caught, expected error
+is not a fuzz failure; an uncaught throw or a hang is.
+
+## Smoke tests (CI)
+
+The `rules-smoke-test` GitHub Actions workflow runs js-recon end-to-end against a seeded lab app and
+asserts every expected rule fires. If you're adding a new AST/request rule to `js-recon-rules`, seed
+the corresponding vulnerability in `js-recon-labs`'s `next_js/vuln-all-rules` app and add the rule ID
+to `EXPECTED_RULES` in `scripts/smoke-test.js`. See the root `CLAUDE.md`'s "Rules smoke test (CI)"
+section for details.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,24 @@
+import tseslint from "typescript-eslint";
+import security from "eslint-plugin-security";
+
+export default tseslint.config(
+    {
+        ignores: ["build/**", "output/**", "output_refactored/**", "node_modules/**"],
+    },
+    {
+        files: ["src/**/*.ts"],
+        extends: [...tseslint.configs.recommended],
+        plugins: {
+            security,
+        },
+        rules: {
+            ...security.configs.recommended.rules,
+            // These fire on legitimate dynamic-code patterns intrinsic to a bundle-analysis tool
+            // (parsing/instrumenting untrusted third-party JS is the entire point of js-recon).
+            "security/detect-non-literal-fs-filename": "off",
+            "security/detect-object-injection": "off",
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+        },
+    },
+);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,5 +20,5 @@ export default tseslint.config(
             "@typescript-eslint/no-explicit-any": "off",
             "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
         },
-    },
+    }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,10 +64,15 @@
                 "@types/graphql": "^14.2.3",
                 "@types/node": "^24.12.4",
                 "@types/shell-quote": "^1.7.5",
+                "@vitest/coverage-v8": "^4.1.10",
+                "eslint": "^10.8.0",
+                "eslint-plugin-security": "^4.0.1",
+                "fast-check": "^4.9.0",
                 "patch-package": "^8.0.1",
                 "ts-node": "^10.9.2",
                 "tsconfig-paths": "^4.2.0",
                 "typescript": "^5.9.2",
+                "typescript-eslint": "^8.66.0",
                 "vitest": "^4.1.10"
             }
         },
@@ -586,6 +591,16 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@bcoe/v8-coverage": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+            "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@borewit/text-codec": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
@@ -672,6 +687,113 @@
             "integrity": "sha512-u+NaYB2aqEugQ3u7w3c5QNkPogf8q/xGgsPaqdY6pUiGWtYiTiFspKFcha6+oeZhWXWQ23rf0KrUq0kfuzqYyQ==",
             "license": "Apache-2.0"
         },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+            "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@eslint/config-array": {
+            "version": "0.23.5",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+            "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/object-schema": "^3.0.5",
+                "debug": "^4.3.1",
+                "minimatch": "^10.2.4"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+            "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^1.2.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@eslint/core": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+            "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+            "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+            "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^1.2.1",
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
         "node_modules/@hono/node-server": {
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
@@ -682,6 +804,72 @@
             },
             "peerDependencies": {
                 "hono": "^4"
+            }
+        },
+        "node_modules/@humanfs/core": {
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node": {
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
+                "@humanwhocodes/retry": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.22"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@humanwhocodes/retry": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@inquirer/ansi": {
@@ -2294,6 +2482,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/esrecurse": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+            "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2337,6 +2532,13 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
             "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
             "license": "MIT"
         },
@@ -2405,6 +2607,267 @@
             "optional": true,
             "dependencies": {
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+            "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.12.2",
+                "@typescript-eslint/scope-manager": "8.66.0",
+                "@typescript-eslint/type-utils": "8.66.0",
+                "@typescript-eslint/utils": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0",
+                "ignore": "^7.0.5",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^8.66.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+            "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "8.66.0",
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+            "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.66.0",
+                "@typescript-eslint/types": "^8.66.0",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+            "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+            "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+            "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0",
+                "@typescript-eslint/utils": "8.66.0",
+                "debug": "^4.4.3",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/types": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+            "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+            "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.66.0",
+                "@typescript-eslint/tsconfig-utils": "8.66.0",
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/visitor-keys": "8.66.0",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+            "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.66.0",
+                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+            "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.66.0",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@vitest/coverage-v8": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+            "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bcoe/v8-coverage": "^1.0.2",
+                "@vitest/utils": "4.1.10",
+                "ast-v8-to-istanbul": "^1.0.0",
+                "istanbul-lib-coverage": "^3.2.2",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-reports": "^3.2.0",
+                "magicast": "^0.5.2",
+                "obug": "^2.1.1",
+                "std-env": "^4.0.0-rc.1",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@vitest/browser": "4.1.10",
+                "vitest": "4.1.10"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@vitest/expect": {
@@ -2541,9 +3004,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2551,6 +3014,16 @@
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-jsx": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/acorn-walk": {
@@ -2675,6 +3148,25 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/ast-v8-to-istanbul": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+            "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "estree-walker": "^3.0.3",
+                "js-tokens": "^10.0.0"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/await-to-js": {
             "version": "3.0.0",
@@ -3410,6 +3902,13 @@
                 "node": ">=4.0.0"
             }
         },
+        "node_modules/deep-is": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/deepmerge": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -3647,16 +4146,191 @@
             "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
             "license": "MIT"
         },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint": {
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+            "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+            "dev": true,
+            "license": "MIT",
+            "workspaces": [
+                "packages/*"
+            ],
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.8.0",
+                "@eslint-community/regexpp": "^4.12.2",
+                "@eslint/config-array": "^0.23.5",
+                "@eslint/config-helpers": "^0.7.0",
+                "@eslint/core": "^1.2.1",
+                "@eslint/plugin-kit": "^0.7.2",
+                "@humanfs/node": "^0.16.6",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@humanwhocodes/retry": "^0.4.2",
+                "@types/estree": "^1.0.6",
+                "ajv": "^6.14.0",
+                "cross-spawn": "^7.0.6",
+                "debug": "^4.3.2",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^9.1.2",
+                "eslint-visitor-keys": "^5.0.1",
+                "espree": "^11.2.0",
+                "esquery": "^1.7.0",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^8.0.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "ignore": "^5.2.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "minimatch": "^10.2.5",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.3"
+            },
+            "bin": {
+                "eslint": "bin/eslint.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-plugin-security": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.1.tgz",
+            "integrity": "sha512-/lZCkOxPOWaf1jXAqgICrS8St3BMBccIPvhOSUYuV6VCr1o5nFVG998FnTLt6w2Nxb8Uo0nM8fzmnhp+GY/aEg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-regex": "^2.1.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-scope": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+            "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@types/esrecurse": "^4.3.1",
+                "@types/estree": "^1.0.8",
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint/node_modules/ajv": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/eslint/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/espree": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+            "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.16.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^5.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
         "node_modules/esquery": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+            "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/estraverse": {
@@ -3676,6 +4350,16 @@
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/etag": {
@@ -3814,10 +4498,47 @@
                 "@types/yauzl": "^2.9.1"
             }
         },
+        "node_modules/fast-check": {
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+            "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "pure-rand": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=12.17.0"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "license": "MIT"
+        },
+        "node_modules/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-sha256": {
@@ -3906,6 +4627,19 @@
                 }
             }
         },
+        "node_modules/file-entry-cache": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flat-cache": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/file-type": {
             "version": "21.3.4",
             "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
@@ -3964,6 +4698,23 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/find-yarn-workspace-root": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
@@ -3973,6 +4724,27 @@
             "dependencies": {
                 "micromatch": "^4.0.2"
             }
+        },
+        "node_modules/flat-cache": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.4"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/flatted": {
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+            "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/for-in": {
             "version": "1.0.2",
@@ -4169,6 +4941,19 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4260,6 +5045,13 @@
                 "node": ">=16.9.0"
             }
         },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/htmlparser2": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
@@ -4349,6 +5141,16 @@
             ],
             "license": "BSD-3-Clause"
         },
+        "node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "node_modules/image-q": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
@@ -4363,6 +5165,16 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
             "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
             "license": "MIT"
+        },
+        "node_modules/imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.19"
+            }
         },
         "node_modules/inherits": {
             "version": "2.0.3",
@@ -4451,6 +5263,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4458,6 +5280,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-number": {
@@ -4521,6 +5356,45 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/istanbul-lib-coverage": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+            "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/jimp": {
@@ -4600,6 +5474,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/json-schema-to-ts": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
@@ -4645,6 +5526,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4680,6 +5568,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
+        },
         "node_modules/kind-of": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4709,6 +5607,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/levn": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/lightningcss": {
@@ -4984,6 +5896,22 @@
                 "url": "https://github.com/sponsors/antonk52"
             }
         },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/lru-cache": {
             "version": "11.5.2",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -5001,6 +5929,34 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/magicast": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+            "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/make-dir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/make-error": {
@@ -5280,6 +6236,13 @@
             "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
             "license": "MIT"
         },
+        "node_modules/natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/negotiator": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -5432,6 +6395,56 @@
                 }
             }
         },
+        "node_modules/optionator": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -5579,6 +6592,16 @@
             "dependencies": {
                 "process": "^0.11.1",
                 "util": "^0.10.3"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/path-expression-matcher": {
@@ -5785,6 +6808,16 @@
                 "node": ">=6"
             }
         },
+        "node_modules/prelude-ls": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
         "node_modules/prettier": {
             "version": "3.7.4",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
@@ -5830,6 +6863,16 @@
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/puppeteer": {
@@ -6006,6 +7049,23 @@
                 }
             }
         },
+        "node_modules/pure-rand": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+            "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/qs": {
             "version": "6.15.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -6100,6 +7160,16 @@
             "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
             "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==",
             "license": "BSD"
+        },
+        "node_modules/regexp-tree": {
+            "version": "0.1.27",
+            "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+            "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "regexp-tree": "bin/regexp-tree"
+            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
@@ -6225,6 +7295,16 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/safe-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+            "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "regexp-tree": "~0.1.1"
+            }
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -6821,6 +7901,19 @@
             "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
             "license": "MIT"
         },
+        "node_modules/ts-api-utils": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.12"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4"
+            }
+        },
         "node_modules/ts-node": {
             "version": "10.9.2",
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -6898,6 +7991,19 @@
                 "node": "*"
             }
         },
+        "node_modules/type-check": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
         "node_modules/type-fest": {
             "version": "0.21.3",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
@@ -6961,6 +8067,30 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/typescript-eslint": {
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+            "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.66.0",
+                "@typescript-eslint/parser": "8.66.0",
+                "@typescript-eslint/typescript-estree": "8.66.0",
+                "@typescript-eslint/utils": "8.66.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
         "node_modules/uint8array-extras": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
@@ -7004,6 +8134,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "punycode": "^2.1.0"
             }
         },
         "node_modules/utif2": {
@@ -7279,6 +8419,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/wrap-ansi": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -7432,6 +8582,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/yoctocolors-cjs": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
         "start": "node --max-old-space-size=8192 build/index.js",
         "test": "vitest run",
         "test:watch": "vitest",
+        "test:coverage": "vitest run --coverage",
+        "test:fuzz": "vitest run --config vitest.fuzz.config.ts",
         "test:build": "node build/index.js -h",
+        "lint": "eslint src",
         "postinstall": "patch-package || true; node scripts/postinstall-completion.mjs",
         "cleanup": "rm -rf build output output_refactored .resp_cache.json .resp_cache.json.entries endpoints.json extracted_urls{.txt,.json,-openapi.json} strings.json mapped{-openapi.json,.json,-openapi.postman_collection.json} analyze.json test{.yaml,.js} js-recon-js-recon-*.tgz js-recon.db report.{html,md} js_recon_run_output *_test.js extracted/ research.json results* out.* swagger-jacker-results.json && tsc"
     },
@@ -84,10 +87,15 @@
         "@types/graphql": "^14.2.3",
         "@types/node": "^24.12.4",
         "@types/shell-quote": "^1.7.5",
+        "@vitest/coverage-v8": "^4.1.10",
+        "eslint": "^10.8.0",
+        "eslint-plugin-security": "^4.0.1",
+        "fast-check": "^4.9.0",
         "patch-package": "^8.0.1",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.9.2",
+        "typescript-eslint": "^8.66.0",
         "vitest": "^4.1.10"
     }
 }

--- a/src/__tests__/strings/extractStrings.fuzz.test.ts
+++ b/src/__tests__/strings/extractStrings.fuzz.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import parser from "@babel/parser";
+import { extractStrings } from "../../strings/index.js";
+
+/**
+ * js-recon's entire pipeline starts by parsing raw JS text pulled from a third-party target's
+ * bundle — that text is fully attacker/target-controlled. This fuzz test drives arbitrary and
+ * adversarially-shaped strings through the same parse config used across the codebase
+ * (`errorRecovery: true`, matching e.g. `map/next_js/utils.ts`) followed by `extractStrings`.
+ *
+ * `errorRecovery: true` does NOT guarantee `parser.parse` never throws — some errors (e.g. an
+ * unterminated string/template literal) are fatal and unrecoverable in Babel regardless of this
+ * option. Every real call site in this codebase already wraps `parser.parse` in try/catch for
+ * exactly this reason, so a thrown SyntaxError here is expected, catchable behavior, not a bug.
+ * What this test actually guards against: (1) `extractStrings` itself throwing or hanging on any
+ * AST that *does* parse successfully, however adversarial, and (2) the parse+extract pair hanging
+ * (bounded per-property runtime) on pathological input rather than failing fast.
+ */
+
+const PARSE_OPTS: parser.ParserOptions = {
+    sourceType: "unambiguous",
+    plugins: ["jsx", "typescript"],
+    errorRecovery: true,
+};
+
+/** Parses like every real call site does — catches the expected fatal-syntax-error case. */
+const tryParseAndExtract = (code: string): string[] | null => {
+    let ast;
+    try {
+        ast = parser.parse(code, PARSE_OPTS);
+    } catch {
+        return null; // expected for unrecoverable syntax — real call sites handle this the same way
+    }
+    return extractStrings(ast);
+};
+
+describe("extractStrings fuzz (parse boundary)", () => {
+    it("never hangs or throws uncaught on arbitrary unicode input", () => {
+        fc.assert(
+            fc.property(fc.string({ maxLength: 500 }), (code) => {
+                expect(() => tryParseAndExtract(code)).not.toThrow();
+            }),
+            { numRuns: 300 }
+        );
+    });
+
+    it("never hangs or throws uncaught on JS-flavored malformed fragments", () => {
+        const jsToken = fc.constantFrom(
+            "const",
+            "function",
+            "=>",
+            "`",
+            '"',
+            "'",
+            "${",
+            "}",
+            "(",
+            ")",
+            "[",
+            "]",
+            "\\",
+            ";",
+            "/",
+            "*",
+            "//",
+            "/*",
+            "class",
+            "..."
+        );
+        fc.assert(
+            fc.property(fc.array(jsToken, { maxLength: 80 }), (tokens) => {
+                expect(() => tryParseAndExtract(tokens.join(" "))).not.toThrow();
+            }),
+            { numRuns: 300 }
+        );
+    });
+
+    it("never hangs or throws uncaught on pathologically repeated quote/backslash sequences", () => {
+        fc.assert(
+            fc.property(
+                fc.constantFrom('"', "'", "\\", "`", "${"),
+                fc.integer({ min: 1, max: 2000 }),
+                (unit, count) => {
+                    expect(() => tryParseAndExtract(unit.repeat(count))).not.toThrow();
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    it("extractStrings never throws on a successfully-parsed adversarial AST", () => {
+        // Valid-but-adversarial JS: deep nesting, many strings, mixed literal kinds.
+        const validSnippets = fc.constantFrom(
+            "const a = " + "[".repeat(200) + "1" + "]".repeat(200) + ";",
+            `const o = {${Array.from({ length: 200 }, (_, i) => `k${i}:"v${i}"`).join(",")}};`,
+            "const t = `" + "${1}".repeat(200) + "`;",
+            'fetch("' + "/a".repeat(500) + '");'
+        );
+        fc.assert(
+            fc.property(validSnippets, (code) => {
+                const ast = parser.parse(code, PARSE_OPTS);
+                expect(() => extractStrings(ast)).not.toThrow();
+            }),
+            { numRuns: 20 }
+        );
+    });
+});

--- a/src/analyze/engine/astEngine.ts
+++ b/src/analyze/engine/astEngine.ts
@@ -28,7 +28,7 @@ import { printMsg, MSG } from "../../utility/printMsg.js";
  * @returns Promise that resolves to an array of analysis findings
  */
 const esqueryEngine = async (rule: Rule, mappedJsonData: Chunks): Promise<EngineOutput[]> => {
-    let findings: EngineOutput[] = [];
+    const findings: EngineOutput[] = [];
 
     for (const chunk of Object.values(mappedJsonData)) {
         // first of all, load the code in ast
@@ -43,7 +43,7 @@ const esqueryEngine = async (rule: Rule, mappedJsonData: Chunks): Promise<Engine
             continue;
         }
 
-        let matchList: { [key: string]: { node: Node; scope: Node; allNodes?: Node[] } } = {};
+        const matchList: { [key: string]: { node: Node; scope: Node; allNodes?: Node[] } } = {};
         const completedSteps: Set<string> = new Set();
         // Cache taint info per "source step name" so we don't recompute when several
         // sink steps share the same source step.
@@ -145,6 +145,7 @@ const esqueryEngine = async (rule: Rule, mappedJsonData: Chunks): Promise<Engine
                 }
             } else if (step.regexMatch) {
                 // Scan all StringLiteral/TemplateLiteral nodes in the chunk for values matching the regex
+                // eslint-disable-next-line security/detect-non-literal-regexp -- pattern comes from a loaded rule YAML file — same trust model as the rest of the rule engine, not user/network input
                 const pattern = new RegExp(step.regexMatch.pattern);
                 const foundNodes: Node[] = [];
                 _traverseDefault(ast, {

--- a/src/analyze/engine/index.ts
+++ b/src/analyze/engine/index.ts
@@ -27,7 +27,7 @@ export const engine = async (
 ): Promise<EngineOutput[] | undefined> => {
     // first of all check what is rule type, and then check if the data for that is available or is undefined
 
-    let findings: EngineOutput[] = [];
+    const findings: EngineOutput[] = [];
 
     if (rule.type === "request") {
         if (!openapiData) {

--- a/src/analyze/engine/requestEngine.ts
+++ b/src/analyze/engine/requestEngine.ts
@@ -15,7 +15,7 @@ import { printMsg, MSG } from "../../utility/printMsg.js";
  * @returns Promise that resolves to an array of analysis findings
  */
 const engine = async (rule: Rule, openapiData: OpenAPISpec): Promise<EngineOutput[]> => {
-    let findings: EngineOutput[] = [];
+    const findings: EngineOutput[] = [];
 
     for (const path in openapiData.paths) {
         const methods = openapiData.paths[path];

--- a/src/analyze/index.ts
+++ b/src/analyze/index.ts
@@ -164,7 +164,7 @@ const analyze = async (
     }
 
     // iterate over the ruleFiles
-    let ruleFindings: EngineOutput[] = [];
+    const ruleFindings: EngineOutput[] = [];
     for (const ruleFile of compatibleRuleFiles) {
         // load the rule
         const rule: Rule = yaml.parse(fs.readFileSync(ruleFile, "utf8"));

--- a/src/config/applicationConfig.ts
+++ b/src/config/applicationConfig.ts
@@ -411,6 +411,7 @@ const findCliConfigPath = (program: Command, argv: readonly string[]): string | 
 
     for (let index = 2; index < argv.length; index += 1) {
         const token = argv[index];
+        // eslint-disable-next-line security/detect-possible-timing-attacks -- comparing CLI argument/command-name strings, not secrets or credentials — timing is not security-relevant here
         if (token === "--config") {
             if (index + 1 >= argv.length) {
                 throw new ApplicationConfigError("--config requires a file path");

--- a/src/cs_mast/index.ts
+++ b/src/cs_mast/index.ts
@@ -1,6 +1,7 @@
 import { cs_mast_init, ParseError, buildSignatureFromConfig } from "@shriyanss/cs-mast";
 import type { CsMastConfig, ScatCategory } from "@shriyanss/cs-mast";
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 import { printMsg, MSG } from "../utility/printMsg.js";
 
@@ -153,7 +154,7 @@ export default async (
         if (!fs.existsSync(permOutput)) fs.mkdirSync(permOutput, { recursive: true });
         const subsets = allScatSubsets();
         const concurrency =
-            permConcurrency > 0 ? permConcurrency : Math.max(1, Math.floor(require("os").cpus().length / 2));
+            permConcurrency > 0 ? permConcurrency : Math.max(1, Math.floor(os.cpus().length / 2));
         printMsg(MSG.Header, `[*] Running ${subsets.length} scat permutations (concurrency: ${concurrency})`);
         let done = 0;
         for (let i = 0; i < subsets.length; i += concurrency) {

--- a/src/cs_mast/index.ts
+++ b/src/cs_mast/index.ts
@@ -153,8 +153,7 @@ export default async (
         }
         if (!fs.existsSync(permOutput)) fs.mkdirSync(permOutput, { recursive: true });
         const subsets = allScatSubsets();
-        const concurrency =
-            permConcurrency > 0 ? permConcurrency : Math.max(1, Math.floor(os.cpus().length / 2));
+        const concurrency = permConcurrency > 0 ? permConcurrency : Math.max(1, Math.floor(os.cpus().length / 2));
         printMsg(MSG.Header, `[*] Running ${subsets.length} scat permutations (concurrency: ${concurrency})`);
         let done = 0;
         for (let i = 0; i < subsets.length; i += concurrency) {

--- a/src/endpoints/gen_report/utility/iterate_n_store.ts
+++ b/src/endpoints/gen_report/utility/iterate_n_store.ts
@@ -19,7 +19,7 @@ import resolvePath from "../../../utility/resolvePath.js";
  * @returns {Promise<object>} - A promise that resolves to the nested object structure
  */
 const iterate_n_store = async (baseUrl: string, urls: string[]) => {
-    let result = {};
+    const result = {};
     for (let url of urls) {
         if (url.startsWith("mailto:") || url.startsWith("tel:")) {
             continue;

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -83,7 +83,7 @@ const endpoints = async (
         printMsg(MSG.Header, "[i] Checking for client-side paths for Next.JS");
 
         // var to store all the paths found
-        let final_client_side: string[] = [];
+        const final_client_side: string[] = [];
 
         if (directory) {
             const subsequentRequestsDir = directory + "/___subsequent_requests";

--- a/src/endpoints/next_js/client_jsFilesHref.ts
+++ b/src/endpoints/next_js/client_jsFilesHref.ts
@@ -17,7 +17,7 @@ const traverse = (_traverse.default ?? _traverse) as typeof _traverse.default;
  */
 const client_jsFilesHref = async (directory: string): Promise<string[]> => {
     printMsg(MSG.Header, "[i] Searching for `href` in the JS chunks");
-    let discoveredPaths = [];
+    const discoveredPaths = [];
     // index all the files in the directory
     let files;
     files = fs.readdirSync(directory, { recursive: true });

--- a/src/endpoints/next_js/client_jsonParse.ts
+++ b/src/endpoints/next_js/client_jsonParse.ts
@@ -16,7 +16,7 @@ import { printMsg, MSG } from "../../utility/printMsg.js";
  * @returns Promise that resolves to an array of discovered paths from JSON.parse() calls
  */
 const client_jsonParse = async (directory: string): Promise<string[]> => {
-    let foundUrls = [];
+    const foundUrls = [];
     printMsg(MSG.Header, "[i] Searching for client-side paths in JSON.parse()");
 
     // filter out the directories

--- a/src/endpoints/next_js/client_mappedJsonFile.ts
+++ b/src/endpoints/next_js/client_mappedJsonFile.ts
@@ -17,9 +17,9 @@ const client_mappedJsonFile = async (filePath: string): Promise<string[]> => {
     // open the file and load the chunks
     const chunks: Chunks = JSON.parse(fs.readFileSync(filePath, "utf-8"));
 
-    let chunksCopy = chunks;
+    const chunksCopy = chunks;
 
-    let foundPaths: string[] = [];
+    const foundPaths: string[] = [];
 
     // iterate over the chunks
     for (const [key, value] of Object.entries(chunks)) {

--- a/src/endpoints/next_js/client_subsequentRequests.ts
+++ b/src/endpoints/next_js/client_subsequentRequests.ts
@@ -6,7 +6,7 @@ import makeRequest from "../../utility/makeReq.js";
 import { printMsg, MSG } from "../../utility/printMsg.js";
 const traverse = (_traverse.default ?? _traverse) as typeof _traverse.default;
 
-let toReturn = [];
+const toReturn = [];
 
 /**
  * Checks for client-side paths in a file and appends discovered paths to the module-scoped `toReturn` array.
@@ -50,7 +50,7 @@ const checkHref = async (files, url) => {
                 }
 
                 // traverse the ast, and find the objects with href, and external
-                let finds: any[] = [];
+                const finds: any[] = [];
                 traverse(ast, {
                     ObjectExpression(path) {
                         const properties = path.node.properties;
@@ -195,7 +195,7 @@ const client_subsequentRequests = async (subsequentRequestsDir, url) => {
     // get all the files in the directory
     const walkSync = (dir, files = []) => {
         fs.readdirSync(dir).forEach((file) => {
-            let dirFile = path.join(dir, file);
+            const dirFile = path.join(dir, file);
             if (fs.statSync(dirFile).isDirectory()) {
                 walkSync(dirFile, files);
             } else {

--- a/src/globalConfig.ts
+++ b/src/globalConfig.ts
@@ -4,7 +4,7 @@ const version = "2.0.1";
 const toolDesc = "JavaScript Enumeration and SAST";
 const axiosNonHttpMethods = ["isAxiosError"]; // methods available in axios, which are not for making HTTP requests
 
-let CONFIG = {
+const CONFIG = {
     github: githubURL,
     modulesDocs: modulesDocs,
     notFoundMessage: `If you believe this is an error or is a new technology, please create an issue on ${githubURL} and we'll figure it out for you`,

--- a/src/lazyLoad/angular/angular_getFromPageSource.ts
+++ b/src/lazyLoad/angular/angular_getFromPageSource.ts
@@ -6,7 +6,7 @@ import { printMsg, MSG } from "../../utility/printMsg.js";
 const angular_getFromPageSource = async (url: string) => {
     printMsg(MSG.Header, "[i] Analyzing page source");
 
-    let foundUrls: string[] = [];
+    const foundUrls: string[] = [];
 
     const pageSource = await makeRequest(url, {});
     const body = await pageSource.text();

--- a/src/lazyLoad/downloadResponse.ts
+++ b/src/lazyLoad/downloadResponse.ts
@@ -49,6 +49,7 @@ const hasCompatibleContentType = (url: string, rawContentType: string | null): b
 
     const assetKind = getDownloadedAssetKind(url);
     if (assetKind === "json") {
+        // eslint-disable-next-line security/detect-unsafe-regex -- anchored, no nested/ambiguous quantifiers — not exploitable
         return contentType === "text/json" || /^application\/(?:[a-z0-9.+-]+\+)?json$/.test(contentType);
     }
     if (assetKind === "vue") {

--- a/src/lazyLoad/index.ts
+++ b/src/lazyLoad/index.ts
@@ -336,7 +336,7 @@ const lazyLoad = async (
 
                     const firstBatch = [...new Set([...jsFilesFromPageSource, ...jsFilesFromStringAnalysis])];
 
-                    let jsFilesFromAST = [];
+                    const jsFilesFromAST = [];
                     if (shouldRunMethod("nuxt_astParse", includeMethods, excludeMethods)) {
                         printMsg(MSG.Header, "[i] Analyzing functions in the files found");
                         for (const jsFile of firstBatch) {

--- a/src/lazyLoad/next_js/NextJsCrawler.ts
+++ b/src/lazyLoad/next_js/NextJsCrawler.ts
@@ -262,7 +262,7 @@ class NextJsCrawler {
     private async recursivePass(jsUrls: string[]): Promise<string[]> {
         const inc = this.includeMethods;
         const exc = this.excludeMethods;
-        let newInThisPass: string[] = [];
+        const newInThisPass: string[] = [];
 
         // Promise.all pattern analysis on JS file contents
         if (shouldRunMethod("next_promiseResolve", inc, exc)) {

--- a/src/lazyLoad/next_js/next_GetLazyResourcesBuildManifestJs.ts
+++ b/src/lazyLoad/next_js/next_GetLazyResourcesBuildManifestJs.ts
@@ -41,7 +41,7 @@ export const parseChunksFromBuildManifest = (content: string, buildManifestUrl: 
  */
 const next_getLazyResourcesBuildManifestJs = async (url: string): Promise<string[] | any> => {
     const foundUrls = globals.getJsUrls();
-    let toReturn: string[] = [];
+    const toReturn: string[] = [];
 
     let buildManifestUrl: string = "";
     for (const jsUrl of foundUrls) {

--- a/src/lazyLoad/next_js/next_GetLazyResourcesWebpackJs.ts
+++ b/src/lazyLoad/next_js/next_GetLazyResourcesWebpackJs.ts
@@ -276,6 +276,7 @@ const next_GetLazyResourcesWebpackJs = async (url: string, threads: number = 1):
 
         let publicPath = "";
         if (pVarName) {
+            // eslint-disable-next-line security/detect-non-literal-regexp -- pVarName is captured from \w* only (no regex metacharacters possible) — not exploitable
             const assignRe = new RegExp(`\\b${pVarName}\\.p\\s*=\\s*["']([^"']*)["']`);
             const assignMatch = jsContent.match(assignRe);
             if (assignMatch) publicPath = assignMatch[1];

--- a/src/lazyLoad/next_js/next_SubsequentRequests.ts
+++ b/src/lazyLoad/next_js/next_SubsequentRequests.ts
@@ -24,7 +24,7 @@ const findStaticFiles = async (js_content) => {
     const matches = [...js_content.matchAll(/\/?static\/chunks\/[a-zA-Z0-9\._\-\/~]+\.js/g)];
     // return matches
 
-    let toReturn = [];
+    const toReturn = [];
 
     for (const match of matches) {
         toReturn.push(match[0]);
@@ -97,7 +97,7 @@ const subsequentRequests = async (
     const stopBarWatcher = watchBarResize(progressBar, 73);
     const releaseBarLogger = activateBarLogger(multiBar, process.stdout.isTTY === true);
 
-    let js_contents = {};
+    const js_contents = {};
     let jsFilesFromPageHtml: string[] = [];
 
     await withProgressResources(

--- a/src/lazyLoad/next_js/next_bruteForceJsFiles.ts
+++ b/src/lazyLoad/next_js/next_bruteForceJsFiles.ts
@@ -7,7 +7,7 @@ const next_bruteForceJsFiles = async (urls: string[], threads: number = 1) => {
     console.log(chalk.cyan("[i] Bruteforcing .map files"));
     const mapFiles = urls.map((url) => url + ".map");
 
-    let foundSourceMaps: string[] = [];
+    const foundSourceMaps: string[] = [];
 
     await runWithConcurrency(mapFiles, threads, async (mapFile) => {
         const req = await makeRequest(mapFile);

--- a/src/lazyLoad/next_js/next_promiseResolve.ts
+++ b/src/lazyLoad/next_js/next_promiseResolve.ts
@@ -70,7 +70,7 @@ const next_promiseResolveWorker = async (url: string, jsDirBase: string): Promis
 const next_promiseResolve = async (urls: string[], threads: number = 1) => {
     console.log(chalk.cyan("[i] Check for Promise.all pattern"));
 
-    let toReturn: string[] = [];
+    const toReturn: string[] = [];
 
     // go through all the URLs, and find which which one has `static/chunks/` in it
     let jsDirBase: string | null = null;

--- a/src/lazyLoad/next_js/next_scriptTagsSubsequentRequests.ts
+++ b/src/lazyLoad/next_js/next_scriptTagsSubsequentRequests.ts
@@ -6,7 +6,7 @@ import { runWithConcurrency } from "../../utility/concurrency.js";
 const next_scriptTagsSubsequentRequests = async (url: string, endpointsFile: string, threads: number = 1) => {
     console.log(chalk.cyan("[i] Getting JS files from subsequent requests (script tags)"));
 
-    let endpoints = JSON.parse(fs.readFileSync(endpointsFile, "utf8")).paths;
+    const endpoints = JSON.parse(fs.readFileSync(endpointsFile, "utf8")).paths;
 
     endpoints.push("/");
 

--- a/src/lazyLoad/nuxt_js/nuxt_astParse.ts
+++ b/src/lazyLoad/nuxt_js/nuxt_astParse.ts
@@ -65,7 +65,7 @@ export const extractChunkBuilderFunctions = (jsContent: string): ChunkBuilderFun
  * Finds all the lazy loaded JS files from a given URL using a Nuxt.js specific approach.
  */
 const nuxt_astParse = async (url: string) => {
-    let filesFound = [];
+    const filesFound = [];
     const resp = await makeRequest(url, {});
     const body = await resp.text();
 
@@ -125,7 +125,7 @@ const nuxt_astParse = async (url: string) => {
                 plugins: ["jsx", "typescript"],
                 errorRecovery: true,
             });
-            let memberExpressions = [];
+            const memberExpressions = [];
             traverse(unknownVarAst, {
                 MemberExpression(path) {
                     // Only collect identifiers like f.p (not obj["x"])
@@ -170,13 +170,14 @@ const nuxt_astParse = async (url: string) => {
 
             // replace the unknown var with the value
             const funcSource = func.source.replace(
+                // eslint-disable-next-line security/detect-non-literal-regexp -- unknownVar values are AST-derived identifier/property names, which cannot contain regex metacharacters
                 new RegExp(`${unknownVar[0]}.${unknownVar[1]}`),
                 `"${unknownVarValue}"`
             );
 
             // continue to executing the function with all possible numbers
             const urlBuilderFunc = `(() => (${funcSource}))()`;
-            let js_paths = [];
+            const js_paths = [];
 
             try {
                 // rather than fuzzing, grep the integers from the func code

--- a/src/lazyLoad/nuxt_js/nuxt_stringAnalysisJSFiles.ts
+++ b/src/lazyLoad/nuxt_js/nuxt_stringAnalysisJSFiles.ts
@@ -10,7 +10,7 @@ import parser from "@babel/parser";
 import _traverse from "@babel/traverse";
 const traverse = (_traverse.default ?? _traverse) as typeof _traverse.default;
 
-let analyzedFiles = [];
+const analyzedFiles = [];
 let filesFound = [];
 
 /**
@@ -29,7 +29,7 @@ export const parseJSFileContent = async (content) => {
             errorRecovery: true,
         });
 
-        let foundJsFiles = {};
+        const foundJsFiles = {};
 
         traverse(ast, {
             StringLiteral(path) {

--- a/src/lazyLoad/svelte/svelte_discoverPagesFromJs.ts
+++ b/src/lazyLoad/svelte/svelte_discoverPagesFromJs.ts
@@ -31,6 +31,7 @@ const extractPagePaths = (content: string): string[] => {
 
     // Template literal path prefixes: `/post/${...}` → try `/post/1`
     // Matches backtick template literals starting with "/" that have at least one ${} segment
+    // eslint-disable-next-line security/detect-unsafe-regex -- single unambiguous greedy run + required literals, no nested quantifiers — not exploitable
     const TEMPLATE_RE = /`(\/[a-zA-Z0-9_\-/]+)\$\{[^`}]+\}(?:\/[a-zA-Z0-9_\-]*)*`/g;
     while ((m = TEMPLATE_RE.exec(content)) !== null) {
         const prefix = m[1]; // e.g. "/post/"

--- a/src/lazyLoad/svelte/svelte_getFromPageSource.ts
+++ b/src/lazyLoad/svelte/svelte_getFromPageSource.ts
@@ -14,7 +14,7 @@ import { printMsg, MSG } from "../../utility/printMsg.js";
  */
 const svelte_getFromPageSource = async (url) => {
     printMsg(MSG.Header, "[i] Analyzing page source");
-    let foundUrls = [];
+    const foundUrls = [];
     const pageSource = await makeRequest(url, {});
     const body = await pageSource.text();
 

--- a/src/lazyLoad/svelte/svelte_stringAnalysisJSFiles.ts
+++ b/src/lazyLoad/svelte/svelte_stringAnalysisJSFiles.ts
@@ -10,7 +10,7 @@ import { FoundJsFiles } from "../../utility/interfaces.js";
 import { runWithConcurrency } from "../../utility/concurrency.js";
 const traverse = (_traverse.default ?? _traverse) as typeof _traverse.default;
 
-let analyzedFiles = [];
+const analyzedFiles = [];
 let filesFound = [];
 let mapFilesFound = [];
 
@@ -30,7 +30,7 @@ export const parseJSFileContent = async (content) => {
             errorRecovery: true,
         });
 
-        let foundJsFiles = {};
+        const foundJsFiles = {};
 
         traverse(ast, {
             StringLiteral(path) {

--- a/src/lazyLoad/techDetect/checkAngularJS.ts
+++ b/src/lazyLoad/techDetect/checkAngularJS.ts
@@ -38,8 +38,8 @@ const checkAngularJS = async ($: cheerio.CheerioAPI, url: string) => {
         if (attribs) {
             for (const [attrName, attrValue] of Object.entries(attribs)) {
                 if (attrName === "src") {
-                    // @ts-ignore
                     // Match main.js (dev builds) and main-HASH.js (production builds)
+                    // eslint-disable-next-line security/detect-unsafe-regex -- anchored at $, bounded groups — not exploitable
                     if (/(?:^|\/)main(-[a-zA-Z0-9]+)?\.js(\?.*)?$/.test(attrValue)) {
                         hasMainJs = true;
 

--- a/src/lazyLoad/techDetect/checkNuxtJS.ts
+++ b/src/lazyLoad/techDetect/checkNuxtJS.ts
@@ -12,14 +12,14 @@ export const checkNuxtJS = async ($: cheerio.CheerioAPI) => {
 
     // go through the page source, and check for "/_nuxt" in the src or href attribute
     $("*").each((_, el) => {
-        // @ts-ignore
+        // @ts-expect-error -- cheerio's Element type doesn't expose tagName in this overload
         const tag = $(el).get(0).tagName;
-        // @ts-ignore
+        // @ts-expect-error -- cheerio's Element type doesn't expose attribs in this overload
         const attribs = el.attribs;
         if (attribs) {
             for (const [attrName, attrValue] of Object.entries(attribs)) {
                 if (attrName === "src" || attrName === "href") {
-                    // @ts-ignore
+                    // @ts-expect-error -- attribs value type is untyped in this cheerio overload
                     if (attrValue.includes("/_nuxt")) {
                         detected = true;
                         evidence = `${attrName} :: ${attrValue}`;

--- a/src/lazyLoad/techDetect/checkSvelte.ts
+++ b/src/lazyLoad/techDetect/checkSvelte.ts
@@ -32,7 +32,6 @@ export const checkSvelte = async ($) => {
         if (!attribs) return;
         for (const [attrName, attrValue] of Object.entries(attribs)) {
             if (attrName === "class" || attrName === "id") {
-                // @ts-ignore
                 if ((attrValue as string).includes("svelte-")) {
                     detected = true;
                     evidence = `${attrName} :: ${attrValue}`;

--- a/src/lazyLoad/techDetect/checkVueJS.ts
+++ b/src/lazyLoad/techDetect/checkVueJS.ts
@@ -40,19 +40,19 @@ const checkVueJS = async ($, url: string) => {
         if (attribs) {
             for (const [attrName, attrValue] of Object.entries(attribs)) {
                 if (attrName === "src") {
-                    // @ts-ignore
+                    // @ts-expect-error -- attribs value type is untyped in this cheerio overload
                     if (attrValue.includes("app.js")) {
                         // get the URL of the app.js file
-                        // @ts-ignore
+                        // @ts-expect-error -- attribs value type is untyped in this cheerio overload
                         if (attrValue.startsWith("/")) {
-                            // @ts-ignore
+                            // @ts-expect-error -- attribs value type is untyped in this cheerio overload
                             appJsURL = new URL(attrValue, url).href;
-                            // @ts-ignore
+                            // @ts-expect-error -- attribs value type is untyped in this cheerio overload
                         } else if (attrValue.startsWith("http")) {
-                            // @ts-ignore
+                            // @ts-expect-error -- attribs value type is untyped in this cheerio overload
                             appJsURL = attrValue;
                         } else {
-                            // @ts-ignore
+                            // @ts-expect-error -- attribs value type is untyped in this cheerio overload
                             appJsURL = new URL(attrValue, url).href;
                         }
                     }

--- a/src/lazyLoad/vue/vue_SingleJsFileOnHome.ts
+++ b/src/lazyLoad/vue/vue_SingleJsFileOnHome.ts
@@ -8,7 +8,7 @@ import { progressError, progressLog, progressWarn } from "../../utility/progress
 const traverse = (_traverse.default ?? _traverse) as typeof _traverse.default;
 
 const vue_singleJsFileOnHome = async (url: string) => {
-    let jsFilesFound: string[] = [];
+    const jsFilesFound: string[] = [];
 
     // first, get the home page content
     const req = await makeRequest(url, {});
@@ -68,7 +68,7 @@ const vue_singleJsFileOnHome = async (url: string) => {
     });
 
     // traverse the AST
-    let initialFoundJsPaths: string[] = [];
+    const initialFoundJsPaths: string[] = [];
     traverse(ast, {
         ArrayExpression(path) {
             const elements = path.node.elements;

--- a/src/lazyLoad/vue/vue_getClientSidePaths.ts
+++ b/src/lazyLoad/vue/vue_getClientSidePaths.ts
@@ -23,7 +23,7 @@ const vue_getClientSidePaths = async (
     showProgress: boolean = true
 ): Promise<string[]> => {
     const MAX_JS_SIZE_BYTES = maxJsSizeMb * 1024 * 1024;
-    let toReturn: string[] = [];
+    const toReturn: string[] = [];
 
     const baseOrigin = new URL(url).origin;
     const addClientPath = (pathValue: string, jsFileOrigin: string): void => {

--- a/src/lazyLoad/vue/vue_pageSrc.ts
+++ b/src/lazyLoad/vue/vue_pageSrc.ts
@@ -4,7 +4,7 @@ import * as cheerio from "cheerio";
 import { progressError } from "../../utility/progressLog.js";
 
 const vue_pageSrc = async (url: string) => {
-    let toReturn: string[] = [];
+    const toReturn: string[] = [];
 
     // first, get the contents of the homepage
     const req = await makeRequest(url);

--- a/src/lazyLoad/vue/vue_reconstructSourceMaps.ts
+++ b/src/lazyLoad/vue/vue_reconstructSourceMaps.ts
@@ -6,7 +6,7 @@ import { progressError, progressLog } from "../../utility/progressLog.js";
 const vue_reconstructSourceMaps = async (url: string, jsFilesToDownload: string[], threads: number = 1) => {
     // get the contents of first file, and check if it has the sourceMappingURL
 
-    let sourceMapUrls: string[] = [];
+    const sourceMapUrls: string[] = [];
     // guard against empty input
     if (jsFilesToDownload.length === 0) {
         return sourceMapUrls;
@@ -36,7 +36,7 @@ const vue_reconstructSourceMaps = async (url: string, jsFilesToDownload: string[
         const content = await req.text();
 
         // get the sourceMappingURL
-        let sourceMappingURL_reg = content.match(/sourceMappingURL=([^"]+)/);
+        const sourceMappingURL_reg = content.match(/sourceMappingURL=([^"]+)/);
         if (sourceMappingURL_reg) {
             // strip the newline, and assign to a new var
             const sourceMappingURL = sourceMappingURL_reg[1].replace(/\n/g, "");

--- a/src/lazyLoad/vue/vue_severalJsFilesHome.ts
+++ b/src/lazyLoad/vue/vue_severalJsFilesHome.ts
@@ -3,7 +3,7 @@ import makeRequest from "../../utility/makeReq.js";
 import * as cheerio from "cheerio";
 import { progressError } from "../../utility/progressLog.js";
 const vue_severalJsFilesHome = async (url: string): Promise<string[]> => {
-    let jsFilesToReturn: string[] = [];
+    const jsFilesToReturn: string[] = [];
 
     // get the contents of the homepage
     const homepageReq = await makeRequest(url);
@@ -20,7 +20,7 @@ const vue_severalJsFilesHome = async (url: string): Promise<string[]> => {
     const scriptTags = $("script");
 
     // iterate through those, and find the ones that aren't CDN URLs, like the relative or absolute paths
-    let jsPaths: string[] = [];
+    const jsPaths: string[] = [];
     for (const tag of scriptTags) {
         const src = $(tag).attr("src");
         if (src && !src.startsWith("http")) {
@@ -43,7 +43,7 @@ const vue_severalJsFilesHome = async (url: string): Promise<string[]> => {
     }
 
     // now that there are files, go through those and get the full path of those
-    let fullJsUrls: string[] = [];
+    const fullJsUrls: string[] = [];
     for (const path of jsPaths) {
         const fullUrl = new URL(path, url).href;
         fullJsUrls.push(fullUrl);

--- a/src/map/interactive-mode/commandHelpers.ts
+++ b/src/map/interactive-mode/commandHelpers.ts
@@ -99,7 +99,7 @@ const commandHelpers = {
             returnText += "\n";
             // get functions which import this particular function
             // iterate over the function
-            let exported_to_chunks = [];
+            const exported_to_chunks = [];
             for (const chunk of Object.values(chunks)) {
                 // get the imports
                 const chunk_imports = chunk.imports;

--- a/src/map/next_js/getAxiosInstances.ts
+++ b/src/map/next_js/getAxiosInstances.ts
@@ -17,7 +17,7 @@ import { printMsg, MSG } from "../../utility/printMsg.js";
 const getAxiosInstances = async (chunks: Chunks, output: string, formats: string[]): Promise<Chunks> => {
     printMsg(MSG.Header, "[i] Getting axios instances");
 
-    let chunkCopy = structuredClone(chunks);
+    const chunkCopy = structuredClone(chunks);
     // iterate through all the chunks
     for (const chunk of Object.values(chunks)) {
         const chunkCode = chunk.code;

--- a/src/map/next_js/getExports.ts
+++ b/src/map/next_js/getExports.ts
@@ -13,7 +13,7 @@ import { printMsg, MSG } from "../../utility/printMsg.js";
 const getExports = async (chunks: Chunks): Promise<Chunks> => {
     printMsg(MSG.Header, "[i] Getting exports");
 
-    let chunkCopy = chunks;
+    const chunkCopy = chunks;
 
     // iterate through the chunks
     for (const chunk of Object.values(chunks)) {
@@ -70,7 +70,7 @@ const getExports = async (chunks: Chunks): Promise<Chunks> => {
             continue;
         }
 
-        let chunkExports: string[] = [];
+        const chunkExports: string[] = [];
 
         // first of all, it is exported something like this:
         // chunkThirdArg.<something>(secondArg, {default: ..., key2: ...})

--- a/src/map/next_js/getFetchInstances.ts
+++ b/src/map/next_js/getFetchInstances.ts
@@ -47,10 +47,10 @@ const isFetchFallback = (node: any): boolean => {
  */
 const getFetchInstances = async (chunks: Chunks, output: string, formats: string[]): Promise<Chunks> => {
     printMsg(MSG.Header, "[i] Running 'getFetchInstances' module");
-    let chunk_copy: Chunks = { ...chunks };
+    const chunk_copy: Chunks = { ...chunks };
 
     //   iterate through the chunks, and check fetch instances
-    for (let chunk of Object.values(chunks)) {
+    for (const chunk of Object.values(chunks)) {
         let chunkAst;
         try {
             chunkAst = parser.parse(chunk.code, {
@@ -106,7 +106,7 @@ const getFetchInstances = async (chunks: Chunks, output: string, formats: string
 
         // -------- Pass 2:  report the call-sites (aliases) --------
         for (const binding of fetchAliases) {
-            // @ts-ignore
+            // @ts-expect-error -- Babel's Binding type doesn't expose referencePaths in this @babel/traverse version
             binding.referencePaths.forEach((ref) => {
                 const parent = ref.parent;
                 if (parent.type === "CallExpression" && parent.callee === ref.node) {
@@ -123,7 +123,7 @@ const getFetchInstances = async (chunks: Chunks, output: string, formats: string
         for (const call of fetchCalls) {
             printMsg(
                 MSG.Info,
-                // @ts-ignore
+                // @ts-expect-error -- Babel's Binding type doesn't expose referencePaths in this @babel/traverse version
                 `[fetch] Webpack ID ${chunk.id}: fetch() called at ${call.line}:${call.column}`
             );
         }

--- a/src/map/next_js/getWebpackConnections.ts
+++ b/src/map/next_js/getWebpackConnections.ts
@@ -74,7 +74,7 @@ const getWebpackConnections = async (directory, output, formats) => {
         return !fs.lstatSync(path.join(directory, file)).isDirectory();
     });
 
-    let chunks: Chunks = {};
+    const chunks: Chunks = {};
 
     // read all the files, and get the chunks
     for (const file of files) {

--- a/src/map/next_js/resolveAxiosHelpers/findAxiosClients.ts
+++ b/src/map/next_js/resolveAxiosHelpers/findAxiosClients.ts
@@ -12,8 +12,8 @@ import { printMsg, MSG } from "../../../utility/printMsg.js";
 export const findAxiosClients = (
     chunks: Chunks
 ): { axiosExportedFrom: string[]; axiosImportedTo: { [key: string]: string } } => {
-    let axiosExportedFrom: string[] = [];
-    let axiosImportedTo: { [key: string]: string } = {};
+    const axiosExportedFrom: string[] = [];
+    const axiosImportedTo: { [key: string]: string } = {};
 
     // first get those which have axios client
     for (const chunkName of Object.keys(chunks)) {

--- a/src/map/next_js/resolveAxiosHelpers/handleAxiosCreate.ts
+++ b/src/map/next_js/resolveAxiosHelpers/handleAxiosCreate.ts
@@ -58,11 +58,11 @@ export const handleAxiosCreate = (
     // We want 'p', not 'e'
 
     // First, traverse up to find if we're inside a function
-    let wrapperFunction = path.findParent((p) => p.isArrowFunctionExpression() || p.isFunctionExpression());
+    const wrapperFunction = path.findParent((p) => p.isArrowFunctionExpression() || p.isFunctionExpression());
 
     if (wrapperFunction) {
         // Now check if this function is assigned to a variable or wrapped in a call expression
-        let assignmentParent = wrapperFunction.findParent(
+        const assignmentParent = wrapperFunction.findParent(
             (p) => p.isAssignmentExpression() || p.isVariableDeclarator()
         );
 

--- a/src/map/next_js/resolveAxiosHelpers/handleZDotCreate.ts
+++ b/src/map/next_js/resolveAxiosHelpers/handleZDotCreate.ts
@@ -224,10 +224,7 @@ export const processZDotCreateCall = (
             // text: the nested `(\.concat\(.+\))+` quantifiers are catastrophically backtracking on
             // crafted input, so a maliciously long argument could hang the analysis pipeline.
             const MAX_CONCAT_PROBE_LENGTH = 2000;
-            if (
-                axiosFirstArgText.length <= MAX_CONCAT_PROBE_LENGTH &&
-                concatRegex.test(axiosFirstArgText)
-            ) {
+            if (axiosFirstArgText.length <= MAX_CONCAT_PROBE_LENGTH && concatRegex.test(axiosFirstArgText)) {
                 callUrl = resolveStringOps(axiosFirstArgText);
             } else if (axiosFirstArg.type === "StringLiteral") {
                 callUrl = axiosFirstArg.value;

--- a/src/map/next_js/resolveAxiosHelpers/handleZDotCreate.ts
+++ b/src/map/next_js/resolveAxiosHelpers/handleZDotCreate.ts
@@ -219,7 +219,7 @@ export const processZDotCreateCall = (
             const axiosFirstArg = args[0];
             const axiosFirstArgText = chunkCode.slice(axiosFirstArg.start, axiosFirstArg.end);
 
-            const concatRegex = /\".*\"(\\.concat\(.+\))+/;
+            const concatRegex = /"[^"]*"(?:\.concat\([^()]*\))+/;
             // Bound the probe length before running this regex against attacker-controlled bundle
             // text: the nested `(\.concat\(.+\))+` quantifiers are catastrophically backtracking on
             // crafted input, so a maliciously long argument could hang the analysis pipeline.

--- a/src/map/next_js/resolveAxiosHelpers/handleZDotCreate.ts
+++ b/src/map/next_js/resolveAxiosHelpers/handleZDotCreate.ts
@@ -220,7 +220,14 @@ export const processZDotCreateCall = (
             const axiosFirstArgText = chunkCode.slice(axiosFirstArg.start, axiosFirstArg.end);
 
             const concatRegex = /\".*\"(\\.concat\(.+\))+/;
-            if (concatRegex.test(axiosFirstArgText)) {
+            // Bound the probe length before running this regex against attacker-controlled bundle
+            // text: the nested `(\.concat\(.+\))+` quantifiers are catastrophically backtracking on
+            // crafted input, so a maliciously long argument could hang the analysis pipeline.
+            const MAX_CONCAT_PROBE_LENGTH = 2000;
+            if (
+                axiosFirstArgText.length <= MAX_CONCAT_PROBE_LENGTH &&
+                concatRegex.test(axiosFirstArgText)
+            ) {
                 callUrl = resolveStringOps(axiosFirstArgText);
             } else if (axiosFirstArg.type === "StringLiteral") {
                 callUrl = axiosFirstArg.value;

--- a/src/map/next_js/resolveAxiosHelpers/processAxiosCall.ts
+++ b/src/map/next_js/resolveAxiosHelpers/processAxiosCall.ts
@@ -94,7 +94,7 @@ export const processAxiosCall = (
             const axiosFirstArg = args[0];
             const axiosFirstArgText = chunkCode.slice(axiosFirstArg.start, axiosFirstArg.end);
 
-            const concatRegex = /\".*\"(\\.concat\(.+\))+/;
+            const concatRegex = /"[^"]*"(?:\.concat\([^()]*\))+/;
             // Bound the probe length before running this regex against attacker-controlled bundle
             // text: the nested `(\.concat\(.+\))+` quantifiers are catastrophically backtracking on
             // crafted input, so a maliciously long argument could hang the analysis pipeline.

--- a/src/map/next_js/resolveAxiosHelpers/processAxiosCall.ts
+++ b/src/map/next_js/resolveAxiosHelpers/processAxiosCall.ts
@@ -99,10 +99,7 @@ export const processAxiosCall = (
             // text: the nested `(\.concat\(.+\))+` quantifiers are catastrophically backtracking on
             // crafted input, so a maliciously long argument could hang the analysis pipeline.
             const MAX_CONCAT_PROBE_LENGTH = 2000;
-            if (
-                axiosFirstArgText.length <= MAX_CONCAT_PROBE_LENGTH &&
-                concatRegex.test(axiosFirstArgText)
-            ) {
+            if (axiosFirstArgText.length <= MAX_CONCAT_PROBE_LENGTH && concatRegex.test(axiosFirstArgText)) {
                 callUrl = resolveNodeValue(
                     axiosFirstArg,
                     path.scope,

--- a/src/map/next_js/resolveAxiosHelpers/processAxiosCall.ts
+++ b/src/map/next_js/resolveAxiosHelpers/processAxiosCall.ts
@@ -95,7 +95,14 @@ export const processAxiosCall = (
             const axiosFirstArgText = chunkCode.slice(axiosFirstArg.start, axiosFirstArg.end);
 
             const concatRegex = /\".*\"(\\.concat\(.+\))+/;
-            if (concatRegex.test(axiosFirstArgText)) {
+            // Bound the probe length before running this regex against attacker-controlled bundle
+            // text: the nested `(\.concat\(.+\))+` quantifiers are catastrophically backtracking on
+            // crafted input, so a maliciously long argument could hang the analysis pipeline.
+            const MAX_CONCAT_PROBE_LENGTH = 2000;
+            if (
+                axiosFirstArgText.length <= MAX_CONCAT_PROBE_LENGTH &&
+                concatRegex.test(axiosFirstArgText)
+            ) {
                 callUrl = resolveNodeValue(
                     axiosFirstArg,
                     path.scope,

--- a/src/map/next_js/resolveAxiosHelpers/processDirectAxiosCall.ts
+++ b/src/map/next_js/resolveAxiosHelpers/processDirectAxiosCall.ts
@@ -50,7 +50,7 @@ export const processDirectAxiosCall = (
             const axiosFirstArg = args[0];
             const axiosFirstArgText = chunkCode.slice(axiosFirstArg.start, axiosFirstArg.end);
 
-            const concatRegex = /\".*\"(\\.concat\(.+\))+/;
+            const concatRegex = /"[^"]*"(?:\.concat\([^()]*\))+/;
             // Bound the probe length before running this regex against attacker-controlled bundle
             // text: the nested `(\.concat\(.+\))+` quantifiers are catastrophically backtracking on
             // crafted input, so a maliciously long argument could hang the analysis pipeline.

--- a/src/map/next_js/resolveAxiosHelpers/processDirectAxiosCall.ts
+++ b/src/map/next_js/resolveAxiosHelpers/processDirectAxiosCall.ts
@@ -51,7 +51,14 @@ export const processDirectAxiosCall = (
             const axiosFirstArgText = chunkCode.slice(axiosFirstArg.start, axiosFirstArg.end);
 
             const concatRegex = /\".*\"(\\.concat\(.+\))+/;
-            if (concatRegex.test(axiosFirstArgText)) {
+            // Bound the probe length before running this regex against attacker-controlled bundle
+            // text: the nested `(\.concat\(.+\))+` quantifiers are catastrophically backtracking on
+            // crafted input, so a maliciously long argument could hang the analysis pipeline.
+            const MAX_CONCAT_PROBE_LENGTH = 2000;
+            if (
+                axiosFirstArgText.length <= MAX_CONCAT_PROBE_LENGTH &&
+                concatRegex.test(axiosFirstArgText)
+            ) {
                 callUrl = resolveStringOps(axiosFirstArgText);
             } else if (t.isStringLiteral(axiosFirstArg)) {
                 callUrl = axiosFirstArg.value;

--- a/src/map/next_js/resolveAxiosHelpers/processDirectAxiosCall.ts
+++ b/src/map/next_js/resolveAxiosHelpers/processDirectAxiosCall.ts
@@ -55,10 +55,7 @@ export const processDirectAxiosCall = (
             // text: the nested `(\.concat\(.+\))+` quantifiers are catastrophically backtracking on
             // crafted input, so a maliciously long argument could hang the analysis pipeline.
             const MAX_CONCAT_PROBE_LENGTH = 2000;
-            if (
-                axiosFirstArgText.length <= MAX_CONCAT_PROBE_LENGTH &&
-                concatRegex.test(axiosFirstArgText)
-            ) {
+            if (axiosFirstArgText.length <= MAX_CONCAT_PROBE_LENGTH && concatRegex.test(axiosFirstArgText)) {
                 callUrl = resolveStringOps(axiosFirstArgText);
             } else if (t.isStringLiteral(axiosFirstArg)) {
                 callUrl = axiosFirstArg.value;

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -1544,7 +1544,15 @@ export const resolveNodeValue = (
                     // .concat() with varying arguments end up here. They needs to be resolved as a string
 
                     // first, match as regex
-                    if (nodeCode.replace(/\n\s*/g, "").match(/^"[^"]*"(\.concat\(.+\))+$/)) {
+                    // Bound the probe length before running this regex against attacker-controlled bundle
+                    // text: the nested `(\.concat\(.+\))+` quantifiers are catastrophically backtracking on
+                    // crafted input, so a maliciously long node could hang the analysis pipeline.
+                    const MAX_CONCAT_PROBE_LENGTH = 2000;
+                    const normalizedNodeCode = nodeCode.replace(/\n\s*/g, "");
+                    if (
+                        normalizedNodeCode.length <= MAX_CONCAT_PROBE_LENGTH &&
+                        normalizedNodeCode.match(/^"[^"]*"(\.concat\(.+\))+$/)
+                    ) {
                         // parse it separately with ast
                         let ast;
                         try {
@@ -1572,7 +1580,7 @@ export const resolveNodeValue = (
                                 case "Identifier":
                                     return `[var ${arg.name}]`; // Format identifiers as [var name]
                                 default:
-                                    // @ts-ignore
+                                    // @ts-expect-error -- arg.property is not narrowed to MemberExpression by this point
                                     return `[${arg.type} -> ${arg.type === "MemberExpression" ? arg.property?.name : ""}]`;
                             }
                         };

--- a/src/map/next_js/utils.ts
+++ b/src/map/next_js/utils.ts
@@ -1551,7 +1551,7 @@ export const resolveNodeValue = (
                     const normalizedNodeCode = nodeCode.replace(/\n\s*/g, "");
                     if (
                         normalizedNodeCode.length <= MAX_CONCAT_PROBE_LENGTH &&
-                        normalizedNodeCode.match(/^"[^"]*"(\.concat\(.+\))+$/)
+                        normalizedNodeCode.match(/^"[^"]*"(?:\.concat\([^()]*\))+$/)
                     ) {
                         // parse it separately with ast
                         let ast;

--- a/src/map/vue_js/taint_utils.ts
+++ b/src/map/vue_js/taint_utils.ts
@@ -73,7 +73,7 @@ const inferOneEnclosingFn = (fnPath: any, file: string): EnclosingFn => {
 };
 
 export const inferEnclosingFn = (callPath: any, file: string): EnclosingFn | null => {
-    let fnPath = callPath.getFunctionParent();
+    const fnPath = callPath.getFunctionParent();
     if (!fnPath) return null;
     const innermost = inferOneEnclosingFn(fnPath, file);
     let chainTail = innermost;

--- a/src/mcp/chatOneShot.ts
+++ b/src/mcp/chatOneShot.ts
@@ -29,7 +29,7 @@ export const runChatOneShot = async (
 ): Promise<void> => {
     let providerName = (cliProvider || config.provider) as "openai" | "anthropic";
     let model = cliModel || config.model;
-    let apiKey = resolveApiKey(providerName, cliApiKey, config);
+    const apiKey = resolveApiKey(providerName, cliApiKey, config);
 
     let provider: LLMProvider | null = null;
 

--- a/src/mcp/skills.ts
+++ b/src/mcp/skills.ts
@@ -89,6 +89,7 @@ export const findSkill = (name: string): Skill | undefined => {
 export const parseSkillArgs = (input: string, skill?: Skill): Record<string, string> => {
     const out: Record<string, string> = {};
     const positional: string[] = [];
+    // eslint-disable-next-line security/detect-unsafe-regex -- alternatives are mutually exclusive by first char and input is one bounded CLI command line — not exploitable
     const tokens = input.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
 
     for (let i = 0; i < tokens.length; i++) {

--- a/src/proxy/detectBlockedResponse.ts
+++ b/src/proxy/detectBlockedResponse.ts
@@ -118,6 +118,7 @@ const STATUS_DENIAL_PATTERNS: Readonly<Record<number, readonly Readonly<{ patter
     Object.freeze({
         403: Object.freeze([
             Object.freeze({ pattern: /\baccess\s+denied\b/i, label: "access denied" }),
+            // eslint-disable-next-line security/detect-unsafe-regex -- literal-heavy, no nested/ambiguous quantifiers — not exploitable
             Object.freeze({ pattern: /\brequest\s+(?:was\s+)?blocked\b/i, label: "request blocked" }),
         ]),
         429: Object.freeze([
@@ -177,6 +178,7 @@ const blockedResult = (
 const isHtmlDocument = (headers: NormalizedHeaders, body: string): boolean =>
     !JAVASCRIPT_CONTENT_TYPE.test(headers["content-type"] ?? "") && HTML_DOCUMENT_START.test(body);
 
+// eslint-disable-next-line security/detect-unsafe-regex -- single lazy scan to the next literal, no nested quantifiers — not exploitable
 const normalizedTitle = (body: string): string | null => {
     const match = /<title(?:\s[^>]*)?>([\s\S]*?)<\/title\s*>/i.exec(body);
     return match ? match[1].replace(/\s+/g, " ").trim() : null;

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -144,9 +144,9 @@ const destroyGateway = async (id: string): Promise<void> => {
         return;
     }
     //   read the aws gateway map
-    let config = readAwsGatewayMap(configFile);
+    const config = readAwsGatewayMap(configFile);
     //   get the name of the api gateway
-    let name = Object.keys(config).find((key) => config[key].id === id);
+    const name = Object.keys(config).find((key) => config[key].id === id);
 
     console.log(chalk.bgGreen("Name:"), chalk.green(name));
     console.log(chalk.bgGreen("ID:"), chalk.green(id));
@@ -184,7 +184,7 @@ const destroyGateway = async (id: string): Promise<void> => {
 const destroyAllGateways = async () => {
     console.log(chalk.cyan("[i] Destroying all API Gateways"));
     //   read the aws gateway map
-    let config = readAwsGatewayMap(configFile);
+    const config = readAwsGatewayMap(configFile);
 
     //   destroy all the gateways
     for (const [key, value] of Object.entries(config)) {

--- a/src/refactor/react-vite/index.ts
+++ b/src/refactor/react-vite/index.ts
@@ -598,7 +598,7 @@ export default async function refactorVite(
             continue;
         }
 
-        let statements: t.Statement[] = ast.program.body as t.Statement[];
+        const statements: t.Statement[] = ast.program.body as t.Statement[];
 
         // Step 3a: Find rolldown-runtime import to identify __toESM local name
         let toEsmLocalName: string | null = null;

--- a/src/run/index.ts
+++ b/src/run/index.ts
@@ -217,7 +217,6 @@ const processUrl = async (
 
         printMsg(MSG.Header, "[3/4] Running analyze...");
         resetSkipStep();
-        // @ts-ignore
         await Promise.race([
             analyze(
                 cmd.rules || "",
@@ -338,7 +337,6 @@ const processUrl = async (
 
         printMsg(MSG.Header, "[3/4] Running analyze...");
         resetSkipStep();
-        // @ts-ignore
         await Promise.race([
             analyze(
                 cmd.rules || "",
@@ -439,7 +437,6 @@ const processUrl = async (
 
         printMsg(MSG.Header, "[3/4] Running analyze...");
         resetSkipStep();
-        // @ts-ignore
         await Promise.race([
             analyze(
                 cmd.rules || "",
@@ -538,7 +535,6 @@ const processUrl = async (
 
         printMsg(MSG.Header, "[3/4] Running analyze...");
         resetSkipStep();
-        // @ts-ignore
         await Promise.race([
             analyze(
                 cmd.rules || "",
@@ -616,7 +612,6 @@ const processUrl = async (
 
         printMsg(MSG.Header, "[3/4] Running analyze...");
         resetSkipStep();
-        // @ts-ignore
         await Promise.race([
             analyze(
                 cmd.rules || "",

--- a/src/strings/index.ts
+++ b/src/strings/index.ts
@@ -95,13 +95,13 @@ const strings = async (
     });
 
     // filter out non JS files
-    let jsFiles = files.filter((file) => file.endsWith(".js") || file.endsWith(".mjs"));
+    const jsFiles = files.filter((file) => file.endsWith(".js") || file.endsWith(".mjs"));
 
     // filter out subsequent requests files
     // jsFiles = jsFiles.filter((file) => !file.startsWith("___subsequent_requests"));
 
     // read all JS files
-    let js_files_path = [];
+    const js_files_path = [];
     for (const file of jsFiles) {
         const filePath = path.join(directory, file);
         if (!fs.lstatSync(filePath).isDirectory()) {
@@ -112,12 +112,12 @@ const strings = async (
     printMsg(MSG.Header, `[i] Found ${js_files_path.length} JS files`);
 
     // read all JS files
-    let all_strings = {};
+    const all_strings = {};
     for (const file of js_files_path) {
         if (file.includes("___subsequent_requests")) {
             // iterate through the file line by line
             const lines = fs.readFileSync(file, "utf-8").split("\n");
-            let strings = [];
+            const strings = [];
             for (const line of lines) {
                 // if the line matches with a particular regex, then extract the JS snippet
                 if (line.match(/^[0-9a-z]+:\[.+/)) {

--- a/src/strings/secrets.ts
+++ b/src/strings/secrets.ts
@@ -88,6 +88,7 @@ interface SecretMatch {
 const secrets = async (source: string): Promise<SecretMatch[]> => {
     const foundSecrets: SecretMatch[] = [];
     for (const [secretName, pattern] of Object.entries(secret_patterns)) {
+        // eslint-disable-next-line security/detect-non-literal-regexp -- pattern is a hardcoded value from the static secret_patterns map, not external input
         const regex = new RegExp(pattern, "g");
         const matches = source.matchAll(regex);
         for (const match of matches) {

--- a/src/utility/ai.ts
+++ b/src/utility/ai.ts
@@ -78,7 +78,7 @@ async function getCompletion(prompt, systemPrompt = "You are a helpful assistant
     }
 
     if (provider === "openai") {
-        // @ts-ignore
+        // @ts-expect-error -- openai SDK types don't yet cover the Responses API shape used here
         const completion = await client.responses.create({
             input: [
                 { role: "system", content: systemPrompt },
@@ -108,7 +108,7 @@ async function getCompletion(prompt, systemPrompt = "You are a helpful assistant
     }
 
     if (provider === "anthropic") {
-        // @ts-ignore
+        // @ts-expect-error -- openai SDK types don't yet cover the Responses API shape used here
         const response = await client.messages.create({
             model: model || "claude-haiku-4-5-20251001",
             max_tokens: 4096,

--- a/src/utility/makeReq.ts
+++ b/src/utility/makeReq.ts
@@ -164,7 +164,7 @@ interface CacheEntry {
     readonly responseHeaders: Readonly<Record<string, string>>;
 }
 
-const getCacheIdentityDigest = (url: string, headers: {}): string => {
+const getCacheIdentityDigest = (url: string, headers: HeadersInit): string => {
     const normalizedHeaders = [...new Headers(headers as HeadersInit).entries()].sort(([left], [right]) =>
         left.localeCompare(right)
     );
@@ -173,7 +173,7 @@ const getCacheIdentityDigest = (url: string, headers: {}): string => {
         .digest("hex");
 };
 
-const getCacheEntryPath = (url: string, headers: {}): string => {
+const getCacheEntryPath = (url: string, headers: HeadersInit): string => {
     const digest = getCacheIdentityDigest(url, headers);
     return `${globals.getRespCacheFile()}.entries/${digest}.json`;
 };
@@ -192,7 +192,7 @@ const getCacheEntryPath = (url: string, headers: {}): string => {
  * @param headers - Request headers that were used
  * @returns A Promise that resolves to a Response object if the cache is found, or null if not
  */
-const readCache = async (url: string, headers: {}): Promise<Response | null> => {
+const readCache = async (url: string, headers: HeadersInit): Promise<Response | null> => {
     const identityDigest = getCacheIdentityDigest(url, headers);
     const entryPath = getCacheEntryPath(url, headers);
     if (fs.existsSync(entryPath)) {
@@ -261,7 +261,7 @@ const readCache = async (url: string, headers: {}): Promise<Response | null> => 
  */
 const writeCache = async (
     url: string,
-    headers: {},
+    headers: HeadersInit,
     response: Response,
     reportErrors: boolean = true,
     signal?: AbortSignal
@@ -277,7 +277,7 @@ const writeCache = async (
     }
 };
 
-const writeCacheUnsafe = async (url: string, headers: {}, response: Response, signal?: AbortSignal): Promise<void> => {
+const writeCacheUnsafe = async (url: string, headers: HeadersInit, response: Response, signal?: AbortSignal): Promise<void> => {
     if (signal?.aborted) return;
     const identityDigest = getCacheIdentityDigest(url, headers);
     const entryPath = getCacheEntryPath(url, headers);

--- a/src/utility/makeReq.ts
+++ b/src/utility/makeReq.ts
@@ -277,7 +277,12 @@ const writeCache = async (
     }
 };
 
-const writeCacheUnsafe = async (url: string, headers: HeadersInit, response: Response, signal?: AbortSignal): Promise<void> => {
+const writeCacheUnsafe = async (
+    url: string,
+    headers: HeadersInit,
+    response: Response,
+    signal?: AbortSignal
+): Promise<void> => {
     if (signal?.aborted) return;
     const identityDigest = getCacheIdentityDigest(url, headers);
     const entryPath = getCacheEntryPath(url, headers);

--- a/vitest.fuzz.config.ts
+++ b/vitest.fuzz.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
     test: {
         environment: "node",
-        include: ["src/**/*.test.ts"],
-        exclude: ["src/**/*.fuzz.test.ts", "**/node_modules/**"],
+        include: ["src/**/*.fuzz.test.ts"],
+        testTimeout: 30000,
     },
 });


### PR DESCRIPTION
## Summary

Implements the OpenSSF Best Practices "Passing" badge checklist from js-recon-internal-docs#136:

- `SECURITY.md`: explicit 14-day acknowledgement SLA and 60-day fix-SLA language (distinct from the existing 90-day disclosure embargo).
- New `.github/workflows/codeql.yml`: CodeQL analysis (javascript-typescript) on push/PR to dev/main plus a weekly schedule.
- New ESLint + `eslint-plugin-security` setup (`eslint.config.js`, `npm run lint`, wired into CI as a new `lint` job). Findings were triaged: genuine catastrophic-backtracking regexes in the axios URL-concat resolvers (`handleZDotCreate.ts`, `processAxiosCall.ts`, `processDirectAxiosCall.ts`, `map/next_js/utils.ts`) — which run against attacker-controlled bundle text — got a bounded probe-length guard; the rest were confirmed false positives and suppressed with a one-line justification comment each. Also cleaned up unrelated lint errors surfaced along the way (dead `@ts-ignore` directives, a `require()` import, `{}` empty-object types).
- Coverage tooling (`@vitest/coverage-v8`, `npm run test:coverage`) — current measured coverage ~33% statements, consistent with this project's documented pure-logic-only unit test scope.
- Fuzz testing (`fast-check`, `npm run test:fuzz`, separate `vitest.fuzz.config.ts`): a new `src/__tests__/strings/extractStrings.fuzz.test.ts` exercises the Babel-parse → `extractStrings` boundary — the entry point where untrusted third-party bundle text first enters the tool.
- New `CONTRIBUTING.md` and `contributing/testing.md`: codifies the test-required-for-new-code policy, the docs-sync policy (changes affecting user-facing behavior must update `js-recon-docs`), and how-to instructions for unit/fuzz/smoke tests.

Companion PRs: `js-recon-docs` (contributing page update) and a `js-recon-agentic-files` CLAUDE.md update (CHANGELOG `### Security` sub-section convention) — not part of this repo's PR since they live in separate repos.

## Test plan

- [x] `npm run lint` — clean (0 errors)
- [x] `npm run test:coverage` — 836 tests passing, ~33% statement coverage
- [x] `npm run test:fuzz` — new fuzz suite passing
- [x] `npx tsc --noEmit` — clean
- [x] `confidential-info-guard` run on the staged diff before commit — CLEAR TO COMMIT
- [ ] CI green (CodeQL, lint, build-and-prettify, rules-smoke-test)