### PR TITLE
Add framework detection smoke test

### DIFF
--- a/.github/workflows/framework-detection-smoke-test.yaml
+++ b/.github/workflows/framework-detection-smoke-test.yaml
@@ -1,0 +1,136 @@
+name: Framework Detection Smoke Test
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+  pull_request:
+    branches:
+      - dev
+      - main
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  framework-detection-smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout js-recon
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Checkout js-recon-labs
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: js-recon/js-recon-labs
+          path: js-recon-labs
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install js-recon dependencies
+        run: npm ci
+
+      - name: Build js-recon
+        run: npm run build
+
+      - name: Start next_js detection app (port 3010)
+        working-directory: js-recon-labs/detection/next_js
+        run: |
+          npm ci
+          npm run build
+          npm start &
+          echo "Waiting for app on port 3010..."
+          timeout 60 bash -c 'until curl -sf http://localhost:3010 > /dev/null; do sleep 2; done'
+
+      - name: Start vue detection app (port 3011)
+        working-directory: js-recon-labs/detection/vue
+        run: |
+          npm ci
+          npm run build
+          npm start &
+          echo "Waiting for app on port 3011..."
+          timeout 60 bash -c 'until curl -sf http://localhost:3011 > /dev/null; do sleep 2; done'
+
+      - name: Start nuxt detection app (port 3012)
+        working-directory: js-recon-labs/detection/nuxt
+        run: |
+          npm ci
+          npm run build
+          npm start &
+          echo "Waiting for app on port 3012..."
+          timeout 60 bash -c 'until curl -sf http://localhost:3012 > /dev/null; do sleep 2; done'
+
+      - name: Start svelte detection app (port 3013)
+        working-directory: js-recon-labs/detection/svelte
+        run: |
+          npm ci
+          npm run build
+          npm start &
+          echo "Waiting for app on port 3013..."
+          timeout 60 bash -c 'until curl -sf http://localhost:3013 > /dev/null; do sleep 2; done'
+
+      - name: Start angular detection app (port 3014)
+        working-directory: js-recon-labs/detection/angular
+        run: |
+          npm ci
+          npm run build
+          npm start &
+          echo "Waiting for app on port 3014..."
+          timeout 60 bash -c 'until curl -sf http://localhost:3014 > /dev/null; do sleep 2; done'
+
+      - name: Start react-vite detection app (port 3015)
+        working-directory: js-recon-labs/detection/react_vite
+        run: |
+          npm ci
+          npm run build
+          npm start &
+          echo "Waiting for app on port 3015..."
+          timeout 60 bash -c 'until curl -sf http://localhost:3015 > /dev/null; do sleep 2; done'
+
+      - name: Start react-webpack detection app (port 3016)
+        working-directory: js-recon-labs/detection/react_webpack
+        run: |
+          npm ci
+          npm run build
+          npm start &
+          echo "Waiting for app on port 3016..."
+          timeout 60 bash -c 'until curl -sf http://localhost:3016 > /dev/null; do sleep 2; done'
+
+      - name: Run js-recon fingerprint against all detection apps
+        run: |
+          cat > /tmp/framework-urls.txt << 'EOF'
+          http://localhost:3010
+          http://localhost:3011
+          http://localhost:3012
+          http://localhost:3013
+          http://localhost:3014
+          http://localhost:3015
+          http://localhost:3016
+          EOF
+          node --max-old-space-size=4096 build/index.js fingerprint \
+            -u /tmp/framework-urls.txt \
+            -f json \
+            -o /tmp/fingerprint-result \
+            -t 3 \
+            --no-sandbox
+
+      - name: Verify all frameworks detected correctly
+        run: node scripts/framework-detect-smoke-test.js /tmp/fingerprint-result.json
+
+      - name: Upload fingerprint result on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fingerprint-result
+          path: /tmp/fingerprint-result.json
+          if-no-files-found: ignore

--- a/.github/workflows/framework-detection-smoke-test.yaml
+++ b/.github/workflows/framework-detection-smoke-test.yaml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
-          cache: "npm"
 
       - name: Install js-recon dependencies
         run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `run`: added `--sj`/`--sj-bin`/`--sj-args` to integrate [swagger-jacker](https://github.com/AlexPistola/swagger-jacker) against the generated OpenAPI output after `report`; also available standalone on `report`. Exits with code 31 if the `sj` binary can't be found and `--sj-bin` wasn't given. (`run`, `report`)
 - `run`: added `--web-stats-dashboard`/`--web-stats-port` — an optional local HTTP dashboard showing live per-target progress (current step, running/completed/skipped/errored) while a batch run is in flight. (`run`)
 - `map`/`run`: `--ai-provider` now accepts `anthropic` in addition to `openai`; the option and its API key flag are renamed `--ai-api-key` (was `--openai-api-key`) to reflect the broader provider choice. (`map`, `run`)
+- New CI workflow `.github/workflows/framework-detection-smoke-test.yaml` runs `fingerprint` against a matrix of lab apps (Next.js, Vue, Nuxt, SvelteKit, Angular, React/Vite, React/webpack) from `js-recon-labs/detection/*` and asserts each is correctly identified, verified by the new `scripts/framework-detect-smoke-test.js`. The existing `rules-smoke-test.yaml` only exercised the rule engine against a single Next.js app; this closes the gap for tech-detection regressions across every other supported framework/bundler. Runs on push/PR to `dev`/`main` and after a release is published. (`ci`)
 
 ### Fixed
 

--- a/scripts/framework-detect-smoke-test.js
+++ b/scripts/framework-detect-smoke-test.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Smoke test: verifies that js-recon's `fingerprint` command detects the
+ * correct front-end framework for every lab app in the framework-detection
+ * matrix (js-recon-labs/detection/*).
+ *
+ * Usage:
+ *   node scripts/framework-detect-smoke-test.js [path-to-fingerprint-result.json]
+ *
+ * Default path: /tmp/fingerprint-result.json
+ */
+
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const resultPath = process.argv[2] || "/tmp/fingerprint-result.json";
+const absolutePath = resolve(resultPath);
+
+let results;
+try {
+    results = JSON.parse(readFileSync(absolutePath, "utf-8"));
+} catch (err) {
+    console.error(`[!] Could not read ${absolutePath}: ${err.message}`);
+    console.error("    Make sure `js-recon fingerprint -f json` completed successfully before running this script.");
+    process.exit(1);
+}
+
+// URL -> expected framework name, matching js-recon-labs/detection/* app ports.
+const EXPECTED = {
+    "http://localhost:3010": "next",
+    "http://localhost:3011": "vue",
+    "http://localhost:3012": "nuxt",
+    "http://localhost:3013": "svelte",
+    "http://localhost:3014": "angular",
+    "http://localhost:3015": "react",
+    "http://localhost:3016": "react",
+};
+
+const detected = new Map(results.map((r) => [r.url, r.framework]));
+const rows = [];
+let failed = false;
+
+for (const [url, expected] of Object.entries(EXPECTED)) {
+    const actual = detected.get(url) ?? "unknown";
+    const ok = actual === expected;
+    if (!ok) failed = true;
+    rows.push({ url, expected, actual, ok });
+}
+
+console.log(`[i] Checked ${rows.length} lab apps.`);
+console.log();
+console.log("URL".padEnd(28), "Expected".padEnd(10), "Detected".padEnd(10), "Result");
+for (const { url, expected, actual, ok } of rows) {
+    console.log(url.padEnd(28), expected.padEnd(10), actual.padEnd(10), ok ? "OK" : "MISMATCH");
+}
+console.log();
+
+if (failed) {
+    const mismatches = rows.filter((r) => !r.ok).length;
+    console.error(`[!] ${mismatches} / ${rows.length} apps failed framework detection. Smoke test FAILED.`);
+    process.exit(1);
+}
+
+console.log(`[✓] All ${rows.length} apps detected correctly. Smoke test PASSED.`);


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/framework-detection-smoke-test.yaml`, a new CI workflow that runs `fingerprint` against 7 lab apps (Next.js, Vue, Nuxt, SvelteKit, Angular, React/Vite, React/webpack) from `js-recon-labs/detection/*` and asserts each is correctly identified — closing the gap left by `rules-smoke-test.yaml`, which only exercises Next.js/rule-firing.
- Adds `scripts/framework-detect-smoke-test.js`, the verification script comparing detected vs. expected framework per URL.
- Documents the new workflow in `CHANGELOG.md` and `CLAUDE.md` ("Framework detection smoke test (CI)" subsection).
- Companion changes already merged to `js-recon-labs` main (new `detection/` lab apps) and PR open in `js-recon-internal-docs` (#148, design rationale doc).

Resolves js-recon-internal-docs#145.

## Test plan
- [x] `npm run cleanup && npm test` — 844 unit tests pass
- [x] Built and started all 7 `js-recon-labs/detection/*` apps locally on ports 3010-3016
- [x] `node build/index.js fingerprint -u <urls> -f json` against all 7 — correctly detected next/vue/nuxt/svelte/angular/react/react
- [x] `node scripts/framework-detect-smoke-test.js` — passes on correct results, fails (non-zero exit) on a deliberately mismatched result
- [ ] New `framework-detection-smoke-test` GitHub Actions workflow passes on this PR (triggered by `pull_request` to `dev`)